### PR TITLE
fix: a typo and a probable cut-and-paste error (replacement for #80)

### DIFF
--- a/src/rulesets/oas3/__tests__/__snapshots__/api-servers.ts.snap
+++ b/src/rulesets/oas3/__tests__/__snapshots__/api-servers.ts.snap
@@ -10,7 +10,7 @@ Array [
     ],
     "severity": 40,
     "severityLabel": "warn",
-    "summary": "OpenAPI \`servers\` must be present and non-empty string.",
+    "summary": "OpenAPI \`servers\` must be present and non-empty array.",
   },
 ]
 `;
@@ -25,7 +25,7 @@ Array [
     ],
     "severity": 40,
     "severityLabel": "warn",
-    "summary": "OpenAPI \`servers\` must be present and non-empty string.",
+    "summary": "OpenAPI \`servers\` must be present and non-empty array.",
   },
 ]
 `;

--- a/src/rulesets/oas3/index.ts
+++ b/src/rulesets/oas3/index.ts
@@ -9,7 +9,7 @@ export { commonOasFunctions as oas3Functions } from '../oas';
 
 export const oas3Rules = () => {
   return merge(commonOasRules(), {
-    // specifcication validation
+    // specification validation
     'oas3-schema': {
       summary: 'Validate structure of OpenAPIv3 specification.',
       type: RuleType.VALIDATION,
@@ -25,7 +25,7 @@ export const oas3Rules = () => {
 
     // generic rules
     'api-servers': {
-      summary: 'OpenAPI `servers` must be present and non-empty string.',
+      summary: 'OpenAPI `servers` must be present and non-empty array.',
       type: RuleType.STYLE,
       given: '$',
       then: {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] Tests for the changes have been added (for bug fixes / features)
- n/a Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

* Typo in comment (harmless). 
* OpenAPI3 test for present and non-empty `servers` array uses the word `string` instead of `array`. Associated tests therefore expect this summary value too.

### If this is a feature change, what is the new behavior?

The correct summary is given for the rule `api-servers`.

### Does this PR introduce a breaking change?

Possibly, if users are dependent on value of `summary` property. Users may need to update their harness code.

### Other information

src/rulesets/oas3/index.ts and associated tests:

'specifcication' -> 'specification' in a comment
`servers` must be, and is tested against, being an `array` not a `string`.