### PR TITLE
SO-19, SO-20 refactor: reuse IValidationResult

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,15 +43,16 @@
     "test.watch": "yarn test --watch"
   },
   "dependencies": {
+    "@stoplight/types": "3.x.x",
     "ajv": "6.x.x",
     "jsonpath": "git://github.com/stoplightio/jsonpath.git#fe90d42",
     "lodash": "4.x.x",
     "should": "13.2.x"
   },
   "devDependencies": {
+    "@stoplight/scripts": "3.0.2",
     "@types/jsonpath": "0.2.x",
     "@types/lodash": "4.x.x",
-    "@stoplight/scripts": "3.0.2",
     "typescript": "3.2.1"
   },
   "lint-staged": {

--- a/src/__tests__/spectral.test.ts
+++ b/src/__tests__/spectral.test.ts
@@ -1,7 +1,8 @@
 const merge = require('lodash/merge');
+import { ValidationSeverity } from '@stoplight/types/validations';
 import { Spectral } from '../index';
 import { defaultRuleset } from '../rulesets';
-import { IRuleset, RuleFunction, RuleSeverity, RuleType } from '../types';
+import { IRuleset, RuleFunction, RuleType } from '../types';
 
 const todosPartialDeref = require('./fixtures/todos.partial-deref.oas2.json');
 
@@ -144,7 +145,7 @@ Array [
               function: RuleFunction.TRUTHY,
               path: '$',
               enabled: false,
-              severity: RuleSeverity.ERROR,
+              severity: ValidationSeverity.Error,
               description: 'this should return an error if enabled',
               summary: '',
               input: {

--- a/src/functions/schema.ts
+++ b/src/functions/schema.ts
@@ -1,7 +1,8 @@
 import * as AJV from 'ajv';
 import * as jsonSpecv4 from 'ajv/lib/refs/json-schema-draft-04.json';
 
-import { IRuleFunction, IRuleOpts, IRuleResult, ISchemaRule, RuleSeverity } from '../types';
+import { ValidationSeverity, ValidationSeverityLabel } from '@stoplight/types/validations';
+import { IRuleFunction, IRuleOpts, IRuleResult, ISchemaRule } from '../types';
 
 const ajv = new AJV({
   meta: false,
@@ -33,8 +34,9 @@ export const schema: IRuleFunction<ISchemaRule> = (opts: IRuleOpts<ISchemaRule>)
         type: meta.rule.type,
         path: meta.path.concat(e.dataPath.split('/').slice(1)),
         name: meta.name,
-        summary: rule.summary,
-        severity: rule.severity ? rule.severity : RuleSeverity.ERROR,
+        description: rule.description || '',
+        severity: rule.severity || ValidationSeverity.Error,
+        severityLabel: rule.severityLabel || ValidationSeverityLabel.Error,
         message: e.message ? e.message : '',
       });
     });

--- a/src/functions/utils/ensureRule.ts
+++ b/src/functions/utils/ensureRule.ts
@@ -1,4 +1,5 @@
-import { IRuleMetadata, IRuleResult, RuleSeverity } from '../../types';
+import { ValidationSeverity, ValidationSeverityLabel } from '@stoplight/types/validations';
+import { IRuleMetadata, IRuleResult } from '../../types';
 
 export const ensureRule = (shouldAssertion: Function, ruleMeta: IRuleMetadata): void | IRuleResult => {
   try {
@@ -13,8 +14,9 @@ export const ensureRule = (shouldAssertion: Function, ruleMeta: IRuleMetadata): 
       path: ruleMeta.path,
       name: ruleMeta.name,
       type: ruleMeta.rule.type,
-      summary: ruleMeta.rule.summary,
-      severity: ruleMeta.rule.severity ? ruleMeta.rule.severity : RuleSeverity.WARN,
+      description: ruleMeta.rule.summary,
+      severity: ruleMeta.rule.severity || ValidationSeverity.Warn,
+      severityLabel: ruleMeta.rule.severityLabel || ValidationSeverityLabel.Warn,
       message: error.message ? error.message : '',
     };
   }

--- a/src/rulesets/oas/functions/oasOpParams/index.ts
+++ b/src/rulesets/oas/functions/oasOpParams/index.ts
@@ -1,4 +1,5 @@
-import { IRuleFunction, IRuleOpts, IRuleResult, Rule, RuleSeverity } from '../../../../types';
+import { ValidationSeverity, ValidationSeverityLabel } from '@stoplight/types/validations';
+import { IRuleFunction, IRuleOpts, IRuleResult, Rule } from '../../../../types';
 
 export const oasOpParams: IRuleFunction<Rule> = (opts: IRuleOpts<Rule>) => {
   const results: IRuleResult[] = [];
@@ -106,8 +107,9 @@ export const oasOpParams: IRuleFunction<Rule> = (opts: IRuleOpts<Rule>) => {
               message,
               path: ['$', 'paths', path, operation],
               name: meta.name,
-              summary: rule.summary,
-              severity: meta.rule.severity || RuleSeverity.ERROR,
+              description: rule.summary,
+              severity: meta.rule.severity || ValidationSeverity.Error,
+              severityLabel: meta.rule.severityLabel || ValidationSeverityLabel.Error,
               type: rule.type,
             });
           }
@@ -126,8 +128,9 @@ export const oasOpParams: IRuleFunction<Rule> = (opts: IRuleOpts<Rule>) => {
             message,
             path: ['$', 'paths', path, operation],
             name: meta.name,
-            summary: rule.summary,
-            severity: meta.rule.severity || RuleSeverity.ERROR,
+            description: rule.summary,
+            severity: meta.rule.severity || ValidationSeverity.Error,
+            severityLabel: meta.rule.severityLabel || ValidationSeverityLabel.Error,
             type: rule.type,
           });
         }
@@ -145,8 +148,9 @@ export const oasOpParams: IRuleFunction<Rule> = (opts: IRuleOpts<Rule>) => {
             message,
             path: ['$', 'paths', path, operation],
             name: meta.name,
-            summary: rule.summary,
-            severity: meta.rule.severity || RuleSeverity.ERROR,
+            description: rule.summary,
+            severity: meta.rule.severity || ValidationSeverity.Error,
+            severityLabel: meta.rule.severityLabel || ValidationSeverityLabel.Error,
             type: rule.type,
           });
         }

--- a/src/rulesets/oas/functions/oasPathParam/index.ts
+++ b/src/rulesets/oas/functions/oasPathParam/index.ts
@@ -1,4 +1,5 @@
-import { IRuleFunction, IRuleMetadata, IRuleOpts, IRuleResult, Rule, RuleSeverity } from '../../../../types';
+import { ValidationSeverity, ValidationSeverityLabel } from '@stoplight/types/validations';
+import { IRuleFunction, IRuleMetadata, IRuleOpts, IRuleResult, Rule } from '../../../../types';
 
 const pathRegex = /(\{[a-zA-Z0-9_-]+\})+/g;
 
@@ -193,8 +194,9 @@ function generateResult(message: string, path: Array<string | number>, rule: Rul
     message,
     path,
     name: _m.name,
-    summary: rule.summary,
-    severity: _m.rule.severity ? _m.rule.severity : RuleSeverity.ERROR,
+    description: rule.summary,
+    severity: _m.rule.severity || ValidationSeverity.Error,
+    severityLabel: _m.rule.severityLabel || ValidationSeverityLabel.Error,
     type: rule.type,
   };
 }

--- a/src/rulesets/oas/index.ts
+++ b/src/rulesets/oas/index.ts
@@ -1,4 +1,5 @@
-import { IRuleDeclaration, IRuleset, RuleFunction, RuleSeverity, RuleType } from '../../types';
+import { ValidationSeverity } from '@stoplight/types/validations';
+import { IRuleDeclaration, IRuleset, RuleFunction, RuleType } from '../../types';
 
 export const operationPath = "$..paths.*[?( name() !== 'parameters' )]";
 
@@ -87,7 +88,7 @@ export const commonOasRules = (): IRuleDeclaration => ({
     type: RuleType.VALIDATION,
     summary: 'Path parameters are correct and valid.',
     enabled: true,
-    severity: RuleSeverity.ERROR,
+    severity: ValidationSeverity.Error,
     path: '$',
     function: 'oasPathParam',
     tags: ['path'],

--- a/src/rulesets/oas2/index.ts
+++ b/src/rulesets/oas2/index.ts
@@ -1,6 +1,7 @@
 const merge = require('lodash/merge');
 
-import { IRuleset, RuleFunction, RuleSeverity, RuleType } from '../../types';
+import { ValidationSeverity } from '@stoplight/types/validations';
+import { IRuleset, RuleFunction, RuleType } from '../../types';
 import { commonOasRuleset } from '../oas';
 import * as schema from './schemas/main.json';
 
@@ -13,7 +14,7 @@ export const oas2Ruleset = (): IRuleset => {
           type: RuleType.VALIDATION,
           summary: 'Validate structure of OpenAPIv2 specification.',
           enabled: true,
-          severity: RuleSeverity.ERROR,
+          severity: ValidationSeverity.Error,
           path: '$',
           function: RuleFunction.SCHEMA,
           input: {

--- a/src/rulesets/oas3/index.ts
+++ b/src/rulesets/oas3/index.ts
@@ -1,6 +1,7 @@
 const merge = require('lodash/merge');
 
-import { IRuleset, RuleFunction, RuleSeverity, RuleType } from '../../types';
+import { ValidationSeverity } from '@stoplight/types/validations';
+import { IRuleset, RuleFunction, RuleType } from '../../types';
 import { commonOasRuleset } from '../oas';
 import * as schema from './schemas/main.json';
 
@@ -13,7 +14,7 @@ export const oas3Ruleset = (): IRuleset => {
           type: RuleType.VALIDATION,
           summary: 'Validate structure of OpenAPIv3 specification.',
           enabled: true,
-          severity: RuleSeverity.ERROR,
+          severity: ValidationSeverity.Error,
           path: '$',
           function: RuleFunction.SCHEMA,
           input: {

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -1,9 +1,3 @@
-export enum RuleSeverity {
-  ERROR = 'error',
-  WARN = 'warn',
-  INFO = 'info',
-}
-
 export enum RuleType {
   VALIDATION = 'validation',
   STYLE = 'style',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,9 @@
 import { ErrorObject } from 'ajv';
 import { AssertionError } from 'assert';
 
-import { RuleSeverity, RuleType } from './enums';
+// import { ValidationSeverity, RuleType } from './enums';
+import { IValidationResult } from '@stoplight/types/validations';
+import { RuleType } from './enums';
 import { Rule } from './rule';
 
 export type TargetSpec = 'oas2' | 'oas3' | string;
@@ -18,33 +20,8 @@ export interface IRuleOpts<I = Rule> {
 
 export type IRuleFunction<I = Rule> = (opts: IRuleOpts<I>) => IRuleResult[];
 
-export interface IRuleResult {
+export interface IRuleResult extends IValidationResult {
   type: RuleType;
-
-  /**
-   * The relevant path within the object being operated on
-   */
-  path: Path;
-
-  /**
-   * The rule emitting the result
-   */
-  name: string;
-
-  /**
-   * The rule summary for the rule generating the result
-   */
-  summary: string;
-
-  /**
-   * The rule emitting the result
-   */
-  severity: RuleSeverity;
-
-  /**
-   * Message describing the error
-   */
-  message: string;
 }
 
 export interface IRuleMetadata {

--- a/src/types/rule.ts
+++ b/src/types/rule.ts
@@ -1,4 +1,5 @@
-import { RuleFunction, RuleSeverity, RuleType } from './enums';
+import { ValidationSeverity, ValidationSeverityLabel } from '@stoplight/types/validations';
+import { RuleFunction, RuleType } from './enums';
 
 export type Rule =
   | IRule
@@ -35,7 +36,8 @@ export interface IRule {
   enabled?: boolean;
 
   // The severity of results this rule generates
-  severity?: RuleSeverity;
+  severity?: ValidationSeverity;
+  severityLabel?: ValidationSeverityLabel;
 
   // Tags attached to the rule, which can be used for organizational purposes
   tags?: string[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1229,6 +1229,11 @@
     typedoc "0.13.x"
     typescript-plugin-styled-components "1.0.x"
 
+"@stoplight/types@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-3.0.0.tgz#2464b3149accd0ef4b822a6079a1a8ece416e9c3"
+  integrity sha512-08VUdzyHUenrk5m8rP6DiCQjZ/6DIjmFDKryBTuBNCrQQ6dwlqqGRN+f4nCOPc+Ks6jhHRLjT3hUCn8TUwIKuw==
+
 "@storybook/addon-actions@4.0.7":
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-4.0.7.tgz#a7088e619f705f1839156fe9eec65e43e747d206"
@@ -3990,7 +3995,7 @@ debug@^4.0.0, debug@^4.0.1, debug@^4.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -6018,7 +6023,7 @@ import-local@^1.0.0:
     pkg-dir "^2.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -7493,11 +7498,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseisequal@^3.0.0:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz#d8025f76339d29342767dcc887ce5cb95a5b51f1"
@@ -7515,29 +7515,17 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*, lodash._bindcallback@^3.0.0:
+lodash._bindcallback@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
   integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
 
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
   integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
@@ -7673,11 +7661,6 @@ lodash.pick@4.4.0, lodash.pick@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
   integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -10186,7 +10169,7 @@ readable-stream@~1.1.10:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   integrity sha1-n6+jfShr5dksuuve4DDcm19AZ0c=


### PR DESCRIPTION
SO-19

BREAKING CHANGE: IRuleResult extends IValidationResult which has a required `severityLabel` field.

I have updated the code to replace IRuleResult with IValidationResult. I left the original interface because it adds its own properties (and because the impact was much lower).