### PR TITLE
fix(severity): default severity should be warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,28 +34,28 @@ Think of a set of **rules** and **functions** as a flexible and customizable sty
 Spectral has a built-in set of functions which you can reference in your rules. This example uses the `RuleFunction.PATTERN` to create a rule that checks that all property values are in snake case.
 
 ```javascript
-const { RuleFunction, Spectral } = require("@stoplight/spectral");
+const { RuleFunction, Spectral } = require('@stoplight/spectral');
 
 const spectral = new Spectral();
 
 spectral.addRules({
   snake_case: {
-    summary: "Checks for snake case pattern",
+    summary: 'Checks for snake case pattern',
 
     // evaluate every property
-    given: "$..*",
+    given: '$..*',
 
     then: {
       function: RuleFunction.PATTERN,
       functionOptions: {
-        match: "^[a-z]+[a-z0-9_]*[a-z0-9]+$"
-      }
-    }
-  }
+        match: '^[a-z]+[a-z0-9_]*[a-z0-9]+$',
+      },
+    },
+  },
 });
 
 const results = spectral.run({
-  name: "helloWorld"
+  name: 'helloWorld',
 });
 
 console.log(JSON.stringify(results, null, 4));
@@ -66,8 +66,8 @@ console.log(JSON.stringify(results, null, 4));
 //     {
 //       "name": "snake_case",
 //       "message": "must match the pattern '^[a-z]+[a-z0-9_]*[a-z0-9]+$'",
-//       "severity": 50,
-//       "severityLabel": "error",
+//       "severity": 40,
+//       "severityLabel": "warn",
 //       "path": [
 //         "name"
 //       ]
@@ -81,7 +81,7 @@ console.log(JSON.stringify(results, null, 4));
 Sometimes the built-in functions don't cover your use case. This example creates a custom function, `customNotThatFunction`, and then uses it within a rule, `openapi_not_swagger`. The custom function checks that you are not using a specific string (e.g., "Swagger") and suggests what to use instead (e.g., "OpenAPI").
 
 ```javascript
-const { Spectral } = require("@stoplight/spectral");
+const { Spectral } = require('@stoplight/spectral');
 
 // custom function
 const customNotThatFunction = (targetValue, options) => {
@@ -91,8 +91,8 @@ const customNotThatFunction = (targetValue, options) => {
     // return the single error
     return [
       {
-        message: `Use ${suggestion} instead of ${match}!`
-      }
+        message: `Use ${suggestion} instead of ${match}!`,
+      },
     ];
   }
 };
@@ -100,31 +100,31 @@ const customNotThatFunction = (targetValue, options) => {
 const spectral = new Spectral();
 
 spectral.addFunctions({
-  notThat: customNotThatFunction
+  notThat: customNotThatFunction,
 });
 
 spectral.addRules({
   openapi_not_swagger: {
-    summary: "Checks for use of Swagger, and suggests OpenAPI.",
+    summary: 'Checks for use of Swagger, and suggests OpenAPI.',
 
     // check every property
-    given: "$..*",
+    given: '$..*',
 
     then: {
       // reference the function we added!
-      function: "notThat",
+      function: 'notThat',
 
       // pass it the options it needs
       functionOptions: {
-        match: "Swagger",
-        suggestion: "OpenAPI"
-      }
-    }
-  }
+        match: 'Swagger',
+        suggestion: 'OpenAPI',
+      },
+    },
+  },
 });
 
 const results = spectral.run({
-  description: "Swagger is pretty cool!"
+  description: 'Swagger is pretty cool!',
 });
 
 console.log(JSON.stringify(results, null, 4));
@@ -135,8 +135,8 @@ console.log(JSON.stringify(results, null, 4));
 //     {
 //       "name": "openapi_not_swagger",
 //       "message": "Use OpenAPI instead of Swagger!",
-//       "severity": 50,
-//       "severityLabel": "error",
+//       "severity": 40,
+//       "severityLabel": "warn",
 //       "path": [
 //         "description"
 //       ]
@@ -152,23 +152,20 @@ Spectral also includes a number of ready made rules and functions for OpenAPI Sp
 You can also add to these rules to create a customized linting style guide for your OAS documents.
 
 ```javascript
-const { Spectral } = require("@stoplight/spectral");
-const {
-  oas2Functions,
-  oas2Rules
-} = require("@stoplight/spectral/rulesets/oas2");
+const { Spectral } = require('@stoplight/spectral');
+const { oas2Functions, oas2Rules } = require('@stoplight/spectral/rulesets/oas2');
 
 // an OASv2 document
 var myOAS = {
   // ... properties in your document
   responses: {
-    "200": {
-      description: "",
+    '200': {
+      description: '',
       schema: {
-        $ref: "#/definitions/error-response"
-      }
-    }
-  }
+        $ref: '#/definitions/error-response',
+      },
+    },
+  },
   // ... properties in your document
 };
 

--- a/src/__tests__/linter.ts
+++ b/src/__tests__/linter.ts
@@ -88,8 +88,8 @@ describe('linter', () => {
     expect(result.results[0]).toEqual({
       name: 'rule1',
       message,
-      severity: ValidationSeverity.Error,
-      severityLabel: ValidationSeverityLabel.Error,
+      severity: ValidationSeverity.Warn,
+      severityLabel: ValidationSeverityLabel.Warn,
       path: ['responses', '404', 'description'],
     });
   });
@@ -110,6 +110,35 @@ describe('linter', () => {
         given: '$.x',
         severity: ValidationSeverity.Info,
         severityLabel: ValidationSeverityLabel.Info,
+        then: {
+          function: 'func1',
+        },
+      },
+    });
+
+    const result = spectral.run({
+      x: true,
+    });
+
+    expect(result.results[0].severity).toEqual(ValidationSeverity.Info);
+    expect(result.results[0].severityLabel).toEqual(ValidationSeverityLabel.Info);
+  });
+
+  test('should default severityLabel based on rule severity', () => {
+    spectral.addFunctions({
+      func1: () => {
+        return [
+          {
+            message: 'foo',
+          },
+        ];
+      },
+    });
+
+    spectral.addRules({
+      rule1: {
+        given: '$.x',
+        severity: ValidationSeverity.Info,
         then: {
           function: 'func1',
         },

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -1,7 +1,8 @@
-import { ObjPath, ValidationSeverity, ValidationSeverityLabel } from '@stoplight/types';
+import { ObjPath, ValidationSeverity } from '@stoplight/types';
 import * as jp from 'jsonpath';
 const get = require('lodash/get');
 const has = require('lodash/has');
+const invert = require('lodash/invert');
 
 import { IFunction, IGivenNode, IRuleResult, IRunOpts, IRunRule, IThen } from './types';
 
@@ -83,15 +84,18 @@ export const lintNode = (
         }
       ) || [];
 
+    const severity = rule.severity || ValidationSeverity.Warn;
+    const severityLabel = rule.severityLabel || invert(ValidationSeverity)[rule.severity || ValidationSeverity.Warn];
+
     results = results.concat(
       targetResults.map(result => {
         return {
           name: rule.name,
           summary: rule.summary,
           message: result.message,
-          severity: rule.severity || ValidationSeverity.Error,
-          severityLabel: rule.severityLabel || ValidationSeverityLabel.Error,
           path: result.path || targetPath,
+          severity,
+          severityLabel,
         };
       })
     );

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -1,4 +1,4 @@
-import { ObjPath, ValidationSeverity } from '@stoplight/types';
+import { ObjPath, ValidationSeverity, ValidationSeverityLabel } from '@stoplight/types';
 import * as jp from 'jsonpath';
 const get = require('lodash/get');
 const has = require('lodash/has');
@@ -85,7 +85,8 @@ export const lintNode = (
       ) || [];
 
     const severity = rule.severity || ValidationSeverity.Warn;
-    const severityLabel = rule.severityLabel || invert(ValidationSeverity)[rule.severity || ValidationSeverity.Warn];
+    const severityLabel =
+      rule.severityLabel || (ValidationSeverityLabel[invert(ValidationSeverity)[severity]] as ValidationSeverityLabel);
 
     results = results.concat(
       targetResults.map(result => {

--- a/src/rulesets/oas/__tests__/__snapshots__/contact-properties.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/contact-properties.ts.snap
@@ -10,8 +10,8 @@ Array [
       "contact",
       "name",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Contact object should have \`name\`, \`url\` and \`email\`.",
   },
   Object {
@@ -22,8 +22,8 @@ Array [
       "contact",
       "url",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Contact object should have \`name\`, \`url\` and \`email\`.",
   },
   Object {
@@ -34,8 +34,8 @@ Array [
       "contact",
       "email",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Contact object should have \`name\`, \`url\` and \`email\`.",
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/example-value-or-externalValue.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/example-value-or-externalValue.ts.snap
@@ -8,8 +8,8 @@ Array [
     "path": Array [
       "example",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Example should have either a \`value\` or \`externalValue\` field.",
   },
 ]
@@ -23,8 +23,8 @@ Array [
     "path": Array [
       "example",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Example should have either a \`value\` or \`externalValue\` field.",
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/info-contact.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/info-contact.ts.snap
@@ -9,8 +9,8 @@ Array [
       "info",
       "contact",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Info object should contain \`contact\` object.",
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/info-description.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/info-description.ts.snap
@@ -9,8 +9,8 @@ Array [
       "info",
       "description",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "OpenAPI object info \`description\` must be present and non-empty string.",
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/info-license.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/info-license.ts.snap
@@ -9,8 +9,8 @@ Array [
       "info",
       "license",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "OpenAPI object info \`license\` must be present and non-empty string.",
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/license-url.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/license-url.ts.snap
@@ -10,8 +10,8 @@ Array [
       "license",
       "url",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "License object should include \`url\`.",
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/no-eval-in-markdown.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/no-eval-in-markdown.ts.snap
@@ -9,8 +9,8 @@ Array [
       "info",
       "description",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Markdown descriptions should not contain \`eval(\`.",
   },
   Object {
@@ -20,8 +20,8 @@ Array [
       "info",
       "title",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Markdown descriptions should not contain \`eval(\`.",
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/no-script-tags-in-markdown.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/no-script-tags-in-markdown.ts.snap
@@ -9,8 +9,8 @@ Array [
       "info",
       "description",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Markdown descriptions should not contain \`<script>\` tags.",
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/only-local-references.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/only-local-references.ts.snap
@@ -10,8 +10,8 @@ Array [
       0,
       "$ref",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "References should start with \`#/\`.",
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/openapi-tags-alphabetical.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/openapi-tags-alphabetical.ts.snap
@@ -8,8 +8,8 @@ Array [
     "path": Array [
       "tags",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "OpenAPI object should have alphabetical \`tags\`.",
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/openapi-tags.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/openapi-tags.ts.snap
@@ -8,8 +8,8 @@ Array [
     "path": Array [
       "tags",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "OpenAPI object should have non-empty \`tags\` array.",
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-default-response.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-default-response.ts.snap
@@ -12,8 +12,8 @@ Array [
       "responses",
       "default",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Operations must have a default response.",
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-description.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-description.ts.snap
@@ -13,8 +13,8 @@ Array [
       "get",
       "description",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Operation \`description\` must be present and non-empty string.",
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-operationId.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-operationId.ts.snap
@@ -13,8 +13,8 @@ Array [
       "get",
       "operationId",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Operation should have an \`operationId\`.",
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-singular-tag.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-singular-tag.ts.snap
@@ -11,8 +11,8 @@ Array [
       "get",
       "tags",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Operation may only have one tag.",
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-summary-formatted.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-summary-formatted.ts.snap
@@ -11,8 +11,8 @@ Array [
       "get",
       "summary",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Operation \`summary\` should start with upper case and end with a dot.",
   },
 ]
@@ -29,8 +29,8 @@ Array [
       "get",
       "summary",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Operation \`summary\` should start with upper case and end with a dot.",
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-tags.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-tags.ts.snap
@@ -11,8 +11,8 @@ Array [
       "get",
       "tags",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Operation should have non-empty \`tags\` array.",
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/path-declarations-must-exist.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/path-declarations-must-exist.ts.snap
@@ -9,8 +9,8 @@ Array [
       "paths",
       "/path/{}",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "given declarations cannot be empty, ex.\`/given/{}\` is invalid.",
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/path-keys-no-trailing-slash.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/path-keys-no-trailing-slash.ts.snap
@@ -9,8 +9,8 @@ Array [
       "paths",
       "/path/",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "given keys should not end with a slash.",
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/path-not-include-query.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/path-not-include-query.ts.snap
@@ -9,8 +9,8 @@ Array [
       "paths",
       "/path?query=true",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "given keys should not include a query string.",
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/schema-items-is-object.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/schema-items-is-object.ts.snap
@@ -9,8 +9,8 @@ Array [
       "schema",
       "items",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Schema containing \`items\` requires the items property to be an object.",
   },
 ]
@@ -25,8 +25,8 @@ Array [
       "schema",
       "items",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Schema containing \`items\` requires the items property to be an object.",
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/tag-description.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/tag-description.ts.snap
@@ -10,8 +10,8 @@ Array [
       0,
       "description",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Tag object should have a \`description\`.",
   },
 ]

--- a/src/rulesets/oas/functions/oasOp2xxResponse/__tests__/__snapshots__/index.ts.snap
+++ b/src/rulesets/oas/functions/oasOp2xxResponse/__tests__/__snapshots__/index.ts.snap
@@ -11,8 +11,8 @@ Array [
       "get",
       "responses",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Operation must have at least one \`2xx\` response.",
   },
 ]
@@ -29,8 +29,8 @@ Array [
       "get",
       "responses",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Operation must have at least one \`2xx\` response.",
   },
 ]

--- a/src/rulesets/oas/functions/oasOpFormDataConsumeCheck/__tests__/__snapshots__/index.ts.snap
+++ b/src/rulesets/oas/functions/oasOpFormDataConsumeCheck/__tests__/__snapshots__/index.ts.snap
@@ -10,8 +10,8 @@ Array [
       "/path1",
       "get",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Operations with an \`in: formData\` parameter must include \`application/x-www-form-urlencoded\` or \`multipart/form-data\` in their \`consumes\` property.",
   },
 ]

--- a/src/rulesets/oas/functions/oasOpIdUnique/__tests__/__snapshots__/index.ts.snap
+++ b/src/rulesets/oas/functions/oasOpIdUnique/__tests__/__snapshots__/index.ts.snap
@@ -11,8 +11,8 @@ Array [
       "get",
       "operationId",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Every operation must have a unique \`operationId\`.",
   },
   Object {
@@ -24,8 +24,8 @@ Array [
       "get",
       "operationId",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Every operation must have a unique \`operationId\`.",
   },
 ]
@@ -42,8 +42,8 @@ Array [
       "get",
       "operationId",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Every operation must have a unique \`operationId\`.",
   },
   Object {
@@ -55,8 +55,8 @@ Array [
       "post",
       "operationId",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Every operation must have a unique \`operationId\`.",
   },
 ]

--- a/src/rulesets/oas/functions/oasOpParams/__tests__/__snapshots__/index.ts.snap
+++ b/src/rulesets/oas/functions/oasOpParams/__tests__/__snapshots__/index.ts.snap
@@ -15,8 +15,8 @@ Parameters found at:
       "/foo",
       "get",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Operation parameters are unique and non-repeating.",
   },
 ]
@@ -35,8 +35,8 @@ Parameters found at:
       "/foo",
       "get",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Operation parameters are unique and non-repeating.",
   },
 ]
@@ -46,7 +46,7 @@ exports[`oasOpParams Error if nonunique param on same operation 1`] = `
 Array [
   Object {
     "message": "Operations must have unique \`name\` + \`in\` parameters.
-Repeats of \`in:query\` + \`name:foo\` 
+Repeats of \`in:query\` + \`name:foo\`
 
 Parameters found at:
 [ \`paths\`, \`/foo\`, \`get\`, \`0\` ]
@@ -59,8 +59,8 @@ Parameters found at:
       "/foo",
       "get",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Operation parameters are unique and non-repeating.",
   },
 ]

--- a/src/rulesets/oas/functions/oasOpParams/index.ts
+++ b/src/rulesets/oas/functions/oasOpParams/index.ts
@@ -94,7 +94,7 @@ export const oasOpParams: IFunction<Rule> = (targetVal, _options, _paths, vals) 
             const inVal = nonUnique[group][firstMatch].in;
             const nameVal = nonUnique[group][firstMatch].name;
 
-            let message = `Operations must have unique \`name\` + \`in\` parameters.\nRepeats of \`in:${inVal}\` + \`name:${nameVal}\` \n\nParameters found at:\n`;
+            let message = `Operations must have unique \`name\` + \`in\` parameters.\nRepeats of \`in:${inVal}\` + \`name:${nameVal}\`\n\nParameters found at:\n`;
 
             for (const index in nonUnique[group]) {
               if (!inBody[index]) {

--- a/src/rulesets/oas/functions/oasOpSecurityDefined/__tests__/__snapshots__/index.ts.snap
+++ b/src/rulesets/oas/functions/oasOpSecurityDefined/__tests__/__snapshots__/index.ts.snap
@@ -12,8 +12,8 @@ Array [
       "security",
       "0",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Operation \`security\` values must match a scheme defined in the \`securityDefinitions\` object.",
   },
 ]
@@ -31,8 +31,8 @@ Array [
       "security",
       "0",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Operation \`security\` values must match a scheme defined in the \`components.securitySchemes\` object.",
   },
 ]

--- a/src/rulesets/oas/index.ts
+++ b/src/rulesets/oas/index.ts
@@ -323,6 +323,7 @@ export const commonOasRules = (): RuleCollection => ({
   },
   'path-keys-no-trailing-slash': {
     summary: 'given keys should not end with a slash.',
+    type: RuleType.STYLE,
     given: '$..paths',
     then: {
       field: '@key',

--- a/src/rulesets/oas2/__tests__/__snapshots__/api-host.ts.snap
+++ b/src/rulesets/oas2/__tests__/__snapshots__/api-host.ts.snap
@@ -8,8 +8,8 @@ Array [
     "path": Array [
       "host",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "OpenAPI \`host\` must be present and non-empty string.",
   },
 ]

--- a/src/rulesets/oas2/__tests__/__snapshots__/api-schemes.ts.snap
+++ b/src/rulesets/oas2/__tests__/__snapshots__/api-schemes.ts.snap
@@ -8,8 +8,8 @@ Array [
     "path": Array [
       "schemes",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "OpenAPI host \`schemes\` must be present and non-empty array.",
   },
 ]
@@ -23,8 +23,8 @@ Array [
     "path": Array [
       "schemes",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "OpenAPI host \`schemes\` must be present and non-empty array.",
   },
 ]

--- a/src/rulesets/oas2/__tests__/__snapshots__/host-not-example.ts.snap
+++ b/src/rulesets/oas2/__tests__/__snapshots__/host-not-example.ts.snap
@@ -8,8 +8,8 @@ Array [
     "path": Array [
       "host",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Server URL should not point at \`example.com\`.",
   },
 ]

--- a/src/rulesets/oas2/__tests__/__snapshots__/host-trailing-slash.ts.snap
+++ b/src/rulesets/oas2/__tests__/__snapshots__/host-trailing-slash.ts.snap
@@ -8,8 +8,8 @@ Array [
     "path": Array [
       "host",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Server URL should not have a trailing slash.",
   },
 ]

--- a/src/rulesets/oas2/__tests__/__snapshots__/model-description.ts.snap
+++ b/src/rulesets/oas2/__tests__/__snapshots__/model-description.ts.snap
@@ -10,8 +10,8 @@ Array [
       "user",
       "description",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Definition \`description\` must be present and non-empty string.",
   },
 ]

--- a/src/rulesets/oas3/__tests__/__snapshots__/api-servers.ts.snap
+++ b/src/rulesets/oas3/__tests__/__snapshots__/api-servers.ts.snap
@@ -8,8 +8,8 @@ Array [
     "path": Array [
       "servers",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "OpenAPI \`servers\` must be present and non-empty string.",
   },
 ]
@@ -23,8 +23,8 @@ Array [
     "path": Array [
       "servers",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "OpenAPI \`servers\` must be present and non-empty string.",
   },
 ]

--- a/src/rulesets/oas3/__tests__/__snapshots__/model-description.ts.snap
+++ b/src/rulesets/oas3/__tests__/__snapshots__/model-description.ts.snap
@@ -11,8 +11,8 @@ Array [
       "user",
       "description",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Model \`description\` must be present and non-empty string.",
   },
 ]

--- a/src/rulesets/oas3/__tests__/__snapshots__/server-not-example.ts.snap
+++ b/src/rulesets/oas3/__tests__/__snapshots__/server-not-example.ts.snap
@@ -10,8 +10,8 @@ Array [
       0,
       "url",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Server URL should not point at \`example.com\`.",
   },
 ]

--- a/src/rulesets/oas3/__tests__/__snapshots__/server-trailing-slash.ts.snap
+++ b/src/rulesets/oas3/__tests__/__snapshots__/server-trailing-slash.ts.snap
@@ -10,8 +10,8 @@ Array [
       0,
       "url",
     ],
-    "severity": 50,
-    "severityLabel": "error",
+    "severity": 40,
+    "severityLabel": "warn",
     "summary": "Server URL should not have a trailing slash.",
   },
 ]


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

**Current**: if no `rule.severity` always default to `ValidationSeverity.Error`
**Expected/Fixed**: if no `rule.severity` always default to label corresponding to `ValidationSeverity.Error`

**Current**: if no `rule.severityLabel` always default to `ValidationSeverityLabel.Warn`
**Expected/Fixed**: if no `rule.severityLabel` always default to label corresponding to `rule.severity`

### Does this PR introduce a breaking change?

No

