### PR TITLE
update structure for rule inputs

### DIFF
--- a/src/__tests__/spectral.test.ts
+++ b/src/__tests__/spectral.test.ts
@@ -26,7 +26,7 @@ describe('spectral', () => {
             description: 'this should return a result if enabled',
             summary: '',
             input: {
-              truthy: 'something-not-present',
+              properties: 'something-not-present',
             },
           },
         },

--- a/src/__tests__/style.test.ts
+++ b/src/__tests__/style.test.ts
@@ -27,7 +27,7 @@ describe('lint', () => {
               description: '',
               summary: '',
               input: {
-                truthy: 'something-not-present',
+                properties: 'something-not-present',
               },
             },
             {
@@ -52,7 +52,7 @@ describe('lint', () => {
               enabled: true,
               description: '',
               summary: '',
-              input: { truthy: 'version' },
+              input: { properties: 'version' },
             },
             {
               swagger: '2.0',
@@ -79,10 +79,8 @@ describe('lint', () => {
               summary: '',
               description: '',
               input: {
-                alphabetical: {
-                  properties: 'tags',
-                  keyedBy: 'name',
-                },
+                properties: 'tags',
+                keyedBy: 'name',
               },
             },
             {
@@ -108,10 +106,8 @@ describe('lint', () => {
               description: '',
               summary: '',
               input: {
-                alphabetical: {
-                  properties: 'tags',
-                  keyedBy: 'name',
-                },
+                properties: 'tags',
+                keyedBy: 'name',
               },
             },
             {
@@ -138,7 +134,7 @@ describe('lint', () => {
               enabled: true,
               description: '',
               summary: '',
-              input: { or: ['something-not-present', 'something-else-not-present'] },
+              input: { properties: ['something-not-present', 'something-else-not-present'] },
             },
             {
               swagger: '2.0',
@@ -161,7 +157,7 @@ describe('lint', () => {
               enabled: true,
               description: '',
               summary: '',
-              input: { or: ['version', 'something-else-not-present'] },
+              input: { properties: ['version', 'something-else-not-present'] },
             },
             {
               swagger: '2.0',
@@ -181,7 +177,7 @@ describe('lint', () => {
               enabled: true,
               description: '',
               summary: '',
-              input: { or: ['version', 'title', 'termsOfService'] },
+              input: { properties: ['version', 'title', 'termsOfService'] },
             },
             {
               swagger: '2.0',
@@ -207,7 +203,7 @@ describe('lint', () => {
               enabled: true,
               description: '',
               summary: '',
-              input: { xor: ['yada-yada', 'whatever'] },
+              input: { properties: ['yada-yada', 'whatever'] },
             },
             {
               swagger: '2.0',
@@ -231,7 +227,7 @@ describe('lint', () => {
               enabled: true,
               description: '',
               summary: '',
-              input: { xor: ['version', 'title'] },
+              input: { properties: ['version', 'title'] },
             },
             {
               swagger: '2.0',
@@ -255,7 +251,7 @@ describe('lint', () => {
               enabled: true,
               description: '',
               summary: '',
-              input: { xor: ['something', 'title'] },
+              input: { properties: ['something', 'title'] },
             },
             {
               swagger: '2.0',
@@ -282,10 +278,8 @@ describe('lint', () => {
               description: '',
               summary: '',
               input: {
-                pattern: {
-                  property: 'termsOfService',
-                  value: '^orange.*$',
-                },
+                property: 'termsOfService',
+                value: '^orange.*$',
               },
             },
             {
@@ -311,10 +305,8 @@ describe('lint', () => {
               description: '',
               summary: '',
               input: {
-                pattern: {
-                  property: '*',
-                  value: '^[0-9]+$',
-                },
+                property: '*',
+                value: '^[0-9]+$',
               },
             },
             {
@@ -345,10 +337,8 @@ describe('lint', () => {
               description: '',
               summary: '',
               input: {
-                pattern: {
-                  property: 'termsOfService',
-                  value: '^http.*$',
-                },
+                property: 'termsOfService',
+                value: '^http.*$',
               },
             },
             {
@@ -374,10 +364,8 @@ describe('lint', () => {
               description: '',
               summary: '',
               input: {
-                pattern: {
-                  property: '*',
-                  value: '^[0-9]+$',
-                },
+                property: '*',
+                value: '^[0-9]+$',
               },
             },
             {
@@ -409,7 +397,7 @@ describe('lint', () => {
               enabled: true,
               description: '',
               summary: '',
-              input: { notContain: { properties: ['description'], value: '<script' } },
+              input: { properties: ['description'], value: '<script' },
             },
             {
               swagger: '2.0',
@@ -434,7 +422,7 @@ describe('lint', () => {
               enabled: true,
               description: '',
               summary: '',
-              input: { notContain: { properties: ['description'], value: '<script' } },
+              input: { properties: ['description'], value: '<script' },
             },
             {
               swagger: '2.0',
@@ -461,7 +449,7 @@ describe('lint', () => {
               enabled: true,
               description: '',
               summary: '',
-              input: { notEndWith: { property: 'url', value: '/' } },
+              input: { property: 'url', value: '/' },
             },
             {
               swagger: '2.0',
@@ -490,7 +478,7 @@ describe('lint', () => {
               enabled: true,
               description: '',
               summary: '',
-              input: { notEndWith: { property: 'url', value: '/' } },
+              input: { property: 'url', value: '/' },
             },
             {
               swagger: '2.0',
@@ -522,9 +510,7 @@ describe('lint', () => {
               description: 'summary should be short (description can be long)',
               summary: '',
               input: {
-                maxLength: {
-                  value: 20,
-                },
+                value: 20,
               },
             },
             {
@@ -552,9 +538,7 @@ describe('lint', () => {
               description: 'summary should be short (description can be long)',
               summary: '',
               input: {
-                maxLength: {
-                  value: 20,
-                },
+                value: 20,
               },
             },
             {

--- a/src/rules/default.json
+++ b/src/rules/default.json
@@ -1,257 +1,241 @@
 {
   "rules": {
-    "oas2|oas3": {
-      "parameter-description": {
-        "type": "lint",
-        "function": "truthy",
-        "path": "$..paths.*.*.parameters",
-        "enabled": true,
-        "description": "parameter objects should have a description",
-        "input": {
-          "truthy": "description"
-        }
-      },
-      "operation-operationID": {
-        "type": "lint",
-        "function": "truthy",
-        "path": "$..paths.*[?( name() !== 'parameters' )]",
-        "enabled": true,
-        "description": "operation should have an operationId",
-        "input": {
-          "truthy": "operationId"
-        }
-      },
-      "operation-summary-or-description": {
-        "type": "lint",
-        "function": "or",
-        "path": "$..paths.*[?( name() !== 'parameters')]",
-        "enabled": true,
-        "description": "operation should have summary or description",
-        "input": {
-          "or": ["summary", "description"]
-        }
-      },
-      "operation-tags": {
-        "type": "lint",
-        "function": "truthy",
-        "path": "$..paths.*[?( name() !== 'parameters')]",
-        "enabled": true,
-        "description": "operation should have non-empty tags array",
-        "input": {
-          "truthy": "tags"
-        }
-      },
-      "path-keys-no-trailing-slash": {
-        "type": "lint",
-        "function": "notEndWith",
-        "path": "$..paths",
-        "enabled": true,
-        "description": "path item keys should not end with a slash",
-        "input": {
-          "notEndWith": {
-            "property": "*",
-            "value": "/"
-          }
-        }
-      },
-      "server-trailing-slash": {
-        "type": "lint",
-        "function": "notEndWith",
-        "path": "$.servers",
-        "enabled": true,
-        "description": "server url should not have a trailing slash",
-        "input": {
-          "notEndWith": {
-            "property": "url",
-            "value": "/"
-          }
-        }
-      },
-      "openapi-tags": {
-        "type": "lint",
-        "function": "truthy",
-        "path": "$",
-        "enabled": false,
-        "description": "openapi object should have non-empty tags array",
-        "input": {
-          "truthy": "tags"
-        }
-      },
-      "openapi-tags-alphabetical": {
-        "type": "lint",
-        "function": "alphabetical",
-        "path": "$",
-        "enabled": true,
-        "description": "openapi object should have alphabetical tags",
-        "input": {
-          "alphabetical": {
-            "properties": "tags",
-            "keyedBy": "name"
-          }
-        }
-      },
-      "reference-no-other-properties": {
-        "type": "lint",
-        "function": "truthy",
-        "path": "reference",
-        "enabled": true,
-        "description": "reference objects should only have a $ref property",
-        "input": {
-          "truthy": "$ref",
-          "properties": 1
-        }
-      },
-      "pathItem-summary-or-description": {
-        "type": "lint",
-        "function": "or",
-        "path": "pathItem",
-        "enabled": false,
-        "description": "pathItem should have summary or description",
-        "input": {
-          "or": ["summary", "description"]
-        }
-      },
-      "example-value-or-externalValue": {
-        "type": "lint",
-        "function": "xor",
-        "path": "$..example",
-        "enabled": true,
-        "description": "example should have either a value or externalValue member",
-        "input": {
-          "xor": ["value", "externalValue"]
-        }
-      },
-      "reference-components-regex": {
-        "type": "lint",
-        "function": "pattern",
-        "path": "$..['$ref']",
-        "enabled": false,
-        "description": "reference components should all match regex ^[a-zA-Z0-9\\.\\-_]+",
-        "input": {
-          "pattern": {
-            "omit": "#",
-            "split": "/",
-            "value": "^[a-zA-Z0-9\\.\\-_]+$"
-          }
-        }
-      },
-      "no-script-tags-in-markdown": {
-        "type": "lint",
-        "function": "notContain",
-        "path": "$..*",
-        "enabled": true,
-        "description": "markdown descriptions should not contain <script> tags",
-        "input": {
-          "notContain": {
-            "properties": ["description"],
-            "value": "<script"
-          }
-        }
-      },
-      "info-contact": {
-        "type": "lint",
-        "function": "truthy",
-        "path": "$.info",
-        "enabled": true,
-        "description": "info object should contain contact object",
-        "input": {
-          "truthy": "contact"
-        }
-      },
-      "license-apimatic-bug": {
-        "type": "lint",
-        "function": "notContain",
-        "path": "$.license",
-        "enabled": true,
-        "description": "license url should not point at gruntjs",
-        "input": {
-          "notContain": {
-            "properties": ["url"],
-            "value": "gruntjs"
-          }
-        }
-      },
-      "no-eval-in-descriptions": {
-        "type": "lint",
-        "function": "notContain",
-        "path": "$..*",
-        "enabled": true,
-        "description": "markdown descriptions should not contain 'eval('",
-        "input": {
-          "notContain": {
-            "properties": ["description", "title"],
-            "value": "eval("
-          }
-        }
-      },
-      "contact-properties": {
-        "type": "lint",
-        "function": "truthy",
-        "path": "$.info.contact",
-        "enabled": false,
-        "description": "contact object should have name, url and email",
-        "input": {
-          "truthy": ["name", "url", "email"]
-        }
-      },
-      "license-url": {
-        "type": "lint",
-        "function": "truthy",
-        "path": "$.info.license",
-        "enabled": false,
-        "description": "license object should include url",
-        "input": {
-          "truthy": "url"
-        }
-      },
-      "server-not-example.com": {
-        "type": "lint",
-        "function": "notContain",
-        "path": "$.servers",
-        "enabled": false,
-        "description": "server url should not point at example.com",
-        "input": {
-          "notContain": {
-            "properties": ["url"],
-            "value": "example.com"
-          }
-        }
-      },
-      "tag-description": {
-        "type": "lint",
-        "function": "truthy",
-        "path": "$.tags",
-        "enabled": false,
-        "description": "tag object should have a description",
-        "input": {
-          "truthy": "description"
-        }
-      }
-    },
     "oas2": {
       "oas2-schema": {
-        "type": "validation",
-        "function": "schema",
-        "path": "$",
         "enabled": true,
-        "severity": "error",
-        "description": "validate structure of OpenAPIv2 specification",
+        "function": "schema",
         "input": {
           "schema": "oas2"
-        }
+        },
+        "path": "$",
+        "severity": "error",
+        "summary": "Validate structure of OpenAPIv2 specification.",
+        "type": "validation"
       }
     },
     "oas3": {
       "oas3-schema": {
-        "type": "validation",
-        "function": "schema",
-        "path": "$",
         "enabled": true,
-        "severity": "error",
-        "description": "validate structure of OpenAPIv3 specification",
+        "function": "schema",
         "input": {
           "schema": "oas3"
-        }
+        },
+        "path": "$",
+        "severity": "error",
+        "summary": "Validate structure of OpenAPIv3 specification.",
+        "type": "validation"
+      }
+    },
+    "oas2|oas3": {
+      "contact-properties": {
+        "enabled": false,
+        "function": "truthy",
+        "input": {
+          "properties": ["email", "name", "url"]
+        },
+        "path": "$.info.contact",
+        "summary": "Contact object should have `name`, `url` and `email`.",
+        "type": "style"
+      },
+      "example-value-or-externalValue": {
+        "enabled": true,
+        "function": "xor",
+        "input": {
+          "properties": ["externalValue", "value"]
+        },
+        "path": "$..example",
+        "summary": "Example should have either a `value` or `externalValue` field.",
+        "type": "style"
+      },
+      "info-contact": {
+        "enabled": true,
+        "function": "truthy",
+        "input": {
+          "properties": "contact"
+        },
+        "path": "$.info",
+        "summary": "Info object should contain `contact` object.",
+        "type": "style"
+      },
+      "license-apimatic-bug": {
+        "enabled": true,
+        "function": "notContain",
+        "input": {
+          "properties": ["url"],
+          "value": "gruntjs"
+        },
+        "path": "$.license",
+        "summary": "License URL should not point at `gruntjs`.",
+        "type": "style"
+      },
+      "license-url": {
+        "enabled": false,
+        "function": "truthy",
+        "input": {
+          "properties": "url"
+        },
+        "path": "$.info.license",
+        "summary": "License object should include `url`.",
+        "type": "style"
+      },
+      "no-eval-in-descriptions": {
+        "enabled": true,
+        "function": "notContain",
+        "input": {
+          "properties": ["description", "title"],
+          "value": "eval("
+        },
+        "path": "$..*",
+        "summary": "Markdown descriptions should not contain `eval(`.",
+        "type": "style"
+      },
+      "no-script-tags-in-markdown": {
+        "enabled": true,
+        "function": "notContain",
+        "input": {
+          "properties": ["description"],
+          "value": "<script"
+        },
+        "path": "$..*",
+        "summary": "Markdown descriptions should not contain `<script>` tags.",
+        "type": "style"
+      },
+      "openapi-tags": {
+        "enabled": false,
+        "function": "truthy",
+        "input": {
+          "properties": "tags"
+        },
+        "path": "$",
+        "summary": "OpenAPI object should have non-empty `tags` array.",
+        "type": "style"
+      },
+      "openapi-tags-alphabetical": {
+        "enabled": true,
+        "function": "alphabetical",
+        "input": {
+          "keyedBy": "name",
+          "properties": "tags"
+        },
+        "path": "$",
+        "summary": "OpenAPI object should have alphabetical `tags`.",
+        "type": "style"
+      },
+      "operation-operationId": {
+        "enabled": true,
+        "function": "truthy",
+        "input": {
+          "properties": "operationId"
+        },
+        "path": "$..paths.*[?( name() !== 'parameters' )]",
+        "summary": "Operation should have an `operationId`.",
+        "type": "style"
+      },
+      "operation-summary-or-description": {
+        "enabled": true,
+        "function": "or",
+        "input": {
+          "properties": ["description", "summary"]
+        },
+        "path": "$..paths.*[?( name() !== 'parameters')]",
+        "summary": "Operation should have `summary` or `description`.",
+        "type": "style"
+      },
+      "operation-tags": {
+        "enabled": true,
+        "function": "truthy",
+        "input": {
+          "properties": "tags"
+        },
+        "path": "$..paths.*[?( name() !== 'parameters')]",
+        "summary": "Operation should have non-empty `tags` array.",
+        "type": "style"
+      },
+      "parameter-description": {
+        "enabled": true,
+        "function": "truthy",
+        "input": {
+          "properties": "description"
+        },
+        "path": "$..paths.*.*.parameters",
+        "summary": "Parameter objects should have a `description`.",
+        "type": "style"
+      },
+      "path-keys-no-trailing-slash": {
+        "enabled": true,
+        "function": "notEndWith",
+        "input": {
+          "property": "*",
+          "value": "/"
+        },
+        "path": "$..paths",
+        "summary": "Path keys should not end with a slash.",
+        "type": "style"
+      },
+      "pathItem-summary-or-description": {
+        "enabled": false,
+        "function": "or",
+        "input": {
+          "properties": ["description", "summary"]
+        },
+        "path": "pathItem",
+        "summary": "pathItem should have `summary` or `description`.",
+        "type": "style"
+      },
+      "reference-components-regex": {
+        "enabled": false,
+        "function": "pattern",
+        "input": {
+          "omit": "#",
+          "split": "/",
+          "value": "^[a-zA-Z0-9\\.\\-_]+$"
+        },
+        "path": "$..['$ref']",
+        "summary": "References should all match regex `^[a-zA-Z0-9\\.\\-_]+`.",
+        "type": "style"
+      },
+      "reference-no-other-properties": {
+        "enabled": true,
+        "function": "truthy",
+        "input": {
+          "properties": 1,
+          "truthy": "$ref"
+        },
+        "path": "reference",
+        "summary": "References objects should only have a `$ref` property.",
+        "type": "style"
+      },
+      "server-not-example.com": {
+        "enabled": false,
+        "function": "notContain",
+        "input": {
+          "properties": ["url"],
+          "value": "example.com"
+        },
+        "path": "$.servers",
+        "summary": "Server URL should not point at `example.com`.",
+        "type": "style"
+      },
+      "server-trailing-slash": {
+        "enabled": true,
+        "function": "notEndWith",
+        "input": {
+          "property": "url",
+          "value": "/"
+        },
+        "path": "$.servers",
+        "summary": "Server URL should not have a trailing slash.",
+        "type": "style"
+      },
+      "tag-description": {
+        "enabled": false,
+        "function": "truthy",
+        "input": {
+          "properties": "description"
+        },
+        "path": "$.tags",
+        "summary": "Tag object should have a `description`.",
+        "type": "style"
       }
     }
   }

--- a/src/rules/style/alphabetical.ts
+++ b/src/rules/style/alphabetical.ts
@@ -6,11 +6,15 @@ export const alphabetical = (
 ): ((object: any, ruleMeta: IRuleMetadata) => IRuleResult[]) => {
   return (object: object, ruleMeta: IRuleMetadata): IRuleResult[] => {
     const results: IRuleResult[] = [];
-    if (r.input.alphabetical.properties && !Array.isArray(r.input.alphabetical.properties)) {
-      r.input.alphabetical.properties = [r.input.alphabetical.properties];
+
+    const { keyedBy, properties: inputProperties } = r.input;
+
+    let properties = inputProperties;
+    if (properties && !Array.isArray(properties)) {
+      properties = [properties];
     }
 
-    for (const property of r.input.alphabetical.properties) {
+    for (const property of properties) {
       if (!object[property] || object[property].length < 2) {
         continue;
       }
@@ -19,8 +23,7 @@ export const alphabetical = (
 
       // If we aren't expecting an object keyed by a specific property, then treat the
       // object as a simple array.
-      if (r.input.alphabetical.keyedBy) {
-        const keyedBy = r.input.alphabetical.keyedBy;
+      if (keyedBy) {
         arrayCopy.sort((a, b) => {
           if (a[keyedBy] < b[keyedBy]) {
             return -1;

--- a/src/rules/style/maxLength.ts
+++ b/src/rules/style/maxLength.ts
@@ -6,7 +6,7 @@ export const maxLength = (
 ): ((object: any, meta: IRuleMetadata) => IRuleResult[]) => {
   return (object: object, meta: IRuleMetadata): IRuleResult[] => {
     const results: IRuleResult[] = [];
-    const { value, property = undefined } = r.input.maxLength;
+    const { value, property } = r.input;
 
     let target: any;
     if (property) {

--- a/src/rules/style/notContain.ts
+++ b/src/rules/style/notContain.ts
@@ -9,7 +9,7 @@ export const notContain = (
 ): ((object: any, ruleMeta: IRuleMetadata) => IRuleResult[]) => {
   return (obj: object, meta: IRuleMetadata): IRuleResult[] => {
     const results: IRuleResult[] = [];
-    const { value, properties } = r.input.notContain;
+    const { value, properties } = r.input;
 
     for (const property of properties) {
       if (obj && obj.hasOwnProperty(property)) {

--- a/src/rules/style/notEndWith.ts
+++ b/src/rules/style/notEndWith.ts
@@ -6,7 +6,7 @@ export const notEndWith = (
 ): ((object: any, ruleMeta: IRuleMetadata) => IRuleResult[]) => {
   return (object: object, ruleMeta: IRuleMetadata): IRuleResult[] => {
     const results: IRuleResult[] = [];
-    const { value, property } = r.input.notEndWith;
+    const { value, property } = r.input;
     const process = (target: any) => {
       const res = ensureRule(() => {
         target.should.not.endWith(value);

--- a/src/rules/style/or.ts
+++ b/src/rules/style/or.ts
@@ -5,8 +5,10 @@ export const or = (r: IOrRule): ((object: any, ruleMeta: IRuleMetadata) => IRule
   return (object: object, ruleMeta: IRuleMetadata): IRuleResult[] => {
     const results: IRuleResult[] = [];
 
+    const { properties } = r.input;
+
     let found = false;
-    for (const property of r.input.or) {
+    for (const property of properties) {
       if (typeof object[property] !== 'undefined') {
         found = true;
         break;

--- a/src/rules/style/pattern.ts
+++ b/src/rules/style/pattern.ts
@@ -8,7 +8,7 @@ export const pattern = (
 ): ((object: any, ruleMeta: IRuleMetadata) => IRuleResult[]) => {
   return (object: object, ruleMeta: IRuleMetadata): IRuleResult[] => {
     const results: IRuleResult[] = [];
-    const { omit, property, split, value } = r.input.pattern;
+    const { omit, property, split, value } = r.input;
 
     // if the collected object is not an object/array, set our target to be
     // the object itself

--- a/src/rules/style/truthy.ts
+++ b/src/rules/style/truthy.ts
@@ -3,15 +3,16 @@ import { ensureRule } from '../index';
 
 import * as should from 'should';
 
-export const truthy = (
-  rule: ITruthyRule
-): ((object: any, meta: IRuleMetadata) => IRuleResult[]) => {
+export const truthy = (r: ITruthyRule): ((object: any, meta: IRuleMetadata) => IRuleResult[]) => {
   return (object: object, meta: IRuleMetadata): IRuleResult[] => {
     const results: IRuleResult[] = [];
 
-    if (!Array.isArray(rule.input.truthy)) rule.input.truthy = [rule.input.truthy];
+    const { properties: inputProperties, max } = r.input;
 
-    for (const property of rule.input.truthy) {
+    let properties = inputProperties;
+    if (!Array.isArray(properties)) properties = [properties];
+
+    for (const property of properties) {
       const res = ensureRule(() => {
         object.should.have.property(property);
         object[property].should.not.be.empty();
@@ -21,11 +22,11 @@ export const truthy = (
       }
     }
 
-    if (rule.input.properties) {
+    if (max) {
       const res = ensureRule(() => {
         // Ignore vendor extensions, for reasons like our the resolver adding x-miro
         const keys = Object.keys(object).filter(key => !key.startsWith('x-'));
-        should(keys.length).be.exactly(rule.input.properties);
+        should(keys.length).be.exactly(max);
       }, meta);
       if (res) {
         results.push(res);

--- a/src/rules/style/xor.ts
+++ b/src/rules/style/xor.ts
@@ -7,8 +7,10 @@ export const xor = (r: IXorRule): ((object: any, ruleMeta: IRuleMetadata) => IRu
   return (object: object, ruleMeta: IRuleMetadata): IRuleResult[] => {
     const results: IRuleResult[] = [];
 
+    const { properties } = r.input;
+
     let found = false;
-    for (const property of r.input.xor) {
+    for (const property of properties) {
       if (typeof object[property] !== 'undefined') {
         if (found) {
           const res = ensureRule(() => {

--- a/src/rules/validation/schema.ts
+++ b/src/rules/validation/schema.ts
@@ -23,8 +23,10 @@ export const schema = (r: ISchemaRule): ((object: any, meta: IRuleMetadata) => I
   return (object: object, meta: IRuleMetadata): IRuleResult[] => {
     const results: any = [];
 
-    if (typeof r.input.schema === 'string') {
-      if (!ajv.validate(r.input.schema, object) && ajv.errors) {
+    const { schema } = r.input;
+
+    if (typeof schema === 'string') {
+      if (!ajv.validate(schema, object) && ajv.errors) {
         ajv.errors.forEach((e: AJV.ErrorObject) => {
           // @ts-ignore
           if (e.params && e.params.additionalProperty) {

--- a/src/types/style.ts
+++ b/src/types/style.ts
@@ -38,9 +38,9 @@ export interface ITruthyRule extends IRuleDefinitionBase {
   input: {
     // key(s) of object that should evaluate as 'truthy' (considered true in a
     // boolean context)
-    truthy: string | string[];
+    properties: string | string[];
 
-    properties?: number;
+    max?: number;
   };
 }
 
@@ -49,7 +49,7 @@ export interface IOrRule extends IRuleDefinitionBase {
 
   input: {
     // test to verify if any of the provided keys are present in object
-    or: string[];
+    properties: string[];
   };
 }
 
@@ -59,53 +59,43 @@ export interface IXorRule extends IRuleDefinitionBase {
   input: {
     // test to verify if one (but not all) of the provided keys are present in
     // object
-    xor: string[];
+    properties: string[];
   };
 }
 
 export interface IMaxLengthRule extends IRuleDefinitionBase {
   function: 'maxLength';
 
-  input: {
-    // verify property is under a specified number of characters
-    maxLength: IRuleNumberParam;
-  };
+  // verify property is under a specified number of characters
+  input: IRuleNumberParam;
 }
 
 export interface IAlphaRule extends IRuleDefinitionBase {
   function: 'alphabetical';
 
-  input: {
-    // verify property is within alphabetical order
-    alphabetical: IAlphaRuleParam;
-  };
+  // verify property is within alphabetical order
+  input: IAlphaRuleParam;
 }
 
 export interface INotEndWithRule extends IRuleDefinitionBase {
   function: 'notEndWith';
 
-  input: {
-    // verify property does not end with string
-    notEndWith: IRulePatternParam;
-  };
+  // verify property does not end with string
+  input: IRulePatternParam;
 }
 
 export interface INotContainRule extends IRuleDefinitionBase {
   function: 'notContain';
 
-  input: {
-    // verify property does not contain value
-    notContain: IRuleStringParam;
-  };
+  // verify property does not contain value
+  input: IRuleStringParam;
 }
 
 export interface IPatternRule extends IRuleDefinitionBase {
   function: 'pattern';
 
-  input: {
-    // run regex match
-    pattern: IRulePatternParam;
-  };
+  // run regex match
+  input: IRulePatternParam;
 }
 
 export type StyleRule =


### PR DESCRIPTION
fixes #24 

- Updated the inputs for all the rules to not be so nested
    - most notable change is truthy, instead of properties as a count I changed it to be called max
- Changed description to summary in the default.json
- Changed all descriptions/summary to be proper sentence structure with markdown (code ticks)
- Checked tests, all still pass without any warnings

