### PR TITLE
Dont include tests in JS output

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,5 +26,9 @@
     "baseUrl": ".",
     "paths": {}
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": [
+    "src/**/*test.ts",
+    "fixtures"
+  ]
 }


### PR DESCRIPTION
This updates the tsconfig to not include tests or test fixtures in the JS output.