### PR TITLE
feat: remove the idea of pipes, matches on rule format should be exact

### DIFF
--- a/src/__tests__/spectral.test.ts
+++ b/src/__tests__/spectral.test.ts
@@ -12,7 +12,7 @@ describe('spectral', () => {
     });
 
     const results = s.run({ target: todosPartialDeref, spec: 'oas2' });
-    expect(results.length).toBe(0);
+    expect(results.length).toBeGreaterThan(0);
   });
 
   // Assures: https://stoplightio.atlassian.net/browse/SL-786
@@ -183,18 +183,6 @@ Array [
         rules: {
           oas2: {
             rule1: {
-              type: RuleType.STYLE,
-              function: RuleFunction.TRUTHY,
-              path: '$',
-              enabled: false,
-              summary: '',
-              input: {
-                properties: 'something-not-present',
-              },
-            },
-          },
-          'oas2|oas3': {
-            rule2: {
               type: RuleType.STYLE,
               function: RuleFunction.TRUTHY,
               path: '$',

--- a/src/rulesets/oas/functions/oasOp2xxResponse/__tests__/index.ts
+++ b/src/rulesets/oas/functions/oasOp2xxResponse/__tests__/index.ts
@@ -11,7 +11,7 @@ describe('oasOp2xxResponse', () => {
         rules: {
           oas2: {
             'operation-2xx-response': Object.assign(
-              ruleset.rules['oas2|oas3']['operation-2xx-response'],
+              ruleset.rules.oas2['operation-2xx-response'],
               {
                 enabled: true,
               }

--- a/src/rulesets/oas/functions/oasOpFormDataConsumeCheck/__tests__/index.ts
+++ b/src/rulesets/oas/functions/oasOpFormDataConsumeCheck/__tests__/index.ts
@@ -11,7 +11,7 @@ describe('oasOpFormDataConsumeCheck', () => {
         rules: {
           oas2: {
             'operation-formData-consume-check': Object.assign(
-              ruleset.rules['oas2|oas3']['operation-formData-consume-check'],
+              ruleset.rules.oas2['operation-formData-consume-check'],
               {
                 enabled: true,
               }

--- a/src/rulesets/oas/functions/oasOpIdUnique/__tests__/index.ts
+++ b/src/rulesets/oas/functions/oasOpIdUnique/__tests__/index.ts
@@ -11,7 +11,7 @@ describe('oasOpIdUnique', () => {
         rules: {
           oas2: {
             'operation-operationId-unique': Object.assign(
-              ruleset.rules['oas2|oas3']['operation-operationId-unique'],
+              ruleset.rules.oas2['operation-operationId-unique'],
               {
                 enabled: true,
               }

--- a/src/rulesets/oas/functions/oasOpParams/__tests__/index.ts
+++ b/src/rulesets/oas/functions/oasOpParams/__tests__/index.ts
@@ -10,12 +10,9 @@ describe('oasOpParams', () => {
         functions: ruleset.functions,
         rules: {
           oas2: {
-            'operation-parameters': Object.assign(
-              ruleset.rules['oas2|oas3']['operation-parameters'],
-              {
-                enabled: true,
-              }
-            ),
+            'operation-parameters': Object.assign(ruleset.rules.oas2['operation-parameters'], {
+              enabled: true,
+            }),
           },
         },
       },

--- a/src/rulesets/oas/functions/oasPathParam/__tests__/index.ts
+++ b/src/rulesets/oas/functions/oasPathParam/__tests__/index.ts
@@ -10,7 +10,7 @@ describe('oasPathParam', () => {
         functions: ruleset.functions,
         rules: {
           oas2: {
-            'path-params': Object.assign(ruleset.rules['oas2|oas3']['path-params'], {
+            'path-params': Object.assign(ruleset.rules.oas2['path-params'], {
               enabled: true,
             }),
           },

--- a/src/rulesets/oas/index.ts
+++ b/src/rulesets/oas/index.ts
@@ -1,4 +1,4 @@
-import { IRuleset, RuleFunction, RuleSeverity, RuleType } from '../../types';
+import { IRuleDeclaration, IRuleset, RuleFunction, RuleSeverity, RuleType } from '../../types';
 
 export const operationPath = "$..paths.*[?( name() !== 'parameters' )]";
 
@@ -15,413 +15,8 @@ export const commonOasRuleset = (): IRuleset => {
       oasOpParams: require('./functions/oasOpParams').oasOpParams,
     },
     rules: {
-      'oas2|oas3': {
-        'operation-parameters': {
-          enabled: true,
-          function: 'oasOpParams',
-          path: '$',
-          summary: 'Operation parameters are unique and non-repeating.',
-          type: RuleType.VALIDATION,
-          tags: ['operation'],
-        },
-        'operation-2xx-response': {
-          enabled: true,
-          function: 'oasOp2xxResponse',
-          path: `${operationPath}.responses`,
-          summary: 'Operation must have at least one `2xx` response.',
-          type: RuleType.STYLE,
-          tags: ['operation'],
-        },
-        'operation-operationId-unique': {
-          enabled: true,
-          function: 'oasOpIdUnique',
-          path: '$',
-          summary: 'Every operation must have a unique `operationId`.',
-          type: RuleType.VALIDATION,
-          tags: ['operation'],
-        },
-
-        'operation-formData-consume-check': {
-          enabled: true,
-          function: 'oasOpFormDataConsumeCheck',
-          path: operationPath,
-          summary:
-            'Operations with an `in: formData` parameter must include `application/x-www-form-urlencoded` or `multipart/form-data` in their `consumes` property.',
-          type: RuleType.VALIDATION,
-          tags: ['operation'],
-        },
-        'path-params': {
-          type: RuleType.VALIDATION,
-          summary: 'Path parameters are correct and valid.',
-          enabled: true,
-          severity: RuleSeverity.ERROR,
-          path: '$',
-          function: 'oasPathParam',
-          tags: ['path'],
-        },
-        'contact-properties': {
-          enabled: false,
-          function: RuleFunction.TRUTHY,
-          input: {
-            properties: ['email', 'name', 'url'],
-          },
-          path: '$.info.contact',
-          summary: 'Contact object should have `name`, `url` and `email`.',
-          type: RuleType.STYLE,
-          tags: ['api'],
-        },
-        'api-host': {
-          enabled: true,
-          function: RuleFunction.TRUTHY,
-          input: {
-            properties: ['host'],
-          },
-          path: '$',
-          summary: 'OpenAPI `host` must be present and non-empty string.',
-          type: RuleType.STYLE,
-          tags: ['api'],
-        },
-        'api-schemes': {
-          enabled: true,
-          function: RuleFunction.SCHEMA,
-          input: {
-            schema: {
-              items: {
-                type: 'string',
-              },
-              minItems: 1,
-              type: 'array',
-            },
-          },
-          path: '$.schemes',
-          summary: 'OpenAPI host `schemes` must be present and non-empty array.',
-          type: RuleType.STYLE,
-          tags: ['api'],
-        },
-        'example-value-or-externalValue': {
-          enabled: false,
-          function: RuleFunction.XOR,
-          input: {
-            properties: ['externalValue', 'value'],
-          },
-          path: '$..example',
-          summary: 'Example should have either a `value` or `externalValue` field.',
-          type: RuleType.STYLE,
-        },
-        'info-contact': {
-          enabled: true,
-          function: RuleFunction.TRUTHY,
-          input: {
-            properties: 'contact',
-          },
-          path: '$.info',
-          summary: 'Info object should contain `contact` object.',
-          type: RuleType.STYLE,
-          tags: ['api'],
-        },
-        'info-description': {
-          summary: 'OpenAPI object info `description` must be present and non-empty string.',
-          enabled: true,
-          function: RuleFunction.TRUTHY,
-          input: {
-            properties: 'description',
-          },
-          path: '$.info',
-          type: RuleType.STYLE,
-          tags: ['api'],
-        },
-        'info-license': {
-          summary: 'OpenAPI object info `license` must be present and non-empty string.',
-          enabled: false,
-          function: RuleFunction.TRUTHY,
-          input: {
-            properties: 'license',
-          },
-          path: '$.info',
-          type: RuleType.STYLE,
-          tags: ['api'],
-        },
-        'license-apimatic-bug': {
-          enabled: false,
-          function: RuleFunction.NOT_CONTAIN,
-          input: {
-            properties: ['url'],
-            value: 'gruntjs',
-          },
-          path: '$.license',
-          summary: 'License URL should not point at `gruntjs`.',
-          type: RuleType.STYLE,
-          tags: ['api'],
-        },
-        'license-url': {
-          enabled: false,
-          function: RuleFunction.TRUTHY,
-          input: {
-            properties: 'url',
-          },
-          path: '$.info.license',
-          summary: 'License object should include `url`.',
-          type: RuleType.STYLE,
-          tags: ['api'],
-        },
-        'model-description': {
-          summary: 'Definition `description` must be present and non-empty string.',
-          enabled: false,
-          function: RuleFunction.TRUTHY,
-          input: {
-            properties: 'description',
-          },
-          path: '$..definitions.*',
-          type: RuleType.STYLE,
-        },
-        'no-eval-in-descriptions': {
-          enabled: false,
-          function: RuleFunction.NOT_CONTAIN,
-          input: {
-            properties: ['description', 'title'],
-            value: 'eval(',
-          },
-          path: '$..*',
-          summary: 'Markdown descriptions should not contain `eval(`.',
-          type: RuleType.STYLE,
-        },
-        'no-script-tags-in-markdown': {
-          enabled: true,
-          function: RuleFunction.NOT_CONTAIN,
-          input: {
-            properties: ['description'],
-            value: '<script',
-          },
-          path: '$..*',
-          summary: 'Markdown descriptions should not contain `<script>` tags.',
-          type: RuleType.STYLE,
-        },
-        'only-local-references': {
-          summary: 'References should start with `#/`.',
-          enabled: false,
-          function: RuleFunction.PATTERN,
-          input: {
-            value: '^#\\/',
-          },
-          path: "$..['$ref']",
-          type: RuleType.STYLE,
-          tags: ['references'],
-        },
-        'openapi-tags': {
-          enabled: false,
-          function: RuleFunction.TRUTHY,
-          input: {
-            properties: 'tags',
-          },
-          path: '$',
-          summary: 'OpenAPI object should have non-empty `tags` array.',
-          type: RuleType.STYLE,
-          tags: ['api'],
-        },
-        'openapi-tags-alphabetical': {
-          enabled: false,
-          function: RuleFunction.ALPHABETICAL,
-          input: {
-            keyedBy: 'name',
-            properties: 'tags',
-          },
-          path: '$',
-          summary: 'OpenAPI object should have alphabetical `tags`.',
-          type: RuleType.STYLE,
-          tags: ['api'],
-        },
-        'operation-default-response': {
-          summary: 'Operations must have a default response.',
-          enabled: false,
-          function: RuleFunction.TRUTHY,
-          input: {
-            properties: 'default',
-          },
-          path: '$..paths.*.*.responses',
-          type: RuleType.STYLE,
-          tags: ['operation'],
-        },
-        'operation-description': {
-          summary: 'Operation `description` must be present and non-empty string.',
-          enabled: true,
-          function: RuleFunction.TRUTHY,
-          input: {
-            properties: 'description',
-          },
-          path: operationPath,
-          type: RuleType.STYLE,
-          tags: ['operation'],
-        },
-        'operation-operationId': {
-          enabled: true,
-          function: RuleFunction.TRUTHY,
-          input: {
-            properties: 'operationId',
-          },
-          path: operationPath,
-          summary: 'Operation should have an `operationId`.',
-          type: RuleType.STYLE,
-          tags: ['operation'],
-        },
-        'operation-singular-tag': {
-          summary: 'Operation must have one and only one tag.',
-          enabled: false,
-          function: RuleFunction.SCHEMA,
-          input: {
-            schema: {
-              items: {
-                type: 'string',
-              },
-              maxItems: 1,
-              minItems: 1,
-              type: 'array',
-            },
-          },
-          path: `${operationPath}.tags`,
-          type: RuleType.STYLE,
-          tags: ['operation'],
-        },
-        'operation-summary-formatted': {
-          summary: 'Operation `summary` should start with upper case and end with a dot.',
-          enabled: false,
-          function: RuleFunction.PATTERN,
-          input: {
-            value: '^[A-Z].*\\.$',
-          },
-          path: `${operationPath}.summary`,
-          type: RuleType.STYLE,
-          tags: ['operation'],
-        },
-        'operation-summary-or-description': {
-          enabled: true,
-          function: RuleFunction.OR,
-          input: {
-            properties: ['description', 'summary'],
-          },
-          path: operationPath,
-          summary: 'Operation should have `summary` or `description`.',
-          type: RuleType.STYLE,
-          tags: ['operation'],
-        },
-        'operation-tags': {
-          enabled: true,
-          function: RuleFunction.TRUTHY,
-          input: {
-            properties: 'tags',
-          },
-          path: operationPath,
-          summary: 'Operation should have non-empty `tags` array.',
-          type: RuleType.STYLE,
-          tags: ['operation'],
-        },
-        'parameter-description': {
-          enabled: false,
-          function: RuleFunction.TRUTHY,
-          input: {
-            properties: 'description',
-          },
-          path: '$..paths.*.*.parameters',
-          summary: 'Parameter objects should have a `description`.',
-          type: RuleType.STYLE,
-          tags: ['parameters'],
-        },
-        'path-declarations-must-exist': {
-          summary: 'Path declarations cannot be empty, ex.`/path/{}` is invalid.',
-          enabled: true,
-          function: RuleFunction.NOT_CONTAIN,
-          input: {
-            properties: '*',
-            value: '{}',
-          },
-          path: '$..paths',
-          type: RuleType.STYLE,
-          tags: ['path'],
-        },
-        'path-keys-no-trailing-slash': {
-          enabled: true,
-          function: RuleFunction.NOT_END_WITH,
-          input: {
-            property: '*',
-            value: '/',
-          },
-          path: '$..paths',
-          summary: 'Path keys should not end with a slash.',
-          type: RuleType.STYLE,
-          tags: ['path'],
-        },
-        'path-not-include-query': {
-          summary: 'Path keys should not include a query string.',
-          enabled: true,
-          function: RuleFunction.NOT_CONTAIN,
-          input: {
-            properties: '*',
-            value: '\\?',
-          },
-          path: '$..paths',
-          type: RuleType.STYLE,
-          tags: ['path'],
-        },
-        'reference-components-regex': {
-          enabled: false,
-          function: RuleFunction.PATTERN,
-          input: {
-            omit: '#',
-            split: '/',
-            value: '^[a-zA-Z0-9\\.\\-_]+$',
-          },
-          path: "$..['$ref']",
-          summary: 'References should all match regex `^[a-zA-Z0-9\\.\\-_]+`.',
-          type: RuleType.STYLE,
-          tags: ['references'],
-        },
-        'schema-items-is-object': {
-          summary: 'Schema containing `items` requires the items property to be an object.',
-          enabled: true,
-          function: RuleFunction.SCHEMA,
-          input: {
-            schema: {
-              function: 'object',
-            },
-          },
-          path: '$..schema.items',
-          type: RuleType.VALIDATION,
-        },
-        'server-not-example.com': {
-          enabled: false,
-          function: RuleFunction.NOT_CONTAIN,
-          input: {
-            properties: ['url'],
-            value: 'example.com',
-          },
-          path: '$.servers',
-          summary: 'Server URL should not point at `example.com`.',
-          type: RuleType.STYLE,
-        },
-        'server-trailing-slash': {
-          enabled: true,
-          function: RuleFunction.NOT_END_WITH,
-          input: {
-            property: 'url',
-            value: '/',
-          },
-          path: '$.servers',
-          summary: 'Server URL should not have a trailing slash.',
-          type: RuleType.STYLE,
-        },
-        'tag-description': {
-          enabled: false,
-          function: RuleFunction.TRUTHY,
-          input: {
-            properties: 'description',
-          },
-          path: '$.tags',
-          summary: 'Tag object should have a `description`.',
-          type: RuleType.STYLE,
-          tags: ['api'],
-        },
-      },
-
       oas2: {
+        ...commonOasRules(),
         'operation-security-defined': {
           enabled: true,
           function: 'oasOpSecurityDefined',
@@ -437,6 +32,7 @@ export const commonOasRuleset = (): IRuleset => {
       },
 
       oas3: {
+        ...commonOasRules(),
         'operation-security-defined': {
           enabled: true,
           function: 'oasOpSecurityDefined',
@@ -453,3 +49,409 @@ export const commonOasRuleset = (): IRuleset => {
     },
   };
 };
+
+export const commonOasRules = (): IRuleDeclaration => ({
+  'operation-parameters': {
+    enabled: true,
+    function: 'oasOpParams',
+    path: '$',
+    summary: 'Operation parameters are unique and non-repeating.',
+    type: RuleType.VALIDATION,
+    tags: ['operation'],
+  },
+  'operation-2xx-response': {
+    enabled: true,
+    function: 'oasOp2xxResponse',
+    path: `${operationPath}.responses`,
+    summary: 'Operation must have at least one `2xx` response.',
+    type: RuleType.STYLE,
+    tags: ['operation'],
+  },
+  'operation-operationId-unique': {
+    enabled: true,
+    function: 'oasOpIdUnique',
+    path: '$',
+    summary: 'Every operation must have a unique `operationId`.',
+    type: RuleType.VALIDATION,
+    tags: ['operation'],
+  },
+
+  'operation-formData-consume-check': {
+    enabled: true,
+    function: 'oasOpFormDataConsumeCheck',
+    path: operationPath,
+    summary:
+      'Operations with an `in: formData` parameter must include `application/x-www-form-urlencoded` or `multipart/form-data` in their `consumes` property.',
+    type: RuleType.VALIDATION,
+    tags: ['operation'],
+  },
+  'path-params': {
+    type: RuleType.VALIDATION,
+    summary: 'Path parameters are correct and valid.',
+    enabled: true,
+    severity: RuleSeverity.ERROR,
+    path: '$',
+    function: 'oasPathParam',
+    tags: ['path'],
+  },
+  'contact-properties': {
+    enabled: false,
+    function: RuleFunction.TRUTHY,
+    input: {
+      properties: ['email', 'name', 'url'],
+    },
+    path: '$.info.contact',
+    summary: 'Contact object should have `name`, `url` and `email`.',
+    type: RuleType.STYLE,
+    tags: ['api'],
+  },
+  'api-host': {
+    enabled: true,
+    function: RuleFunction.TRUTHY,
+    input: {
+      properties: ['host'],
+    },
+    path: '$',
+    summary: 'OpenAPI `host` must be present and non-empty string.',
+    type: RuleType.STYLE,
+    tags: ['api'],
+  },
+  'api-schemes': {
+    enabled: true,
+    function: RuleFunction.SCHEMA,
+    input: {
+      schema: {
+        items: {
+          type: 'string',
+        },
+        minItems: 1,
+        type: 'array',
+      },
+    },
+    path: '$.schemes',
+    summary: 'OpenAPI host `schemes` must be present and non-empty array.',
+    type: RuleType.STYLE,
+    tags: ['api'],
+  },
+  'example-value-or-externalValue': {
+    enabled: false,
+    function: RuleFunction.XOR,
+    input: {
+      properties: ['externalValue', 'value'],
+    },
+    path: '$..example',
+    summary: 'Example should have either a `value` or `externalValue` field.',
+    type: RuleType.STYLE,
+  },
+  'info-contact': {
+    enabled: true,
+    function: RuleFunction.TRUTHY,
+    input: {
+      properties: 'contact',
+    },
+    path: '$.info',
+    summary: 'Info object should contain `contact` object.',
+    type: RuleType.STYLE,
+    tags: ['api'],
+  },
+  'info-description': {
+    summary: 'OpenAPI object info `description` must be present and non-empty string.',
+    enabled: true,
+    function: RuleFunction.TRUTHY,
+    input: {
+      properties: 'description',
+    },
+    path: '$.info',
+    type: RuleType.STYLE,
+    tags: ['api'],
+  },
+  'info-license': {
+    summary: 'OpenAPI object info `license` must be present and non-empty string.',
+    enabled: false,
+    function: RuleFunction.TRUTHY,
+    input: {
+      properties: 'license',
+    },
+    path: '$.info',
+    type: RuleType.STYLE,
+    tags: ['api'],
+  },
+  'license-apimatic-bug': {
+    enabled: false,
+    function: RuleFunction.NOT_CONTAIN,
+    input: {
+      properties: ['url'],
+      value: 'gruntjs',
+    },
+    path: '$.license',
+    summary: 'License URL should not point at `gruntjs`.',
+    type: RuleType.STYLE,
+    tags: ['api'],
+  },
+  'license-url': {
+    enabled: false,
+    function: RuleFunction.TRUTHY,
+    input: {
+      properties: 'url',
+    },
+    path: '$.info.license',
+    summary: 'License object should include `url`.',
+    type: RuleType.STYLE,
+    tags: ['api'],
+  },
+  'model-description': {
+    summary: 'Definition `description` must be present and non-empty string.',
+    enabled: false,
+    function: RuleFunction.TRUTHY,
+    input: {
+      properties: 'description',
+    },
+    path: '$..definitions.*',
+    type: RuleType.STYLE,
+  },
+  'no-eval-in-descriptions': {
+    enabled: false,
+    function: RuleFunction.NOT_CONTAIN,
+    input: {
+      properties: ['description', 'title'],
+      value: 'eval(',
+    },
+    path: '$..*',
+    summary: 'Markdown descriptions should not contain `eval(`.',
+    type: RuleType.STYLE,
+  },
+  'no-script-tags-in-markdown': {
+    enabled: true,
+    function: RuleFunction.NOT_CONTAIN,
+    input: {
+      properties: ['description'],
+      value: '<script',
+    },
+    path: '$..*',
+    summary: 'Markdown descriptions should not contain `<script>` tags.',
+    type: RuleType.STYLE,
+  },
+  'only-local-references': {
+    summary: 'References should start with `#/`.',
+    enabled: false,
+    function: RuleFunction.PATTERN,
+    input: {
+      value: '^#\\/',
+    },
+    path: "$..['$ref']",
+    type: RuleType.STYLE,
+    tags: ['references'],
+  },
+  'openapi-tags': {
+    enabled: false,
+    function: RuleFunction.TRUTHY,
+    input: {
+      properties: 'tags',
+    },
+    path: '$',
+    summary: 'OpenAPI object should have non-empty `tags` array.',
+    type: RuleType.STYLE,
+    tags: ['api'],
+  },
+  'openapi-tags-alphabetical': {
+    enabled: false,
+    function: RuleFunction.ALPHABETICAL,
+    input: {
+      keyedBy: 'name',
+      properties: 'tags',
+    },
+    path: '$',
+    summary: 'OpenAPI object should have alphabetical `tags`.',
+    type: RuleType.STYLE,
+    tags: ['api'],
+  },
+  'operation-default-response': {
+    summary: 'Operations must have a default response.',
+    enabled: false,
+    function: RuleFunction.TRUTHY,
+    input: {
+      properties: 'default',
+    },
+    path: '$..paths.*.*.responses',
+    type: RuleType.STYLE,
+    tags: ['operation'],
+  },
+  'operation-description': {
+    summary: 'Operation `description` must be present and non-empty string.',
+    enabled: true,
+    function: RuleFunction.TRUTHY,
+    input: {
+      properties: 'description',
+    },
+    path: operationPath,
+    type: RuleType.STYLE,
+    tags: ['operation'],
+  },
+  'operation-operationId': {
+    enabled: true,
+    function: RuleFunction.TRUTHY,
+    input: {
+      properties: 'operationId',
+    },
+    path: operationPath,
+    summary: 'Operation should have an `operationId`.',
+    type: RuleType.STYLE,
+    tags: ['operation'],
+  },
+  'operation-singular-tag': {
+    summary: 'Operation must have one and only one tag.',
+    enabled: false,
+    function: RuleFunction.SCHEMA,
+    input: {
+      schema: {
+        items: {
+          type: 'string',
+        },
+        maxItems: 1,
+        minItems: 1,
+        type: 'array',
+      },
+    },
+    path: `${operationPath}.tags`,
+    type: RuleType.STYLE,
+    tags: ['operation'],
+  },
+  'operation-summary-formatted': {
+    summary: 'Operation `summary` should start with upper case and end with a dot.',
+    enabled: false,
+    function: RuleFunction.PATTERN,
+    input: {
+      value: '^[A-Z].*\\.$',
+    },
+    path: `${operationPath}.summary`,
+    type: RuleType.STYLE,
+    tags: ['operation'],
+  },
+  'operation-summary-or-description': {
+    enabled: true,
+    function: RuleFunction.OR,
+    input: {
+      properties: ['description', 'summary'],
+    },
+    path: operationPath,
+    summary: 'Operation should have `summary` or `description`.',
+    type: RuleType.STYLE,
+    tags: ['operation'],
+  },
+  'operation-tags': {
+    enabled: true,
+    function: RuleFunction.TRUTHY,
+    input: {
+      properties: 'tags',
+    },
+    path: operationPath,
+    summary: 'Operation should have non-empty `tags` array.',
+    type: RuleType.STYLE,
+    tags: ['operation'],
+  },
+  'parameter-description': {
+    enabled: false,
+    function: RuleFunction.TRUTHY,
+    input: {
+      properties: 'description',
+    },
+    path: '$..paths.*.*.parameters',
+    summary: 'Parameter objects should have a `description`.',
+    type: RuleType.STYLE,
+    tags: ['parameters'],
+  },
+  'path-declarations-must-exist': {
+    summary: 'Path declarations cannot be empty, ex.`/path/{}` is invalid.',
+    enabled: true,
+    function: RuleFunction.NOT_CONTAIN,
+    input: {
+      properties: '*',
+      value: '{}',
+    },
+    path: '$..paths',
+    type: RuleType.STYLE,
+    tags: ['path'],
+  },
+  'path-keys-no-trailing-slash': {
+    enabled: true,
+    function: RuleFunction.NOT_END_WITH,
+    input: {
+      property: '*',
+      value: '/',
+    },
+    path: '$..paths',
+    summary: 'Path keys should not end with a slash.',
+    type: RuleType.STYLE,
+    tags: ['path'],
+  },
+  'path-not-include-query': {
+    summary: 'Path keys should not include a query string.',
+    enabled: true,
+    function: RuleFunction.NOT_CONTAIN,
+    input: {
+      properties: '*',
+      value: '\\?',
+    },
+    path: '$..paths',
+    type: RuleType.STYLE,
+    tags: ['path'],
+  },
+  'reference-components-regex': {
+    enabled: false,
+    function: RuleFunction.PATTERN,
+    input: {
+      omit: '#',
+      split: '/',
+      value: '^[a-zA-Z0-9\\.\\-_]+$',
+    },
+    path: "$..['$ref']",
+    summary: 'References should all match regex `^[a-zA-Z0-9\\.\\-_]+`.',
+    type: RuleType.STYLE,
+    tags: ['references'],
+  },
+  'schema-items-is-object': {
+    summary: 'Schema containing `items` requires the items property to be an object.',
+    enabled: true,
+    function: RuleFunction.SCHEMA,
+    input: {
+      schema: {
+        function: 'object',
+      },
+    },
+    path: '$..schema.items',
+    type: RuleType.VALIDATION,
+  },
+  'server-not-example.com': {
+    enabled: false,
+    function: RuleFunction.NOT_CONTAIN,
+    input: {
+      properties: ['url'],
+      value: 'example.com',
+    },
+    path: '$.servers',
+    summary: 'Server URL should not point at `example.com`.',
+    type: RuleType.STYLE,
+  },
+  'server-trailing-slash': {
+    enabled: true,
+    function: RuleFunction.NOT_END_WITH,
+    input: {
+      property: 'url',
+      value: '/',
+    },
+    path: '$.servers',
+    summary: 'Server URL should not have a trailing slash.',
+    type: RuleType.STYLE,
+  },
+  'tag-description': {
+    enabled: false,
+    function: RuleFunction.TRUTHY,
+    input: {
+      properties: 'description',
+    },
+    path: '$.tags',
+    summary: 'Tag object should have a `description`.',
+    type: RuleType.STYLE,
+    tags: ['api'],
+  },
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,7 +4,7 @@ import { AssertionError } from 'assert';
 import { RuleSeverity, RuleType } from './enums';
 import { Rule } from './rule';
 
-export type TargetSpec = 'oas2' | 'oas3' | 'oas2|oas3' | '*';
+export type TargetSpec = 'oas2' | 'oas3' | string;
 export type RawResult = ErrorObject | AssertionError;
 export type Path = Array<string | number>;
 
@@ -65,7 +65,7 @@ export interface IRuleset {
 export interface IRuleStore {
   /**
    * index is a simplified regex of the format(s) the rules apply to (ie,
-   * 'oas2', 'oas2|oas3', '*')
+   * 'oas2', 'oas3')
    */
   [index: string]: IRuleDeclaration;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,25 +28,6 @@
   resolved "https://registry.yarnpkg.com/@types/jsonpath/-/jsonpath-0.2.0.tgz#13c62db22a34d9c411364fac79fd374d63445aa1"
   integrity sha512-v7qlPA0VpKUlEdhghbDqRoKMxFB3h3Ch688TApBJ6v+XLDdvWCGLJIYiPKGZnS6MAOie+IorCfNYVHOPIHSWwQ==
 
-"@types/lodash.get@4.4.x":
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/@types/lodash.get/-/lodash.get-4.4.4.tgz#34b67841594e4ddc8853341d65e971a38cb4e2f0"
-  integrity sha512-6igkhtKoWAEvTWCgd5uubiuxXLUY/kljQOQZV1G5Y7SrivpmCU+NWG5tGLgRBkccobrDljbJYzBM2vgCG4Oc8Q==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.merge@4.6.x":
-  version "4.6.4"
-  resolved "https://registry.yarnpkg.com/@types/lodash.merge/-/lodash.merge-4.6.4.tgz#0eaae4c82b82d0426612ba929f53edafe5402c58"
-  integrity sha512-usLWpRAicaNbx0VfNDREEgGWvp88inclJLXLJ3NpT83eUE4O05LJdYNRTofHq6pb/NiMZjzNVJHdgPvPzMfu6g==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*":
-  version "4.14.117"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.117.tgz#695a7f514182771a1e0f4345d189052ee33c8778"
-  integrity sha512-xyf2m6tRbz8qQKcxYZa7PA4SllYcay+eh25DN3jmNYY6gSTL7Htc/bttVdkqj2wfJGbeWlQiX8pIyJpKU+tubw==
-
 "@types/lodash@^4.14.118":
   version "4.14.118"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.118.tgz#247bab39bfcc6d910d4927c6e06cbc70ec376f27"
@@ -2310,16 +2291,6 @@ locate-path@^2.0.0:
   dependencies:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
-
-lodash.get@4.4.x:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
-
-lodash.merge@4.6.x:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
-  integrity sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==
 
 lodash.sortby@^4.7.0:
   version "4.7.0"


### PR DESCRIPTION
piped formats for common rules doesn't make sense outside of the scope of `oas2|oas3` and adds for unnecessary complexity are getting rules and format specificity. For now we are removing in favor of exact format matches to simplify logic