### PR TITLE
Chore/SO-9/spectral function tests

### DIFF
--- a/src/__tests__/__snapshots__/style.test.ts.snap
+++ b/src/__tests__/__snapshots__/style.test.ts.snap
@@ -1,0 +1,204 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`lint rules alphabetical dont return result if values are alphabetized 1`] = `Array []`;
+
+exports[`lint rules alphabetical returns result if values are not alphabetized 1`] = `
+Array [
+  Object {
+    "description": "",
+    "message": "expected Array [
+  Object { name: 'Far', description: 'bar' },
+  Object { name: 'Boo', description: 'foo' }
+] to equal Array [
+  Object { name: 'Boo', description: 'foo' },
+  Object { name: 'Far', description: 'bar' }
+] (at '0' -> name, A has 'Far' and B has 'Boo')",
+    "name": "test:rule",
+    "path": Array [
+      "$",
+      "info",
+    ],
+    "severity": 40,
+    "severityLabel": "warn",
+    "type": "style",
+  },
+]
+`;
+
+exports[`lint rules maxLength dont return result if property is shorter than value 1`] = `Array []`;
+
+exports[`lint rules maxLength return result if property is longer than value 1`] = `
+Array [
+  Object {
+    "description": "",
+    "message": "expected 61 to be below or equal 20",
+    "name": "test:rule",
+    "path": Array [
+      "$",
+      "paths",
+      "/rooms/{room_id}/reserve/",
+      "post",
+      "summary",
+    ],
+    "severity": 40,
+    "severityLabel": "warn",
+    "type": "style",
+  },
+]
+`;
+
+exports[`lint rules notContain dont return results if property doesnt contain value 1`] = `Array []`;
+
+exports[`lint rules notContain returns result if property contains value 1`] = `
+Array [
+  Object {
+    "description": "",
+    "message": "expected '### Notes:\\\\n\\\\nThis OAS2 (Swagger 2) specification defines common models and responses, that other specifications may reference.\\\\n\\\\nFor example, check out the user poperty in the main.oas2 todo-partial model - it references the user model in this specification!\\\\n\\\\nLikewise, the main.oas2 operations reference the shared error responses in this common specification.\\\\n\\\\n<script>console.log(\\\\'sup homie\\\\');</script>' not to match /<script/ (false negative fail)",
+    "name": "test:rule",
+    "path": Array [
+      "$",
+      "info",
+    ],
+    "severity": 40,
+    "severityLabel": "warn",
+    "type": "style",
+  },
+]
+`;
+
+exports[`lint rules notEndWith dont return result if property doesnt end with value 1`] = `Array []`;
+
+exports[`lint rules notEndWith return result if property ends with value 1`] = `
+Array [
+  Object {
+    "description": "",
+    "message": "expected 'http://localhost:5000/' not to end with '/' (false negative fail)",
+    "name": "test:rule",
+    "path": Array [
+      "$",
+      "servers",
+    ],
+    "severity": 40,
+    "severityLabel": "warn",
+    "type": "style",
+  },
+]
+`;
+
+exports[`lint rules or dont returns results if any properties are present 1`] = `Array []`;
+
+exports[`lint rules or dont returns results if any properties are present 2`] = `Array []`;
+
+exports[`lint rules or returns result if no properties are present 1`] = `
+Array [
+  Object {
+    "description": "",
+    "message": "expected false to be true",
+    "name": "test:rule",
+    "path": Array [
+      "$",
+      "info",
+    ],
+    "severity": 40,
+    "severityLabel": "warn",
+    "type": "style",
+  },
+]
+`;
+
+exports[`lint rules pattern dont return result if pattern is matched (on object keys) 1`] = `Array []`;
+
+exports[`lint rules pattern dont return result if pattern is matched (on string) 1`] = `Array []`;
+
+exports[`lint rules pattern returns result if pattern is not matched (on object keys) 1`] = `
+Array [
+  Object {
+    "description": "",
+    "message": ", but received: 456avbas",
+    "name": "test:rule",
+    "path": Array [
+      "$",
+      "responses",
+    ],
+    "severity": 40,
+    "severityLabel": "warn",
+    "type": "style",
+  },
+]
+`;
+
+exports[`lint rules pattern returns result if pattern is not matched (on string) 1`] = `
+Array [
+  Object {
+    "description": "",
+    "message": ", but received: http://swagger.io/terms/",
+    "name": "test:rule",
+    "path": Array [
+      "$",
+      "info",
+    ],
+    "severity": 40,
+    "severityLabel": "warn",
+    "type": "style",
+  },
+]
+`;
+
+exports[`lint rules truthy doesnt return result if value is present 1`] = `Array []`;
+
+exports[`lint rules truthy returns result if value is not present 1`] = `
+Array [
+  Object {
+    "description": "",
+    "message": "expected Object {
+  version: '1.0.0',
+  title: 'Swagger Petstore',
+  termsOfService: 'http://swagger.io/terms/'
+} to have property 'something-not-present'",
+    "name": "test:rule",
+    "path": Array [
+      "$",
+      "info",
+    ],
+    "severity": 40,
+    "severityLabel": "warn",
+    "type": "style",
+  },
+]
+`;
+
+exports[`lint rules xor dont returns results if one of the properties are present 1`] = `Array []`;
+
+exports[`lint rules xor returns result if both properties are present 1`] = `
+Array [
+  Object {
+    "description": "",
+    "message": "expected true undefined false",
+    "name": "test:rule",
+    "path": Array [
+      "$",
+      "info",
+    ],
+    "severity": 40,
+    "severityLabel": "warn",
+    "type": "style",
+  },
+]
+`;
+
+exports[`lint rules xor returns result if no properties are present 1`] = `
+Array [
+  Object {
+    "description": "",
+    "message": "expected false to be true",
+    "name": "test:rule",
+    "path": Array [
+      "$",
+      "info",
+    ],
+    "severity": 40,
+    "severityLabel": "warn",
+    "type": "style",
+  },
+]
+`;

--- a/src/__tests__/__snapshots__/style.test.ts.snap
+++ b/src/__tests__/__snapshots__/style.test.ts.snap
@@ -25,6 +25,28 @@ Array [
 ]
 `;
 
+exports[`lint rules alphabetical returns result if values are not alphabetized, query nested 1`] = `
+Array [
+  Object {
+    "description": "",
+    "message": "expected Array [
+  Object { name: 'Far', description: 'bar' },
+  Object { name: 'Boo', description: 'foo' }
+] to equal Array [
+  Object { name: 'Boo', description: 'foo' },
+  Object { name: 'Far', description: 'bar' }
+] (at '0' -> name, A has 'Far' and B has 'Boo')",
+    "name": "test:rule",
+    "path": Array [
+      "$",
+    ],
+    "severity": 40,
+    "severityLabel": "warn",
+    "type": "style",
+  },
+]
+`;
+
 exports[`lint rules maxLength dont return result if property is shorter than value 1`] = `Array []`;
 
 exports[`lint rules maxLength return result if property is longer than value 1`] = `
@@ -106,6 +128,22 @@ Array [
 ]
 `;
 
+exports[`lint rules or returns result if no properties are present, nested props 1`] = `
+Array [
+  Object {
+    "description": "",
+    "message": "expected false to be true",
+    "name": "test:rule",
+    "path": Array [
+      "$",
+    ],
+    "severity": 40,
+    "severityLabel": "warn",
+    "type": "style",
+  },
+]
+`;
+
 exports[`lint rules pattern dont return result if pattern is matched (on object keys) 1`] = `Array []`;
 
 exports[`lint rules pattern dont return result if pattern is matched (on string) 1`] = `Array []`;
@@ -144,7 +182,25 @@ Array [
 ]
 `;
 
+exports[`lint rules pattern returns result if pattern is not matched (on string), nested props 1`] = `
+Array [
+  Object {
+    "description": "",
+    "message": ", but received: http://swagger.io/terms/",
+    "name": "test:rule",
+    "path": Array [
+      "$",
+    ],
+    "severity": 40,
+    "severityLabel": "warn",
+    "type": "style",
+  },
+]
+`;
+
 exports[`lint rules truthy doesnt return result if value is present 1`] = `Array []`;
+
+exports[`lint rules truthy linting function should access simple nested fields 1`] = `Array []`;
 
 exports[`lint rules truthy returns result if value is not present 1`] = `
 Array [
@@ -169,11 +225,13 @@ Array [
 
 exports[`lint rules xor dont returns results if one of the properties are present 1`] = `Array []`;
 
+exports[`lint rules xor dont returns results if one of the properties are present, nested props 1`] = `Array []`;
+
 exports[`lint rules xor returns result if both properties are present 1`] = `
 Array [
   Object {
     "description": "",
-    "message": "expected true undefined false",
+    "message": "expected false to be true",
     "name": "test:rule",
     "path": Array [
       "$",

--- a/src/__tests__/style.test.ts
+++ b/src/__tests__/style.test.ts
@@ -39,8 +39,8 @@ describe('lint', () => {
                 termsOfService: 'http://swagger.io/terms/',
               },
             }
-          ).length
-        ).toEqual(1);
+          )
+        ).toMatchSnapshot();
       });
 
       test('doesnt return result if value is present', () => {
@@ -62,8 +62,8 @@ describe('lint', () => {
                 termsOfService: 'http://swagger.io/terms/',
               },
             }
-          ).length
-        ).toEqual(0);
+          )
+        ).toMatchSnapshot();
       });
     });
 
@@ -90,8 +90,8 @@ describe('lint', () => {
                 tags: [{ name: 'Far', description: 'bar' }, { name: 'Boo', description: 'foo' }],
               },
             }
-          ).length
-        ).toEqual(1);
+          )
+        ).toMatchSnapshot();
       });
 
       test('dont return result if values are alphabetized', () => {
@@ -116,8 +116,8 @@ describe('lint', () => {
                 tags: [{ name: 'Boo', description: 'bar' }, { name: 'Far', description: 'foo' }],
               },
             }
-          ).length
-        ).toEqual(0);
+          )
+        ).toMatchSnapshot();
       });
     });
 
@@ -140,8 +140,8 @@ describe('lint', () => {
                 title: 'Swagger Petstore',
               },
             }
-          ).length
-        ).toEqual(1);
+          )
+        ).toMatchSnapshot();
       });
 
       test('dont returns results if any properties are present', () => {
@@ -162,8 +162,8 @@ describe('lint', () => {
                 title: 'Swagger Petstore',
               },
             }
-          ).length
-        ).toEqual(0);
+          )
+        ).toMatchSnapshot();
         expect(
           applyRuleToObject(
             {
@@ -182,8 +182,8 @@ describe('lint', () => {
                 termsOfService: 'http://swagger.io/terms/',
               },
             }
-          ).length
-        ).toEqual(0);
+          )
+        ).toMatchSnapshot();
       });
     });
 
@@ -207,8 +207,8 @@ describe('lint', () => {
                 termsOfService: 'http://swagger.io/terms/',
               },
             }
-          ).length
-        ).toEqual(1);
+          )
+        ).toMatchSnapshot();
       });
 
       test('returns result if both properties are present', () => {
@@ -230,8 +230,8 @@ describe('lint', () => {
                 termsOfService: 'http://swagger.io/terms/',
               },
             }
-          ).length
-        ).toEqual(1);
+          )
+        ).toMatchSnapshot();
       });
 
       test('dont returns results if one of the properties are present', () => {
@@ -253,8 +253,8 @@ describe('lint', () => {
                 termsOfService: 'http://swagger.io/terms/',
               },
             }
-          ).length
-        ).toEqual(0);
+          )
+        ).toMatchSnapshot();
       });
     });
 
@@ -281,8 +281,8 @@ describe('lint', () => {
                 termsOfService: 'http://swagger.io/terms/',
               },
             }
-          ).length
-        ).toEqual(1);
+          )
+        ).toMatchSnapshot();
       });
 
       test('returns result if pattern is not matched (on object keys)', () => {
@@ -312,8 +312,8 @@ describe('lint', () => {
                 },
               },
             }
-          ).length
-        ).toEqual(1);
+          )
+        ).toMatchSnapshot();
       });
 
       test('dont return result if pattern is matched (on string)', () => {
@@ -338,8 +338,8 @@ describe('lint', () => {
                 termsOfService: 'http://swagger.io/terms/',
               },
             }
-          ).length
-        ).toEqual(0);
+          )
+        ).toMatchSnapshot();
       });
 
       test('dont return result if pattern is matched (on object keys)', () => {
@@ -369,8 +369,8 @@ describe('lint', () => {
                 },
               },
             }
-          ).length
-        ).toEqual(0);
+          )
+        ).toMatchSnapshot();
       });
     });
 
@@ -395,8 +395,8 @@ describe('lint', () => {
                   "### Notes:\n\nThis OAS2 (Swagger 2) specification defines common models and responses, that other specifications may reference.\n\nFor example, check out the user poperty in the main.oas2 todo-partial model - it references the user model in this specification!\n\nLikewise, the main.oas2 operations reference the shared error responses in this common specification.\n\n<script>console.log('sup homie');</script>",
               },
             }
-          ).length
-        ).toEqual(1);
+          )
+        ).toMatchSnapshot();
       });
 
       test('dont return results if property doesnt contain value', () => {
@@ -419,8 +419,8 @@ describe('lint', () => {
                   '### Notes:\n\nThis OAS2 (Swagger 2) specification defines common models and responses, that other specifications may reference.\n\nFor example, check out the user poperty in the main.oas2 todo-partial model - it references the user model in this specification!\n\nLikewise, the main.oas2 operations reference the shared error responses in this common specification.',
               },
             }
-          ).length
-        ).toEqual(0);
+          )
+        ).toMatchSnapshot();
       });
     });
 
@@ -449,8 +449,8 @@ describe('lint', () => {
                 },
               ],
             }
-          ).length
-        ).toEqual(1);
+          )
+        ).toMatchSnapshot();
       });
 
       test('dont return result if property doesnt end with value', () => {
@@ -477,8 +477,8 @@ describe('lint', () => {
                 },
               ],
             }
-          ).length
-        ).toEqual(0);
+          )
+        ).toMatchSnapshot();
       });
     });
 
@@ -506,8 +506,8 @@ describe('lint', () => {
                 },
               },
             }
-          ).length
-        ).toEqual(1);
+          )
+        ).toMatchSnapshot();
       });
 
       test('dont return result if property is shorter than value', () => {
@@ -533,8 +533,8 @@ describe('lint', () => {
                 },
               },
             }
-          ).length
-        ).toEqual(0);
+          )
+        ).toMatchSnapshot();
       });
     });
   });

--- a/src/functions/alphabetical.ts
+++ b/src/functions/alphabetical.ts
@@ -1,5 +1,6 @@
+const get = require('lodash/get');
 import { IAlphaRule, IRuleFunction, IRuleOpts, IRuleResult } from '../types';
-import { ensureRule } from './utils/ensureRule';
+import { ensureRule, shouldHaveProperty } from './utils/ensureRule';
 
 export const alphabetical: IRuleFunction<IAlphaRule> = (opts: IRuleOpts<IAlphaRule>) => {
   const results: IRuleResult[] = [];
@@ -13,11 +14,13 @@ export const alphabetical: IRuleFunction<IAlphaRule> = (opts: IRuleOpts<IAlphaRu
   }
 
   for (const property of properties) {
-    if (!object[property] || object[property].length < 2) {
+    const value = get(object, property);
+    // TODO(SO-9): what if 'length' is not defined, bug
+    if (!value || value.length < 2) {
       continue;
     }
 
-    const arrayCopy: object[] = object[property].slice(0);
+    const arrayCopy: object[] = value.slice(0);
 
     // If we aren't expecting an object keyed by a specific property, then treat the
     // object as a simple array.
@@ -36,8 +39,8 @@ export const alphabetical: IRuleFunction<IAlphaRule> = (opts: IRuleOpts<IAlphaRu
     }
 
     const res = ensureRule(() => {
-      object.should.have.property(property);
-      object[property].should.be.deepEqual(arrayCopy);
+      shouldHaveProperty(object, property);
+      value.should.be.deepEqual(arrayCopy);
     }, meta);
 
     if (res) {

--- a/src/functions/maxLength.ts
+++ b/src/functions/maxLength.ts
@@ -1,3 +1,4 @@
+const get = require('lodash/get');
 import { IMaxLengthRule, IRuleFunction, IRuleOpts, IRuleResult } from '../types';
 import { ensureRule } from './utils/ensureRule';
 
@@ -10,8 +11,9 @@ export const maxLength: IRuleFunction<IMaxLengthRule> = (opts: IRuleOpts<IMaxLen
 
   let target: any;
   if (property) {
-    if (object[property] && typeof object[property] === 'string') {
-      target = object[property];
+    const val = get(object, property);
+    if (typeof val === 'string') {
+      target = val;
     }
   } else {
     target = object;

--- a/src/functions/notContain.ts
+++ b/src/functions/notContain.ts
@@ -1,3 +1,4 @@
+import { get, has } from 'lodash';
 import { INotContainRule, IRuleFunction, IRuleOpts, IRuleResult } from '../types';
 import { ensureRule } from './utils/ensureRule';
 
@@ -9,10 +10,14 @@ export const notContain: IRuleFunction<INotContainRule> = (opts: IRuleOpts<INotC
   const { object, rule, meta } = opts;
   const { value, properties } = rule.input;
 
+  // TODO(SO-9): this is a bug. 'Property' can be a string. For of will work because string is iterable, but this is not what
+  // I think was intended. A unit test would help here.
   for (const property of properties) {
-    if (object && object.hasOwnProperty(property)) {
+    if (has(object, property)) {
       const res = ensureRule(() => {
-        object[property].should.be.a.String().and.not.match(regexFromString(value), rule.description);
+        get(object, property)
+          .should.be.a.String()
+          .and.not.match(regexFromString(value), rule.description);
       }, meta);
 
       if (res) {

--- a/src/functions/notEndWith.ts
+++ b/src/functions/notEndWith.ts
@@ -1,3 +1,4 @@
+const get = require('lodash/get');
 import { INotEndWithRule, IRuleFunction, IRuleOpts, IRuleResult } from '../types';
 import { ensureRule } from './utils/ensureRule';
 
@@ -7,7 +8,11 @@ export const notEndWith: IRuleFunction<INotEndWithRule> = (opts: IRuleOpts<INotE
   const { rule, meta } = opts;
   const { value, property } = rule.input;
 
-  const process = (target: any) => {
+  const process = (prop: undefined | string | string[], o: any) => {
+    if (!prop) {
+      return;
+    }
+    const target = get(o, prop);
     const res = ensureRule(() => {
       target.should.not.endWith(value);
     }, meta);
@@ -17,18 +22,17 @@ export const notEndWith: IRuleFunction<INotEndWithRule> = (opts: IRuleOpts<INotE
     }
   };
 
+  // TODO(SO-9): I think this is buggy. If *, we replace object with its keys, but later we do object_key[*] (see #32)
   if (property === '*') {
     object = Object.keys(object);
   }
 
   if (Array.isArray(object)) {
     object.forEach((obj: any) => {
-      if (property && obj[property]) {
-        process(obj[property]);
-      }
+      process(property, obj);
     });
-  } else if (property && object[property]) {
-    process(object[property]);
+  } else {
+    process(property, object);
   }
   return results;
 };

--- a/src/functions/or.ts
+++ b/src/functions/or.ts
@@ -1,5 +1,7 @@
+import * as should from 'should';
 import { IOrRule, IRuleFunction, IRuleOpts, IRuleResult } from '../types';
 import { ensureRule } from './utils/ensureRule';
+import { countExistingProperties } from './utils/object';
 
 export const or: IRuleFunction<IOrRule> = (opts: IRuleOpts<IOrRule>) => {
   const results: IRuleResult[] = [];
@@ -7,15 +9,9 @@ export const or: IRuleFunction<IOrRule> = (opts: IRuleOpts<IOrRule>) => {
   const { object, rule, meta } = opts;
   const { properties } = rule.input;
 
-  let found = false;
-  for (const property of properties) {
-    if (typeof object[property] !== 'undefined') {
-      found = true;
-      break;
-    }
-  }
+  const found = countExistingProperties(object, properties) > 0;
   const res = ensureRule(() => {
-    found.should.be.exactly(true, rule.description);
+    should(found).be.exactly(true, rule.description);
   }, meta);
 
   if (res) {

--- a/src/functions/pattern.ts
+++ b/src/functions/pattern.ts
@@ -2,7 +2,8 @@ import { IPatternRule, IRuleFunction, IRuleOpts, IRuleResult } from '../types';
 import { ensureRule } from './utils/ensureRule';
 
 // @ts-ignore
-import * as should from 'should/as-function';
+const get = require('lodash/get');
+import * as should from 'should';
 
 export const pattern: IRuleFunction<IPatternRule> = (opts: IRuleOpts<IPatternRule>) => {
   const results: IRuleResult[] = [];
@@ -14,10 +15,11 @@ export const pattern: IRuleFunction<IPatternRule> = (opts: IRuleOpts<IPatternRul
   // the object itself
   let target: any;
   if (typeof object === 'object') {
+    // TODO(SO-9): isn't this misleading? I would expect that rule will be applied to all VALUES, not KEYS.
     if (property === '*') {
       target = Object.keys(object);
     } else if (property) {
-      target = object[property];
+      target = get(object, property);
     }
   } else {
     target = object;

--- a/src/functions/truthy.ts
+++ b/src/functions/truthy.ts
@@ -2,6 +2,7 @@ import { IRuleFunction, IRuleOpts, IRuleResult, ITruthyRule } from '../types';
 import { ensureRule } from './utils/ensureRule';
 
 // @ts-ignore
+// TODO(SO-11): isn't this polluting global scope Object? Wouldn't "expect" be better?
 import * as should from 'should/as-function';
 
 export const truthy: IRuleFunction<ITruthyRule> = (opts: IRuleOpts<ITruthyRule>) => {

--- a/src/functions/truthy.ts
+++ b/src/functions/truthy.ts
@@ -1,9 +1,10 @@
 import { IRuleFunction, IRuleOpts, IRuleResult, ITruthyRule } from '../types';
-import { ensureRule } from './utils/ensureRule';
+import { ensureRule, shouldHaveProperty } from './utils/ensureRule';
 
 // @ts-ignore
 // TODO(SO-11): isn't this polluting global scope Object? Wouldn't "expect" be better?
 import * as should from 'should/as-function';
+const get = require('lodash/get');
 
 export const truthy: IRuleFunction<ITruthyRule> = (opts: IRuleOpts<ITruthyRule>) => {
   const results: IRuleResult[] = [];
@@ -16,8 +17,8 @@ export const truthy: IRuleFunction<ITruthyRule> = (opts: IRuleOpts<ITruthyRule>)
 
   for (const property of properties) {
     const res = ensureRule(() => {
-      object.should.have.property(property);
-      object[property].should.not.be.empty();
+      shouldHaveProperty(object, property);
+      get(object, property).should.not.be.empty();
     }, meta);
 
     if (res) {

--- a/src/functions/utils/ensureRule.ts
+++ b/src/functions/utils/ensureRule.ts
@@ -21,3 +21,11 @@ export const ensureRule = (shouldAssertion: Function, ruleMeta: IRuleMetadata): 
     };
   }
 };
+
+export function shouldHaveProperty(object: any, property: string | string[]) {
+  if (Array.isArray(property)) {
+    object.should.have.propertyByPath(...property);
+  } else {
+    object.should.have.property(property);
+  }
+}

--- a/src/functions/utils/object.ts
+++ b/src/functions/utils/object.ts
@@ -1,0 +1,11 @@
+import { get, reduce } from 'lodash';
+
+export function countExistingProperties(object: any, properties: string[] | string[][]): number {
+  return reduce<string | string[], number>(
+    properties,
+    (sum: number, prop: string | string[]) => {
+      return typeof get(object, prop) === 'undefined' ? sum : sum + 1;
+    },
+    0
+  );
+}

--- a/src/functions/xor.ts
+++ b/src/functions/xor.ts
@@ -1,7 +1,7 @@
+import * as should from 'should';
 import { IRuleFunction, IRuleOpts, IRuleResult, IXorRule } from '../types';
 import { ensureRule } from './utils/ensureRule';
-
-import * as should from 'should';
+import { countExistingProperties } from './utils/object';
 
 export const xor: IRuleFunction<IXorRule> = (opts: IRuleOpts<IXorRule>) => {
   const results: IRuleResult[] = [];
@@ -9,25 +9,9 @@ export const xor: IRuleFunction<IXorRule> = (opts: IRuleOpts<IXorRule>) => {
   const { object, rule, meta } = opts;
   const { properties } = rule.input;
 
-  let found = false;
-  for (const property of properties) {
-    if (typeof object[property] !== 'undefined') {
-      if (found) {
-        const innerRes = ensureRule(() => {
-          should.fail(true, false, rule.summary);
-        }, meta);
-
-        if (innerRes) {
-          results.push(innerRes);
-        }
-      }
-
-      found = true;
-    }
-  }
-
+  const found = countExistingProperties(object, properties) === 1;
   const res = ensureRule(() => {
-    found.should.be.exactly(true, rule.summary);
+    should(found).be.exactly(true, rule.summary);
   }, meta);
 
   if (res) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
 const merge = require('lodash/merge');
 const values = require('lodash/values');
+const compact = require('lodash/compact');
+const flatten = require('lodash/flatten');
 import * as jp from 'jsonpath';
 
 import { PathComponent } from 'jsonpath';
-import { compact, flatten } from 'lodash';
 import { functions as defaultFunctions } from './functions';
 import * as types from './types';
 
@@ -205,7 +206,10 @@ export class Spectral {
     let ruleStore = includeCurrent ? this._rulesByIndex : {};
 
     if (rSets.length) {
-      functionStore = { ...functionStore, ...this._rulesetsToFunctions(rulesets) };
+      functionStore = {
+        ...functionStore,
+        ...this._rulesetsToFunctions(rulesets),
+      };
       ruleStore = this._rulesetsToRules(rulesets, ruleStore, functionStore);
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,6 +176,7 @@ export class Spectral {
       meta: {
         path: node.path,
         name: ruleEntry.name,
+        // TODO(SO-11): why is this duplicated with IRuleOpts.rule?
         rule: ruleEntry.rule,
       },
     };

--- a/src/types/rule.ts
+++ b/src/types/rule.ts
@@ -44,7 +44,7 @@ export interface IRule {
 }
 
 export interface IRuleParam {
-  properties: string | string[];
+  properties: string | string[] | string[][];
 }
 
 export interface IRuleStringParam extends IRuleParam {
@@ -53,7 +53,7 @@ export interface IRuleStringParam extends IRuleParam {
 
 export interface IRuleNumberParam {
   value: number;
-  property?: string;
+  property?: string | string[];
 }
 
 export interface IAlphaRuleParam extends IRuleParam {
@@ -66,7 +66,7 @@ export interface IRulePatternParam {
   value: string;
 
   // object key to apply rule to
-  property?: string;
+  property?: string | string[];
 
   // value to omit from regex matching
   omit?: string;
@@ -81,7 +81,8 @@ export interface ITruthyRule extends IRule {
   input: {
     // key(s) of object that should evaluate as 'truthy' (considered true in a
     // boolean context)
-    properties: string | string[];
+    // note: string[][] represents a list of object "paths"
+    properties: string | string[] | string[][];
 
     max?: number;
   };
@@ -92,7 +93,7 @@ export interface IOrRule extends IRule {
 
   input: {
     // test to verify if any of the provided keys are present in object
-    properties: string[];
+    properties: string[] | string[][];
   };
 }
 
@@ -102,7 +103,7 @@ export interface IXorRule extends IRule {
   input: {
     // test to verify if one (but not all) of the provided keys are present in
     // object
-    properties: string[];
+    properties: string[] | string[][];
   };
 }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

Feature

### What is the current behavior?

We currently do not allow nested properties

### If this is a feature change, what is the new behavior?

This adds support (backwards compatible) for selecting nested properties.
This can be useful for rules like 
```javascript
         {
              type: RuleType.STYLE,
              function: RuleFunction.PATTERN,
              path: '$',
              enabled: true,
              summary: '',
              input: {
                property: ['info', 'termsOfService'], // this is basically the same as 'info.termsOfService'
                value: '^orange.*$',
              },
            },
            {
              swagger: '2.0',
              info: {
                version: '1.0.0',
                title: 'Swagger Petstore',
                termsOfService: 'http://swagger.io/terms/',
              },
            }
```

### Does this PR introduce a breaking change?

NO

### Other information

(e.g. detailed explanation, related issues, links for us to have context, eg. stackoverflow, issues outside of the repo, forum, etc.)

https://stoplightio.atlassian.net/browse/SO-12