### PR TITLE
SL-787: same rules under different formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,15 +21,13 @@
   "dependencies": {
     "ajv": "6.5.x",
     "jsonpath": "git://github.com/stoplightio/jsonpath.git#fe90d42",
-    "lodash.get": "4.4.x",
-    "lodash.merge": "4.6.x",
+    "lodash": "^4.17.11",
     "should": "13.2.x"
   },
   "devDependencies": {
     "@types/jest": "23.3.x",
     "@types/jsonpath": "0.2.x",
-    "@types/lodash.get": "4.4.x",
-    "@types/lodash.merge": "4.6.x",
+    "@types/lodash": "^4.14.118",
     "@types/node": "10.12.x",
     "jest": "23.6.x",
     "prettier": "1.14.x",

--- a/src/__tests__/spectral.test.ts
+++ b/src/__tests__/spectral.test.ts
@@ -12,7 +12,7 @@ describe('spectral', () => {
     });
 
     const results = s.run({ target: todosPartialDeref, spec: 'oas2' });
-    expect(results.length).toBeGreaterThan(0);
+    expect(results.length).toBe(0);
   });
 
   // Assures: https://stoplightio.atlassian.net/browse/SL-786
@@ -92,7 +92,7 @@ Array [
   Object {
     "apply": [Function],
     "format": "oas2",
-    "name": "oas2-ruleName1",
+    "name": "ruleName1",
     "rule": Object {
       "enabled": true,
       "function": "truthy",
@@ -111,7 +111,7 @@ Array [
   Object {
     "apply": [Function],
     "format": "oas3",
-    "name": "oas3-ruleName1",
+    "name": "ruleName1",
     "rule": Object {
       "enabled": false,
       "function": "notContain",
@@ -224,6 +224,6 @@ Array [
     const s = new Spectral({ rulesets });
     const results = s.getRules('oas2');
 
-    expect(results.length).toBe(2);
+    expect(results.length).toBe(1);
   });
 });

--- a/src/__tests__/spectral.test.ts
+++ b/src/__tests__/spectral.test.ts
@@ -1,4 +1,4 @@
-const merge = require('lodash.merge');
+const merge = require('lodash/merge');
 import { Spectral } from '../index';
 import { defaultRuleset } from '../rulesets';
 import { IRuleset, RuleFunction, RuleSeverity, RuleType } from '../types';

--- a/src/__tests__/spectral.test.ts
+++ b/src/__tests__/spectral.test.ts
@@ -15,6 +15,7 @@ describe('spectral', () => {
     expect(results.length).toBeGreaterThan(0);
   });
 
+  // Assures: https://stoplightio.atlassian.net/browse/SL-786
   test('setting rules should not mutate the original ruleset', () => {
     const givenCustomRuleSet = {
       rules: {
@@ -48,6 +49,85 @@ describe('spectral', () => {
     ]);
 
     expect(expectedCustomRuleSet).toEqual(givenCustomRuleSet);
+  });
+
+  // Assures: https://stoplightio.atlassian.net/browse/SL-787
+  test('given a ruleset with two identical rules under two distinct formats should not collide', () => {
+    const rulesets = [
+      {
+        rules: {
+          oas2: {
+            ruleName1: {
+              type: RuleType.STYLE,
+              function: RuleFunction.TRUTHY,
+              path: '$',
+              enabled: true,
+              summary: '',
+              input: {
+                properties: 'something-different',
+              },
+            },
+          },
+          oas3: {
+            ruleName1: {
+              type: RuleType.STYLE,
+              function: RuleFunction.NOT_CONTAIN,
+              path: '$.license',
+              enabled: false,
+              summary: '',
+              input: {
+                properties: ['url'],
+                value: 'gruntjs',
+              },
+            },
+          },
+        },
+      },
+    ];
+
+    const s = new Spectral({ rulesets });
+
+    expect(s.getRules('oas2')).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "apply": [Function],
+    "format": "oas2",
+    "name": "oas2-ruleName1",
+    "rule": Object {
+      "enabled": true,
+      "function": "truthy",
+      "input": Object {
+        "properties": "something-different",
+      },
+      "path": "$",
+      "summary": "",
+      "type": "style",
+    },
+  },
+]
+`);
+    expect(s.getRules('oas3')).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "apply": [Function],
+    "format": "oas3",
+    "name": "oas3-ruleName1",
+    "rule": Object {
+      "enabled": false,
+      "function": "notContain",
+      "input": Object {
+        "properties": Array [
+          "url",
+        ],
+        "value": "gruntjs",
+      },
+      "path": "$.license",
+      "summary": "",
+      "type": "style",
+    },
+  },
+]
+`);
   });
 
   test('be able to toggle rules on apply', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,15 +124,6 @@ export class Spectral {
           continue;
         }
 
-        if (rule.path !== path) {
-          console.warn(
-            `Rule '${ruleIndex} was categorized under an incorrect path. Was under ${path}, but rule path is set to ${
-            rule.path
-            }`
-          );
-          continue;
-        }
-
         try {
           const nodes = jp.nodes(target, path);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,13 +60,6 @@ interface IRunOpts {
 }
 
 export class Spectral {
-  // paths is an internal cache of rules keyed by their path element and format.
-  // This is used primarily to ensure that we only issue one JSON path query per
-  // unique path.
-  private _paths: {
-    [path: string]: Set<string>;
-  } = {};
-
   // normalized object for holding rule definitions indexed by name
   private _rulesByIndex: IRuleStore = {};
 
@@ -192,13 +185,6 @@ export class Spectral {
     } catch (e) {
       throw new SyntaxError(`Invalid JSON path for rule '${ruleIndex}': ${rule.path}\n\n${e}`);
     }
-
-    // update paths object (ensure uniqueness)
-    if (!this._paths[rule.path]) {
-      this._paths[rule.path] = new Set();
-    }
-
-    this._paths[rule.path].add(ruleIndex);
 
     const ruleFunc = this._functions[rule.function];
     if (!ruleFunc) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,10 +79,10 @@ export class Spectral {
 
     for (const name in this._rulesByIndex) {
       if (!this._rulesByIndex.hasOwnProperty(name)) continue;
-      const { rule, format, apply } = this._rulesByIndex[name];
+      const { name: rName, rule, format, apply } = this._rulesByIndex[name];
 
       if (!dataFormat || format === dataFormat) {
-        rules.push({ name, format, rule, apply });
+        rules.push({ name: rName, format, rule, apply });
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ interface IRunOpts {
 }
 
 export class Spectral {
-  // normalized object for holding rule definitions indexed by name
+  // normalized object for holding rule definitions indexed by ${format}-${name}
   private _rulesByIndex: IRuleStore = {};
 
   // the initial rule config, set on initialization
@@ -81,7 +81,7 @@ export class Spectral {
       if (!this._rulesByIndex.hasOwnProperty(name)) continue;
       const { rule, format, apply } = this._rulesByIndex[name];
 
-      if (!dataFormat || format.indexOf(dataFormat) !== -1) {
+      if (!dataFormat || format === dataFormat) {
         rules.push({ name, format, rule, apply });
       }
     }
@@ -112,7 +112,7 @@ export class Spectral {
           if (
             !ruleEntry.rule.enabled ||
             (opts.type && ruleEntry.rule.type !== opts.type) ||
-            ruleEntry.format.indexOf(opts.spec) === -1
+            ruleEntry.format !== opts.spec
           ) {
             return null;
           }

--- a/src/rulesets/index.ts
+++ b/src/rulesets/index.ts
@@ -1,4 +1,4 @@
-const merge = require('lodash.merge');
+const merge = require('lodash/merge');
 
 import { IRuleset } from '../types';
 import { oas2Ruleset } from './oas2';

--- a/src/rulesets/oas/functions/oasOpSecurityDefined/index.ts
+++ b/src/rulesets/oas/functions/oasOpSecurityDefined/index.ts
@@ -1,4 +1,4 @@
-const _get = require('lodash.get');
+const _get = require('lodash/get');
 
 import { ensureRule } from '../../../../functions/utils/ensureRule';
 import { IRule, IRuleFunction, IRuleOpts, IRuleResult, Path } from '../../../../types';

--- a/src/rulesets/oas2/index.ts
+++ b/src/rulesets/oas2/index.ts
@@ -1,4 +1,4 @@
-const merge = require('lodash.merge');
+const merge = require('lodash/merge');
 
 import { IRuleset, RuleFunction, RuleSeverity, RuleType } from '../../types';
 import { commonOasRuleset } from '../oas';

--- a/src/rulesets/oas3/index.ts
+++ b/src/rulesets/oas3/index.ts
@@ -1,4 +1,4 @@
-const merge = require('lodash.merge');
+const merge = require('lodash/merge');
 
 import { IRuleset, RuleFunction, RuleSeverity, RuleType } from '../../types';
 import { commonOasRuleset } from '../oas';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,11 @@
     "target": "es5",
     "module": "commonjs",
     "importHelpers": true,
-    "lib": ["es6", "es7", "dom"],
+    "lib": [
+      "es6",
+      "es7",
+      "dom"
+    ],
     "outDir": "lib",
     "experimentalDecorators": true,
     "noUnusedLocals": true,
@@ -17,16 +21,22 @@
     "noImplicitAny": true,
     "noFallthroughCasesInSwitch": true,
     "allowSyntheticDefaultImports": false,
-    "typeRoots": ["node_modules/@types", "reflect-metadata"],
+    "typeRoots": [
+      "node_modules/@types",
+      "reflect-metadata"
+    ],
     "declaration": true,
     "sourceMap": true,
     "suppressImplicitAnyIndexErrors": true,
     "emitDecoratorMetadata": true,
     "resolveJsonModule": true,
     "baseUrl": ".",
-    "paths": {}
+    "paths": {},
+    "downlevelIteration": true,
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*"
+  ],
   "exclude": [
     "src/**/*test.ts",
     "fixtures"

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,6 +47,11 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.117.tgz#695a7f514182771a1e0f4345d189052ee33c8778"
   integrity sha512-xyf2m6tRbz8qQKcxYZa7PA4SllYcay+eh25DN3jmNYY6gSTL7Htc/bttVdkqj2wfJGbeWlQiX8pIyJpKU+tubw==
 
+"@types/lodash@^4.14.118":
+  version "4.14.118"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.118.tgz#247bab39bfcc6d910d4927c6e06cbc70ec376f27"
+  integrity sha512-iiJbKLZbhSa6FYRip/9ZDX6HXhayXLDGY2Fqws9cOkEQ6XeKfaxB0sC541mowZJueYyMnVUmmG+al5/4fCDrgw==
+
 "@types/node@10.12.x":
   version "10.12.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.0.tgz#ea6dcbddbc5b584c83f06c60e82736d8fbb0c235"
@@ -2321,7 +2326,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4:
+lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==


### PR DESCRIPTION
Fix the original bug and did some refactoring.

The biggest change is that I removed `_paths`. It said that it tries to assure uniqueness, but the way it was implemented didn't make rules more unique than they are without paths.

Paths was a map of arrays which meant that each array could have multiple rules anyway.

The refactoring removes the redundancy and restructures the code a bit. Hopefully, simplifies it.