### PR TITLE
feat: new shape of validation results [SL-2123]

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ console.log(JSON.stringify(results, null, 4));
 //   {
 //     "name": "snake_case",
 //     "message": "must match the pattern '^[a-z]+[a-z0-9_]*[a-z0-9]+$'",
-//     "severity": 40,
-//     "severityLabel": "warn",
+//     "severity": 1,
 //     "path": [
 //       "name"
 //     ]
@@ -134,8 +133,7 @@ console.log(JSON.stringify(results, null, 4));
 //   {
 //     "name": "openapi_not_swagger",
 //     "message": "Use OpenAPI instead of Swagger!",
-//     "severity": 40,
-//     "severityLabel": "warn",
+//     "severity": 1,
 //     "path": [
 //       "description"
 //     ]

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@stoplight/json": "1.x.x",
     "@stoplight/json-ref-resolver": "^1.2.2",
-    "@stoplight/types": "3.x.x",
+    "@stoplight/types": "4.x.x",
     "ajv": "6.x.x",
     "jsonpath": "https://github.com/stoplightio/jsonpath#78140eb1980d4ff385780e2fa12177735685ec3e",
     "lodash": ">=4.17.5"

--- a/src/__tests__/linter.test.ts
+++ b/src/__tests__/linter.test.ts
@@ -90,16 +90,6 @@ describe('linter', () => {
       message,
       severity: DiagnosticSeverity.Warning,
       path: ['responses', '404', 'description'],
-      range: expect.objectContaining({
-        start: expect.objectContaining({
-          character: expect.any(Number),
-          line: expect.any(Number),
-        }),
-        end: expect.objectContaining({
-          character: expect.any(Number),
-          line: expect.any(Number),
-        }),
-      }),
     });
   });
 

--- a/src/__tests__/linter.test.ts
+++ b/src/__tests__/linter.test.ts
@@ -85,7 +85,7 @@ describe('linter', () => {
       },
     });
 
-    expect(result.results[0]).toEqual({
+    expect(result[0]).toEqual({
       code: 'rule1',
       message,
       severity: DiagnosticSeverity.Warning,
@@ -118,7 +118,7 @@ describe('linter', () => {
       x: true,
     });
 
-    expect(result.results[0].severity).toEqual(DiagnosticSeverity.Hint);
+    expect(result[0]).toHaveProperty('severity', DiagnosticSeverity.Hint);
   });
 
   test('should default severityLabel based on rule severity', async () => {
@@ -135,7 +135,7 @@ describe('linter', () => {
     spectral.addRules({
       rule1: {
         given: '$.x',
-        severity: ValidationSeverity.Info,
+        severity: DiagnosticSeverity.Information,
         then: {
           function: 'func1',
         },
@@ -146,8 +146,7 @@ describe('linter', () => {
       x: true,
     });
 
-    expect(result[0].severity).toEqual(ValidationSeverity.Info);
-    expect(result[0].severityLabel).toEqual(ValidationSeverityLabel.Info);
+    expect(result[0]).toHaveProperty('severity', DiagnosticSeverity.Information);
   });
 
   describe('functional tests for the given property', () => {

--- a/src/__tests__/linter.test.ts
+++ b/src/__tests__/linter.test.ts
@@ -1,4 +1,4 @@
-import { ValidationSeverity, ValidationSeverityLabel } from '@stoplight/types';
+import { DiagnosticSeverity } from '@stoplight/types';
 
 import { Spectral } from '../spectral';
 
@@ -85,12 +85,21 @@ describe('linter', () => {
       },
     });
 
-    expect(result[0]).toEqual({
-      name: 'rule1',
+    expect(result.results[0]).toEqual({
+      code: 'rule1',
       message,
-      severity: ValidationSeverity.Warn,
-      severityLabel: ValidationSeverityLabel.Warn,
+      severity: DiagnosticSeverity.Warning,
       path: ['responses', '404', 'description'],
+      range: expect.objectContaining({
+        start: expect.objectContaining({
+          character: expect.any(Number),
+          line: expect.any(Number),
+        }),
+        end: expect.objectContaining({
+          character: expect.any(Number),
+          line: expect.any(Number),
+        }),
+      }),
     });
   });
 
@@ -108,8 +117,7 @@ describe('linter', () => {
     spectral.addRules({
       rule1: {
         given: '$.x',
-        severity: ValidationSeverity.Info,
-        severityLabel: ValidationSeverityLabel.Info,
+        severity: DiagnosticSeverity.Hint,
         then: {
           function: 'func1',
         },
@@ -120,8 +128,7 @@ describe('linter', () => {
       x: true,
     });
 
-    expect(result[0].severity).toEqual(ValidationSeverity.Info);
-    expect(result[0].severityLabel).toEqual(ValidationSeverityLabel.Info);
+    expect(result.results[0].severity).toEqual(DiagnosticSeverity.Hint);
   });
 
   test('should default severityLabel based on rule severity', async () => {

--- a/src/__tests__/spectral.test.ts
+++ b/src/__tests__/spectral.test.ts
@@ -1,4 +1,4 @@
-import { ValidationSeverity } from '@stoplight/types';
+import { DiagnosticSeverity } from '@stoplight/types';
 const merge = require('lodash/merge');
 
 import { Spectral } from '../spectral';
@@ -25,7 +25,7 @@ describe('spectral', () => {
 
       s.mergeRules({
         rule1: {
-          severity: ValidationSeverity.Error,
+          severity: DiagnosticSeverity.Error,
         },
       });
 
@@ -39,7 +39,7 @@ describe('spectral', () => {
         rule1: {
           summary: '',
           given: '$',
-          severity: ValidationSeverity.Warn,
+          severity: DiagnosticSeverity.Warning,
           then: {
             function: RuleFunction.TRUTHY,
           },
@@ -60,12 +60,12 @@ describe('spectral', () => {
 
       s.mergeRules({
         rule1: {
-          severity: ValidationSeverity.Error,
+          severity: DiagnosticSeverity.Error,
         },
       });
 
       expect(Object.keys(s.rules)).toEqual(['rule1', 'rule2']);
-      expect(s.rules.rule1.severity).toBe(ValidationSeverity.Error);
+      expect(s.rules.rule1.severity).toBe(DiagnosticSeverity.Error);
     });
   });
 

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -2,8 +2,8 @@ import * as jp from 'jsonpath';
 const get = require('lodash/get');
 const has = require('lodash/has');
 
+import { DiagnosticSeverity, JSONPath } from '@stoplight/types';
 import { IFunction, IGivenNode, IRuleResult, IRunOpts, IRunRule, IThen } from './types';
-import { JSONPath, DiagnosticSeverity } from '@stoplight/types';
 
 // TODO(SO-23): unit test but mock whatShouldBeLinted
 export const lintNode = (
@@ -92,18 +92,7 @@ export const lintNode = (
           message: result.message,
           path: result.path || targetPath,
           severity,
-          // todo: make range optional?
-          range: {
-            start: {
-              character: -1,
-              line: -1,
-            },
-            end: {
-              character: -1,
-              line: -1,
-            }
-          }
-        }
+        };
       })
     );
   }

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -2,7 +2,7 @@ import * as jp from 'jsonpath';
 const get = require('lodash/get');
 const has = require('lodash/has');
 
-import { DiagnosticSeverity, JSONPath } from '@stoplight/types';
+import { DiagnosticSeverity, JsonPath } from '@stoplight/types';
 import { IFunction, IGivenNode, IRuleResult, IRunOpts, IRunRule, IThen } from './types';
 
 // TODO(SO-23): unit test but mock whatShouldBeLinted
@@ -89,6 +89,7 @@ export const lintNode = (
       targetResults.map(result => {
         return {
           code: rule.name,
+          summary: rule.summary,
           message: result.message,
           path: result.path || targetPath,
           severity,
@@ -102,7 +103,7 @@ export const lintNode = (
 
 // TODO(SO-23): unit test idividually
 export const whatShouldBeLinted = (
-  path: JSONPath,
+  path: JsonPath,
   originalValue: any,
   rule: IRunRule
 ): { lint: boolean; value: any } => {

--- a/src/rulesets/oas/__tests__/__snapshots__/contact-properties.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/contact-properties.ts.snap
@@ -3,40 +3,64 @@
 exports[`contact-properties return errors if name, url, email are missing 1`] = `
 Array [
   Object {
+    "code": "contact-properties",
     "message": "info.contact.name is not truthy",
-    "name": "contact-properties",
     "path": Array [
       "info",
       "contact",
       "name",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Contact object should have \`name\`, \`url\` and \`email\`.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
   Object {
+    "code": "contact-properties",
     "message": "info.contact.url is not truthy",
-    "name": "contact-properties",
     "path": Array [
       "info",
       "contact",
       "url",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Contact object should have \`name\`, \`url\` and \`email\`.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
   Object {
+    "code": "contact-properties",
     "message": "info.contact.email is not truthy",
-    "name": "contact-properties",
     "path": Array [
       "info",
       "contact",
       "email",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Contact object should have \`name\`, \`url\` and \`email\`.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/contact-properties.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/contact-properties.ts.snap
@@ -11,6 +11,7 @@ Array [
       "name",
     ],
     "severity": 1,
+    "summary": "Contact object should have \`name\`, \`url\` and \`email\`.",
   },
   Object {
     "code": "contact-properties",
@@ -21,6 +22,7 @@ Array [
       "url",
     ],
     "severity": 1,
+    "summary": "Contact object should have \`name\`, \`url\` and \`email\`.",
   },
   Object {
     "code": "contact-properties",
@@ -31,6 +33,7 @@ Array [
       "email",
     ],
     "severity": 1,
+    "summary": "Contact object should have \`name\`, \`url\` and \`email\`.",
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/contact-properties.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/contact-properties.ts.snap
@@ -10,16 +10,6 @@ Array [
       "contact",
       "name",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
   Object {
@@ -30,16 +20,6 @@ Array [
       "contact",
       "url",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
   Object {
@@ -50,16 +30,6 @@ Array [
       "contact",
       "email",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/example-value-or-externalValue.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/example-value-or-externalValue.ts.snap
@@ -9,6 +9,7 @@ Array [
       "example",
     ],
     "severity": 1,
+    "summary": "Example should have either a \`value\` or \`externalValue\` field.",
   },
 ]
 `;
@@ -22,6 +23,7 @@ Array [
       "example",
     ],
     "severity": 1,
+    "summary": "Example should have either a \`value\` or \`externalValue\` field.",
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/example-value-or-externalValue.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/example-value-or-externalValue.ts.snap
@@ -3,14 +3,22 @@
 exports[`example-value-or-externalValue return errors if both externalValue and value 1`] = `
 Array [
   Object {
+    "code": "example-value-or-externalValue",
     "message": "externalValue and value cannot both be defined",
-    "name": "example-value-or-externalValue",
     "path": Array [
       "example",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Example should have either a \`value\` or \`externalValue\` field.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;
@@ -18,14 +26,22 @@ Array [
 exports[`example-value-or-externalValue return errors if missing externalValue and value 1`] = `
 Array [
   Object {
+    "code": "example-value-or-externalValue",
     "message": "externalValue and value cannot both be defined",
-    "name": "example-value-or-externalValue",
     "path": Array [
       "example",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Example should have either a \`value\` or \`externalValue\` field.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/example-value-or-externalValue.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/example-value-or-externalValue.ts.snap
@@ -8,16 +8,6 @@ Array [
     "path": Array [
       "example",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]
@@ -31,16 +21,6 @@ Array [
     "path": Array [
       "example",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/info-contact.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/info-contact.ts.snap
@@ -3,15 +3,23 @@
 exports[`info-contact return errors if info is missing contact 1`] = `
 Array [
   Object {
+    "code": "info-contact",
     "message": "info.contact is not truthy",
-    "name": "info-contact",
     "path": Array [
       "info",
       "contact",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Info object should contain \`contact\` object.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/info-contact.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/info-contact.ts.snap
@@ -9,16 +9,6 @@ Array [
       "info",
       "contact",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/info-contact.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/info-contact.ts.snap
@@ -10,6 +10,7 @@ Array [
       "contact",
     ],
     "severity": 1,
+    "summary": "Info object should contain \`contact\` object.",
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/info-description.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/info-description.ts.snap
@@ -3,15 +3,23 @@
 exports[`info-description return errors if info missing description 1`] = `
 Array [
   Object {
+    "code": "info-description",
     "message": "info.description is not truthy",
-    "name": "info-description",
     "path": Array [
       "info",
       "description",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "OpenAPI object info \`description\` must be present and non-empty string.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/info-description.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/info-description.ts.snap
@@ -9,16 +9,6 @@ Array [
       "info",
       "description",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/info-description.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/info-description.ts.snap
@@ -10,6 +10,7 @@ Array [
       "description",
     ],
     "severity": 1,
+    "summary": "OpenAPI object info \`description\` must be present and non-empty string.",
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/info-license.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/info-license.ts.snap
@@ -10,6 +10,7 @@ Array [
       "license",
     ],
     "severity": 1,
+    "summary": "OpenAPI object info \`license\` must be present and non-empty string.",
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/info-license.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/info-license.ts.snap
@@ -9,16 +9,6 @@ Array [
       "info",
       "license",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/info-license.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/info-license.ts.snap
@@ -3,15 +3,23 @@
 exports[`info-license return errors if info missing license 1`] = `
 Array [
   Object {
+    "code": "info-license",
     "message": "info.license is not truthy",
-    "name": "info-license",
     "path": Array [
       "info",
       "license",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "OpenAPI object info \`license\` must be present and non-empty string.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/license-url.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/license-url.ts.snap
@@ -10,16 +10,6 @@ Array [
       "license",
       "url",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/license-url.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/license-url.ts.snap
@@ -3,16 +3,24 @@
 exports[`license-url return errors if info license is missing url 1`] = `
 Array [
   Object {
+    "code": "license-url",
     "message": "info.license.url is not truthy",
-    "name": "license-url",
     "path": Array [
       "info",
       "license",
       "url",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "License object should include \`url\`.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/license-url.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/license-url.ts.snap
@@ -11,6 +11,7 @@ Array [
       "url",
     ],
     "severity": 1,
+    "summary": "License object should include \`url\`.",
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/no-eval-in-markdown.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/no-eval-in-markdown.ts.snap
@@ -3,26 +3,42 @@
 exports[`no-eval-in-markdown return errors if descriptions or titles include eval 1`] = `
 Array [
   Object {
+    "code": "no-eval-in-markdown",
     "message": "must not match the pattern 'eval\\\\('",
-    "name": "no-eval-in-markdown",
     "path": Array [
       "info",
       "description",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Markdown descriptions should not contain \`eval(\`.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
   Object {
+    "code": "no-eval-in-markdown",
     "message": "must not match the pattern 'eval\\\\('",
-    "name": "no-eval-in-markdown",
     "path": Array [
       "info",
       "title",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Markdown descriptions should not contain \`eval(\`.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/no-eval-in-markdown.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/no-eval-in-markdown.ts.snap
@@ -9,16 +9,6 @@ Array [
       "info",
       "description",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
   Object {
@@ -28,16 +18,6 @@ Array [
       "info",
       "title",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/no-eval-in-markdown.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/no-eval-in-markdown.ts.snap
@@ -10,6 +10,7 @@ Array [
       "description",
     ],
     "severity": 1,
+    "summary": "Markdown descriptions should not contain \`eval(\`.",
   },
   Object {
     "code": "no-eval-in-markdown",
@@ -19,6 +20,7 @@ Array [
       "title",
     ],
     "severity": 1,
+    "summary": "Markdown descriptions should not contain \`eval(\`.",
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/no-script-tags-in-markdown.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/no-script-tags-in-markdown.ts.snap
@@ -9,16 +9,6 @@ Array [
       "info",
       "description",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/no-script-tags-in-markdown.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/no-script-tags-in-markdown.ts.snap
@@ -3,15 +3,23 @@
 exports[`no-script-tags-in-markdown return errors if descriptions include <script 1`] = `
 Array [
   Object {
+    "code": "no-script-tags-in-markdown",
     "message": "must not match the pattern '<script'",
-    "name": "no-script-tags-in-markdown",
     "path": Array [
       "info",
       "description",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Markdown descriptions should not contain \`<script>\` tags.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/no-script-tags-in-markdown.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/no-script-tags-in-markdown.ts.snap
@@ -10,6 +10,7 @@ Array [
       "description",
     ],
     "severity": 1,
+    "summary": "Markdown descriptions should not contain \`<script>\` tags.",
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/only-local-references.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/only-local-references.ts.snap
@@ -11,6 +11,7 @@ Array [
       "$ref",
     ],
     "severity": 1,
+    "summary": "References should start with \`#/\`.",
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/only-local-references.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/only-local-references.ts.snap
@@ -10,16 +10,6 @@ Array [
       0,
       "$ref",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/only-local-references.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/only-local-references.ts.snap
@@ -3,16 +3,24 @@
 exports[`only-local-references return errors if not local ref 1`] = `
 Array [
   Object {
+    "code": "only-local-references",
     "message": "must match the pattern '^#\\\\/'",
-    "name": "only-local-references",
     "path": Array [
       "parameters",
       0,
       "$ref",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "References should start with \`#/\`.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/openapi-tags-alphabetical.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/openapi-tags-alphabetical.ts.snap
@@ -8,16 +8,6 @@ Array [
     "path": Array [
       "tags",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/openapi-tags-alphabetical.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/openapi-tags-alphabetical.ts.snap
@@ -9,6 +9,7 @@ Array [
       "tags",
     ],
     "severity": 1,
+    "summary": "OpenAPI object should have alphabetical \`tags\`.",
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/openapi-tags-alphabetical.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/openapi-tags-alphabetical.ts.snap
@@ -3,14 +3,22 @@
 exports[`openapi-tags-alphabetical return errors if tags is not in alphabetical order 1`] = `
 Array [
   Object {
+    "code": "openapi-tags-alphabetical",
     "message": "properties are not in alphabetical order",
-    "name": "openapi-tags-alphabetical",
     "path": Array [
       "tags",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "OpenAPI object should have alphabetical \`tags\`.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/openapi-tags.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/openapi-tags.ts.snap
@@ -8,16 +8,6 @@ Array [
     "path": Array [
       "tags",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/openapi-tags.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/openapi-tags.ts.snap
@@ -3,14 +3,22 @@
 exports[`openapi-tags return errors if missing tags 1`] = `
 Array [
   Object {
+    "code": "openapi-tags",
     "message": "tags is not truthy",
-    "name": "openapi-tags",
     "path": Array [
       "tags",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "OpenAPI object should have non-empty \`tags\` array.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/openapi-tags.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/openapi-tags.ts.snap
@@ -9,6 +9,7 @@ Array [
       "tags",
     ],
     "severity": 1,
+    "summary": "OpenAPI object should have non-empty \`tags\` array.",
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-default-response.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-default-response.ts.snap
@@ -13,6 +13,7 @@ Array [
       "default",
     ],
     "severity": 1,
+    "summary": "Operations must have a default response.",
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-default-response.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-default-response.ts.snap
@@ -3,8 +3,8 @@
 exports[`operation-default-response return errors if path-responses is missing default 1`] = `
 Array [
   Object {
+    "code": "operation-default-response",
     "message": "paths./path./get.responses.default is not truthy",
-    "name": "operation-default-response",
     "path": Array [
       "paths",
       "/path",
@@ -12,9 +12,17 @@ Array [
       "responses",
       "default",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Operations must have a default response.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-default-response.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-default-response.ts.snap
@@ -12,16 +12,6 @@ Array [
       "responses",
       "default",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-description.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-description.ts.snap
@@ -14,6 +14,7 @@ Array [
       "description",
     ],
     "severity": 1,
+    "summary": "Operation \`description\` must be present and non-empty string.",
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-description.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-description.ts.snap
@@ -5,17 +5,25 @@ exports[`operation-description does not get called on parameters 1`] = `Array []
 exports[`operation-description return errors if operation description is missing 1`] = `
 Array [
   Object {
+    "code": "operation-description",
     "message": "paths./todos.get.description is not truthy",
-    "name": "operation-description",
     "path": Array [
       "paths",
       "/todos",
       "get",
       "description",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Operation \`description\` must be present and non-empty string.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-description.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-description.ts.snap
@@ -13,16 +13,6 @@ Array [
       "get",
       "description",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-operationId-valid-in-url.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-operationId-valid-in-url.ts.snap
@@ -11,16 +11,6 @@ Array [
       "get",
       "operationId",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-operationId-valid-in-url.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-operationId-valid-in-url.ts.snap
@@ -3,17 +3,25 @@
 exports[`operation-operationId-valid-in-url return errors if operationId contains invalid characters 1`] = `
 Array [
   Object {
+    "code": "operation-operationId-valid-in-url",
     "message": "must match the pattern '^[A-Za-z0-9-._~:/?#\\\\[\\\\]@!\\\\$&'()*+,;=]*$'",
-    "name": "operation-operationId-valid-in-url",
     "path": Array [
       "paths",
       "/todos",
       "get",
       "operationId",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "operationId may only use characters that are valid when used in a URL.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-operationId-valid-in-url.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-operationId-valid-in-url.ts.snap
@@ -12,6 +12,7 @@ Array [
       "operationId",
     ],
     "severity": 1,
+    "summary": "operationId may only use characters that are valid when used in a URL.",
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-operationId.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-operationId.ts.snap
@@ -14,6 +14,7 @@ Array [
       "operationId",
     ],
     "severity": 1,
+    "summary": "Operation should have an \`operationId\`.",
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-operationId.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-operationId.ts.snap
@@ -5,17 +5,25 @@ exports[`operation-operationId does not get called on parameters 1`] = `Array []
 exports[`operation-operationId return errors if operation id is missing 1`] = `
 Array [
   Object {
+    "code": "operation-operationId",
     "message": "paths./todos.get.operationId is not truthy",
-    "name": "operation-operationId",
     "path": Array [
       "paths",
       "/todos",
       "get",
       "operationId",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Operation should have an \`operationId\`.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-operationId.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-operationId.ts.snap
@@ -13,16 +13,6 @@ Array [
       "get",
       "operationId",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-singular-tag.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-singular-tag.ts.snap
@@ -3,17 +3,25 @@
 exports[`operation-singular-tag return errors if tags has more than 1 1`] = `
 Array [
   Object {
+    "code": "operation-singular-tag",
     "message": "max length is 1",
-    "name": "operation-singular-tag",
     "path": Array [
       "paths",
       "/todos",
       "get",
       "tags",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Operation may only have one tag.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-singular-tag.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-singular-tag.ts.snap
@@ -12,6 +12,7 @@ Array [
       "tags",
     ],
     "severity": 1,
+    "summary": "Operation may only have one tag.",
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-singular-tag.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-singular-tag.ts.snap
@@ -11,16 +11,6 @@ Array [
       "get",
       "tags",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-summary-formatted.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-summary-formatted.ts.snap
@@ -12,6 +12,7 @@ Array [
       "summary",
     ],
     "severity": 1,
+    "summary": "Operation \`summary\` should start with upper case and end with a dot.",
   },
 ]
 `;
@@ -28,6 +29,7 @@ Array [
       "summary",
     ],
     "severity": 1,
+    "summary": "Operation \`summary\` should start with upper case and end with a dot.",
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-summary-formatted.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-summary-formatted.ts.snap
@@ -3,17 +3,25 @@
 exports[`operation-summary-formatted return errors if summary does not end with a dot 1`] = `
 Array [
   Object {
+    "code": "operation-summary-formatted",
     "message": "must match the pattern '^[A-Z].*\\\\.$'",
-    "name": "operation-summary-formatted",
     "path": Array [
       "paths",
       "/todos",
       "get",
       "summary",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Operation \`summary\` should start with upper case and end with a dot.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;
@@ -21,17 +29,25 @@ Array [
 exports[`operation-summary-formatted return errors if summary does not start with an uppercase 1`] = `
 Array [
   Object {
+    "code": "operation-summary-formatted",
     "message": "must match the pattern '^[A-Z].*\\\\.$'",
-    "name": "operation-summary-formatted",
     "path": Array [
       "paths",
       "/todos",
       "get",
       "summary",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Operation \`summary\` should start with upper case and end with a dot.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-summary-formatted.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-summary-formatted.ts.snap
@@ -11,16 +11,6 @@ Array [
       "get",
       "summary",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]
@@ -37,16 +27,6 @@ Array [
       "get",
       "summary",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-tags.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-tags.ts.snap
@@ -12,6 +12,7 @@ Array [
       "tags",
     ],
     "severity": 1,
+    "summary": "Operation should have non-empty \`tags\` array.",
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-tags.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-tags.ts.snap
@@ -11,16 +11,6 @@ Array [
       "get",
       "tags",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/operation-tags.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/operation-tags.ts.snap
@@ -3,17 +3,25 @@
 exports[`operation-tags return errors if tags is missing 1`] = `
 Array [
   Object {
+    "code": "operation-tags",
     "message": "paths./todos.get.tags is not truthy",
-    "name": "operation-tags",
     "path": Array [
       "paths",
       "/todos",
       "get",
       "tags",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Operation should have non-empty \`tags\` array.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/path-declarations-must-exist.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/path-declarations-must-exist.ts.snap
@@ -3,15 +3,23 @@
 exports[`path-declarations-must-exist return errors if parameter is empty 1`] = `
 Array [
   Object {
+    "code": "path-declarations-must-exist",
     "message": "must not match the pattern '{}'",
-    "name": "path-declarations-must-exist",
     "path": Array [
       "paths",
       "/path/{}",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "given declarations cannot be empty, ex.\`/given/{}\` is invalid.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/path-declarations-must-exist.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/path-declarations-must-exist.ts.snap
@@ -9,16 +9,6 @@ Array [
       "paths",
       "/path/{}",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/path-declarations-must-exist.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/path-declarations-must-exist.ts.snap
@@ -10,6 +10,7 @@ Array [
       "/path/{}",
     ],
     "severity": 1,
+    "summary": "given declarations cannot be empty, ex.\`/given/{}\` is invalid.",
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/path-keys-no-trailing-slash.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/path-keys-no-trailing-slash.ts.snap
@@ -9,16 +9,6 @@ Array [
       "paths",
       "/path/",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/path-keys-no-trailing-slash.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/path-keys-no-trailing-slash.ts.snap
@@ -10,6 +10,7 @@ Array [
       "/path/",
     ],
     "severity": 1,
+    "summary": "given keys should not end with a slash.",
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/path-keys-no-trailing-slash.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/path-keys-no-trailing-slash.ts.snap
@@ -3,15 +3,23 @@
 exports[`path-keys-no-trailing-slash return errors if path ends with a slash 1`] = `
 Array [
   Object {
+    "code": "path-keys-no-trailing-slash",
     "message": "must not match the pattern '.+\\\\/$'",
-    "name": "path-keys-no-trailing-slash",
     "path": Array [
       "paths",
       "/path/",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "given keys should not end with a slash.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/path-not-include-query.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/path-not-include-query.ts.snap
@@ -3,15 +3,23 @@
 exports[`path-not-include-query return errors if indlues a query 1`] = `
 Array [
   Object {
+    "code": "path-not-include-query",
     "message": "must not match the pattern '\\\\?'",
-    "name": "path-not-include-query",
     "path": Array [
       "paths",
       "/path?query=true",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "given keys should not include a query string.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/path-not-include-query.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/path-not-include-query.ts.snap
@@ -9,16 +9,6 @@ Array [
       "paths",
       "/path?query=true",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/path-not-include-query.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/path-not-include-query.ts.snap
@@ -10,6 +10,7 @@ Array [
       "/path?query=true",
     ],
     "severity": 1,
+    "summary": "given keys should not include a query string.",
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/schema-items-is-object.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/schema-items-is-object.ts.snap
@@ -10,6 +10,7 @@ Array [
       "items",
     ],
     "severity": 1,
+    "summary": "Schema containing \`items\` requires the items property to be an object.",
   },
 ]
 `;
@@ -24,6 +25,7 @@ Array [
       "items",
     ],
     "severity": 1,
+    "summary": "Schema containing \`items\` requires the items property to be an object.",
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/schema-items-is-object.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/schema-items-is-object.ts.snap
@@ -9,16 +9,6 @@ Array [
       "schema",
       "items",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]
@@ -33,16 +23,6 @@ Array [
       "schema",
       "items",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/schema-items-is-object.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/schema-items-is-object.ts.snap
@@ -3,15 +3,23 @@
 exports[`schema-items-is-object return errors if items is not an object 1`] = `
 Array [
   Object {
+    "code": "schema-items-is-object",
     "message": "should be object",
-    "name": "schema-items-is-object",
     "path": Array [
       "schema",
       "items",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Schema containing \`items\` requires the items property to be an object.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;
@@ -19,15 +27,23 @@ Array [
 exports[`schema-items-is-object return errors if items is undefined 1`] = `
 Array [
   Object {
+    "code": "schema-items-is-object",
     "message": "schema.items does not exist",
-    "name": "schema-items-is-object",
     "path": Array [
       "schema",
       "items",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Schema containing \`items\` requires the items property to be an object.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/tag-description.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/tag-description.ts.snap
@@ -11,6 +11,7 @@ Array [
       "description",
     ],
     "severity": 1,
+    "summary": "Tag object should have a \`description\`.",
   },
 ]
 `;

--- a/src/rulesets/oas/__tests__/__snapshots__/tag-description.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/tag-description.ts.snap
@@ -10,16 +10,6 @@ Array [
       0,
       "description",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/__tests__/__snapshots__/tag-description.ts.snap
+++ b/src/rulesets/oas/__tests__/__snapshots__/tag-description.ts.snap
@@ -3,16 +3,24 @@
 exports[`tag-description return errors if tag has no description 1`] = `
 Array [
   Object {
+    "code": "tag-description",
     "message": "tags.0.description is not truthy",
-    "name": "tag-description",
     "path": Array [
       "tags",
       0,
       "description",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Tag object should have a \`description\`.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/functions/oasOp2xxResponse/__tests__/__snapshots__/index.ts.snap
+++ b/src/rulesets/oas/functions/oasOp2xxResponse/__tests__/__snapshots__/index.ts.snap
@@ -11,16 +11,6 @@ Array [
       "get",
       "responses",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]
@@ -37,16 +27,6 @@ Array [
       "get",
       "responses",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/functions/oasOp2xxResponse/__tests__/__snapshots__/index.ts.snap
+++ b/src/rulesets/oas/functions/oasOp2xxResponse/__tests__/__snapshots__/index.ts.snap
@@ -12,6 +12,7 @@ Array [
       "responses",
     ],
     "severity": 1,
+    "summary": "Operation must have at least one \`2xx\` response.",
   },
 ]
 `;
@@ -28,6 +29,7 @@ Array [
       "responses",
     ],
     "severity": 1,
+    "summary": "Operation must have at least one \`2xx\` response.",
   },
 ]
 `;

--- a/src/rulesets/oas/functions/oasOp2xxResponse/__tests__/__snapshots__/index.ts.snap
+++ b/src/rulesets/oas/functions/oasOp2xxResponse/__tests__/__snapshots__/index.ts.snap
@@ -3,17 +3,25 @@
 exports[`oasOp2xxResponse return errors if missing 2xx 1`] = `
 Array [
   Object {
+    "code": "operation-2xx-response",
     "message": "operations must define at least one 2xx response",
-    "name": "operation-2xx-response",
     "path": Array [
       "paths",
       "/path1",
       "get",
       "responses",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Operation must have at least one \`2xx\` response.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;
@@ -21,17 +29,25 @@ Array [
 exports[`oasOp2xxResponse return errors if no responses 1`] = `
 Array [
   Object {
+    "code": "operation-2xx-response",
     "message": "operations must define at least one 2xx response",
-    "name": "operation-2xx-response",
     "path": Array [
       "paths",
       "/path1",
       "get",
       "responses",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Operation must have at least one \`2xx\` response.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/functions/oasOpFormDataConsumeCheck/__tests__/__snapshots__/index.ts.snap
+++ b/src/rulesets/oas/functions/oasOpFormDataConsumeCheck/__tests__/__snapshots__/index.ts.snap
@@ -3,16 +3,24 @@
 exports[`oasOpFormDataConsumeCheck return errors on different path operations same id 1`] = `
 Array [
   Object {
+    "code": "operation-formData-consume-check",
     "message": "consumes must include urlencoded, multipart, or formdata media type when using formData parameter",
-    "name": "operation-formData-consume-check",
     "path": Array [
       "paths",
       "/path1",
       "get",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Operations with an \`in: formData\` parameter must include \`application/x-www-form-urlencoded\` or \`multipart/form-data\` in their \`consumes\` property.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/functions/oasOpFormDataConsumeCheck/__tests__/__snapshots__/index.ts.snap
+++ b/src/rulesets/oas/functions/oasOpFormDataConsumeCheck/__tests__/__snapshots__/index.ts.snap
@@ -11,6 +11,7 @@ Array [
       "get",
     ],
     "severity": 1,
+    "summary": "Operations with an \`in: formData\` parameter must include \`application/x-www-form-urlencoded\` or \`multipart/form-data\` in their \`consumes\` property.",
   },
 ]
 `;

--- a/src/rulesets/oas/functions/oasOpFormDataConsumeCheck/__tests__/__snapshots__/index.ts.snap
+++ b/src/rulesets/oas/functions/oasOpFormDataConsumeCheck/__tests__/__snapshots__/index.ts.snap
@@ -10,16 +10,6 @@ Array [
       "/path1",
       "get",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/functions/oasOpIdUnique/__tests__/__snapshots__/index.ts.snap
+++ b/src/rulesets/oas/functions/oasOpIdUnique/__tests__/__snapshots__/index.ts.snap
@@ -3,30 +3,46 @@
 exports[`oasOpIdUnique return errors on different path operations same id 1`] = `
 Array [
   Object {
+    "code": "operation-operationId-unique",
     "message": "operationId must be unique",
-    "name": "operation-operationId-unique",
     "path": Array [
       "paths",
       "/path1",
       "get",
       "operationId",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Every operation must have a unique \`operationId\`.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
   Object {
+    "code": "operation-operationId-unique",
     "message": "operationId must be unique",
-    "name": "operation-operationId-unique",
     "path": Array [
       "paths",
       "/path2",
       "get",
       "operationId",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Every operation must have a unique \`operationId\`.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;
@@ -34,30 +50,46 @@ Array [
 exports[`oasOpIdUnique return errors on same path operations same id 1`] = `
 Array [
   Object {
+    "code": "operation-operationId-unique",
     "message": "operationId must be unique",
-    "name": "operation-operationId-unique",
     "path": Array [
       "paths",
       "/path1",
       "get",
       "operationId",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Every operation must have a unique \`operationId\`.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
   Object {
+    "code": "operation-operationId-unique",
     "message": "operationId must be unique",
-    "name": "operation-operationId-unique",
     "path": Array [
       "paths",
       "/path1",
       "post",
       "operationId",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Every operation must have a unique \`operationId\`.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/functions/oasOpIdUnique/__tests__/__snapshots__/index.ts.snap
+++ b/src/rulesets/oas/functions/oasOpIdUnique/__tests__/__snapshots__/index.ts.snap
@@ -11,16 +11,6 @@ Array [
       "get",
       "operationId",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
   Object {
@@ -32,16 +22,6 @@ Array [
       "get",
       "operationId",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]
@@ -58,16 +38,6 @@ Array [
       "get",
       "operationId",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
   Object {
@@ -79,16 +49,6 @@ Array [
       "post",
       "operationId",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/functions/oasOpIdUnique/__tests__/__snapshots__/index.ts.snap
+++ b/src/rulesets/oas/functions/oasOpIdUnique/__tests__/__snapshots__/index.ts.snap
@@ -12,6 +12,7 @@ Array [
       "operationId",
     ],
     "severity": 1,
+    "summary": "Every operation must have a unique \`operationId\`.",
   },
   Object {
     "code": "operation-operationId-unique",
@@ -23,6 +24,7 @@ Array [
       "operationId",
     ],
     "severity": 1,
+    "summary": "Every operation must have a unique \`operationId\`.",
   },
 ]
 `;
@@ -39,6 +41,7 @@ Array [
       "operationId",
     ],
     "severity": 1,
+    "summary": "Every operation must have a unique \`operationId\`.",
   },
   Object {
     "code": "operation-operationId-unique",
@@ -50,6 +53,7 @@ Array [
       "operationId",
     ],
     "severity": 1,
+    "summary": "Every operation must have a unique \`operationId\`.",
   },
 ]
 `;

--- a/src/rulesets/oas/functions/oasOpParams/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/rulesets/oas/functions/oasOpParams/__tests__/__snapshots__/index.test.ts.snap
@@ -3,21 +3,29 @@
 exports[`oasOpParams Error if both in:formData and in:body 1`] = `
 Array [
   Object {
+    "code": "operation-parameters",
     "message": "Operation cannot have both \`in:body\` and \`in:formData\` parameters.
 
 Parameters found at:
 [ \`paths\`, \`/foo\`, \`get\`, \`0\` ]
 [ \`paths\`, \`/foo\`, \`get\`, \`1\` ]
 ",
-    "name": "operation-parameters",
     "path": Array [
       "paths",
       "/foo",
       "get",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Operation parameters are unique and non-repeating.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;
@@ -25,19 +33,27 @@ Parameters found at:
 exports[`oasOpParams Error if multiple in:body 1`] = `
 Array [
   Object {
+    "code": "operation-parameters",
     "message": "Operation has multiple instances of the \`in:body\` parameter.
 
 Parameters found at:
 ",
-    "name": "operation-parameters",
     "path": Array [
       "paths",
       "/foo",
       "get",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Operation parameters are unique and non-repeating.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;
@@ -69,6 +85,7 @@ Parameters found at:
 exports[`oasOpParams Error if non-unique param on same operation 1`] = `
 Array [
   Object {
+    "code": "operation-parameters",
     "message": "Operations must have unique \`name\` + \`in\` parameters.
 Repeats of \`in:query\` + \`name:foo\`
 
@@ -77,15 +94,22 @@ Parameters found at:
 [ \`paths\`, \`/foo\`, \`get\`, \`1\` ]
 [ \`paths\`, \`/foo\`, \`get\`, \`2\` ]
 ",
-    "name": "operation-parameters",
     "path": Array [
       "paths",
       "/foo",
       "get",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Operation parameters are unique and non-repeating.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/functions/oasOpParams/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/rulesets/oas/functions/oasOpParams/__tests__/__snapshots__/index.test.ts.snap
@@ -15,16 +15,6 @@ Parameters found at:
       "/foo",
       "get",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]
@@ -43,16 +33,6 @@ Parameters found at:
       "/foo",
       "get",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]
@@ -99,16 +79,6 @@ Parameters found at:
       "/foo",
       "get",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/functions/oasOpParams/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/rulesets/oas/functions/oasOpParams/__tests__/__snapshots__/index.test.ts.snap
@@ -16,6 +16,7 @@ Parameters found at:
       "get",
     ],
     "severity": 1,
+    "summary": "Operation parameters are unique and non-repeating.",
   },
 ]
 `;
@@ -34,6 +35,7 @@ Parameters found at:
       "get",
     ],
     "severity": 1,
+    "summary": "Operation parameters are unique and non-repeating.",
   },
 ]
 `;
@@ -80,6 +82,7 @@ Parameters found at:
       "get",
     ],
     "severity": 1,
+    "summary": "Operation parameters are unique and non-repeating.",
   },
 ]
 `;

--- a/src/rulesets/oas/functions/oasOpParams/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/rulesets/oas/functions/oasOpParams/__tests__/__snapshots__/index.test.ts.snap
@@ -43,6 +43,7 @@ Parameters found at:
 exports[`oasOpParams Error if non-unique $ref param on same operation 1`] = `
 Array [
   Object {
+    "code": "operation-parameters",
     "message": "Operations must have unique \`name\` + \`in\` parameters.
 Repeats of \`in:query\` + \`name:foo\`
 
@@ -51,14 +52,12 @@ Parameters found at:
 [ \`paths\`, \`/foo\`, \`get\`, \`1\` ]
 [ \`paths\`, \`/foo\`, \`get\`, \`2\` ]
 ",
-    "name": "operation-parameters",
     "path": Array [
       "paths",
       "/foo",
       "get",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
+    "severity": 1,
     "summary": "Operation parameters are unique and non-repeating.",
   },
 ]

--- a/src/rulesets/oas/functions/oasOpSecurityDefined/__tests__/__snapshots__/index.ts.snap
+++ b/src/rulesets/oas/functions/oasOpSecurityDefined/__tests__/__snapshots__/index.ts.snap
@@ -3,8 +3,8 @@
 exports[`oasOpSecurityDefined oas2 return errors on invalid object 1`] = `
 Array [
   Object {
+    "code": "operation-security-defined",
     "message": "operation referencing undefined security scheme",
-    "name": "operation-security-defined",
     "path": Array [
       "paths",
       "/path",
@@ -12,9 +12,17 @@ Array [
       "security",
       "0",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Operation \`security\` values must match a scheme defined in the \`securityDefinitions\` object.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;
@@ -22,8 +30,8 @@ Array [
 exports[`oasOpSecurityDefined oas3 return errors on invalid object 1`] = `
 Array [
   Object {
+    "code": "operation-security-defined",
     "message": "operation referencing undefined security scheme",
-    "name": "operation-security-defined",
     "path": Array [
       "paths",
       "/path",
@@ -31,9 +39,17 @@ Array [
       "security",
       "0",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Operation \`security\` values must match a scheme defined in the \`components.securitySchemes\` object.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas/functions/oasOpSecurityDefined/__tests__/__snapshots__/index.ts.snap
+++ b/src/rulesets/oas/functions/oasOpSecurityDefined/__tests__/__snapshots__/index.ts.snap
@@ -12,16 +12,6 @@ Array [
       "security",
       "0",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]
@@ -39,16 +29,6 @@ Array [
       "security",
       "0",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas/functions/oasOpSecurityDefined/__tests__/__snapshots__/index.ts.snap
+++ b/src/rulesets/oas/functions/oasOpSecurityDefined/__tests__/__snapshots__/index.ts.snap
@@ -13,6 +13,7 @@ Array [
       "0",
     ],
     "severity": 1,
+    "summary": "Operation \`security\` values must match a scheme defined in the \`securityDefinitions\` object.",
   },
 ]
 `;
@@ -30,6 +31,7 @@ Array [
       "0",
     ],
     "severity": 1,
+    "summary": "Operation \`security\` values must match a scheme defined in the \`components.securitySchemes\` object.",
   },
 ]
 `;

--- a/src/rulesets/oas/functions/oasOpSecurityDefined/index.ts
+++ b/src/rulesets/oas/functions/oasOpSecurityDefined/index.ts
@@ -1,4 +1,4 @@
-import { JSONPath } from '@stoplight/types';
+import { JsonPath } from '@stoplight/types';
 
 const _get = require('lodash/get');
 
@@ -7,7 +7,7 @@ import { IFunction, IFunctionResult } from '../../../../types';
 export type functionName = 'oasOpSecurityDefined';
 
 export const oasOpSecurityDefined: IFunction<{
-  schemesPath: JSONPath;
+  schemesPath: JsonPath;
 }> = (targetVal, options) => {
   const results: IFunctionResult[] = [];
 

--- a/src/rulesets/oas/functions/oasOpSecurityDefined/index.ts
+++ b/src/rulesets/oas/functions/oasOpSecurityDefined/index.ts
@@ -1,4 +1,4 @@
-import { ObjPath } from '@stoplight/types';
+import { JSONPath } from '@stoplight/types';
 
 const _get = require('lodash/get');
 
@@ -7,7 +7,7 @@ import { IFunction, IFunctionResult } from '../../../../types';
 export type functionName = 'oasOpSecurityDefined';
 
 export const oasOpSecurityDefined: IFunction<{
-  schemesPath: ObjPath;
+  schemesPath: JSONPath;
 }> = (targetVal, options) => {
   const results: IFunctionResult[] = [];
 

--- a/src/rulesets/oas/functions/oasPathParam/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/rulesets/oas/functions/oasPathParam/__tests__/__snapshots__/index.test.ts.snap
@@ -3,18 +3,35 @@
 exports[`oasPathParam Error if $ref path parameter definition is not required 1`] = `
 Array [
   Object {
+<<<<<<< HEAD:src/rulesets/oas/functions/oasPathParam/__tests__/__snapshots__/index.test.ts.snap
     "message": "Path parameter \\"**bar**\\" must have a \`required\` that is set to \`true\`.
 
 To fix, mark this parameter as required.",
     "name": "path-params",
+=======
+    "code": "path-params",
+    "message": "The path \\"**/foo/{bar}/{bar}**\\" uses the parameter \\"**{bar}**\\" multiple times.
+
+Path parameters must be unique.
+
+To fix, update the path so that all parameter names are unique.",
+>>>>>>> feat: make Spectral compatible with new diagnostic interfaces:src/rulesets/oas/functions/oasPathParam/__tests__/__snapshots__/index.ts.snap
     "path": Array [
       "paths",
       "/foo/{bar}",
       "parameters",
     ],
-    "severity": 50,
-    "severityLabel": "error",
-    "summary": "Path parameters are correct and valid.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 0,
   },
 ]
 `;
@@ -22,19 +39,34 @@ To fix, mark this parameter as required.",
 exports[`oasPathParam Error if duplicate path parameters with same name are used 1`] = `
 Array [
   Object {
+<<<<<<< HEAD:src/rulesets/oas/functions/oasPathParam/__tests__/__snapshots__/index.test.ts.snap
     "message": "The path \\"**/foo/{bar}/{bar}**\\" uses the parameter \\"**{bar}**\\" multiple times.
 
 Path parameters must be unique.
 
 To fix, update the path so that all parameter names are unique.",
     "name": "path-params",
+=======
+    "code": "path-params",
+    "message": "The path \\"**/foo/{bar}**\\" uses a parameter \\"**{bar}**\\" that does not have a corresponding definition.
+
+To fix, add a path parameter with the name \\"**bar**\\".",
+>>>>>>> feat: make Spectral compatible with new diagnostic interfaces:src/rulesets/oas/functions/oasPathParam/__tests__/__snapshots__/index.ts.snap
     "path": Array [
       "paths",
       "/foo/{bar}/{bar}",
     ],
-    "severity": 50,
-    "severityLabel": "error",
-    "summary": "Path parameters are correct and valid.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 0,
   },
 ]
 `;
@@ -42,17 +74,32 @@ To fix, update the path so that all parameter names are unique.",
 exports[`oasPathParam Error if no path parameter definition 1`] = `
 Array [
   Object {
+<<<<<<< HEAD:src/rulesets/oas/functions/oasPathParam/__tests__/__snapshots__/index.test.ts.snap
     "message": "The path \\"**/foo/{bar}**\\" uses a parameter \\"**{bar}**\\" that does not have a corresponding definition.
 
 To fix, add a path parameter with the name \\"**bar**\\".",
     "name": "path-params",
+=======
+    "code": "path-params",
+    "message": "Path parameter \\"**bar**\\" must have a \`required\` that is set to \`true\`.
+
+To fix, mark this parameter as required.",
+>>>>>>> feat: make Spectral compatible with new diagnostic interfaces:src/rulesets/oas/functions/oasPathParam/__tests__/__snapshots__/index.ts.snap
     "path": Array [
       "paths",
       "/foo/{bar}",
     ],
-    "severity": 50,
-    "severityLabel": "error",
-    "summary": "Path parameters are correct and valid.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 0,
   },
 ]
 `;
@@ -60,16 +107,24 @@ To fix, add a path parameter with the name \\"**bar**\\".",
 exports[`oasPathParam Error if paths are functionally equivalent 1`] = `
 Array [
   Object {
+    "code": "path-params",
     "message": "The paths \\"**/foo/{boo}**\\" and \\"**/foo/{bar}**\\" are equivalent.
 
 To fix, remove one of the paths or merge them together.",
-    "name": "path-params",
     "path": Array [
       "paths",
     ],
-    "severity": 50,
-    "severityLabel": "error",
-    "summary": "Path parameters are correct and valid.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 0,
   },
 ]
 `;

--- a/src/rulesets/oas/functions/oasPathParam/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/rulesets/oas/functions/oasPathParam/__tests__/__snapshots__/index.test.ts.snap
@@ -21,16 +21,6 @@ To fix, update the path so that all parameter names are unique.",
       "/foo/{bar}",
       "parameters",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 0,
   },
 ]
@@ -56,16 +46,6 @@ To fix, add a path parameter with the name \\"**bar**\\".",
       "paths",
       "/foo/{bar}/{bar}",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 0,
   },
 ]
@@ -89,16 +69,6 @@ To fix, mark this parameter as required.",
       "paths",
       "/foo/{bar}",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 0,
   },
 ]
@@ -114,16 +84,6 @@ To fix, remove one of the paths or merge them together.",
     "path": Array [
       "paths",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 0,
   },
 ]

--- a/src/rulesets/oas/functions/oasPathParam/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/rulesets/oas/functions/oasPathParam/__tests__/__snapshots__/index.test.ts.snap
@@ -3,19 +3,10 @@
 exports[`oasPathParam Error if $ref path parameter definition is not required 1`] = `
 Array [
   Object {
-<<<<<<< HEAD:src/rulesets/oas/functions/oasPathParam/__tests__/__snapshots__/index.test.ts.snap
+    "code": "path-params",
     "message": "Path parameter \\"**bar**\\" must have a \`required\` that is set to \`true\`.
 
 To fix, mark this parameter as required.",
-    "name": "path-params",
-=======
-    "code": "path-params",
-    "message": "The path \\"**/foo/{bar}/{bar}**\\" uses the parameter \\"**{bar}**\\" multiple times.
-
-Path parameters must be unique.
-
-To fix, update the path so that all parameter names are unique.",
->>>>>>> feat: make Spectral compatible with new diagnostic interfaces:src/rulesets/oas/functions/oasPathParam/__tests__/__snapshots__/index.ts.snap
     "path": Array [
       "paths",
       "/foo/{bar}",
@@ -30,19 +21,12 @@ To fix, update the path so that all parameter names are unique.",
 exports[`oasPathParam Error if duplicate path parameters with same name are used 1`] = `
 Array [
   Object {
-<<<<<<< HEAD:src/rulesets/oas/functions/oasPathParam/__tests__/__snapshots__/index.test.ts.snap
+    "code": "path-params",
     "message": "The path \\"**/foo/{bar}/{bar}**\\" uses the parameter \\"**{bar}**\\" multiple times.
 
 Path parameters must be unique.
 
 To fix, update the path so that all parameter names are unique.",
-    "name": "path-params",
-=======
-    "code": "path-params",
-    "message": "The path \\"**/foo/{bar}**\\" uses a parameter \\"**{bar}**\\" that does not have a corresponding definition.
-
-To fix, add a path parameter with the name \\"**bar**\\".",
->>>>>>> feat: make Spectral compatible with new diagnostic interfaces:src/rulesets/oas/functions/oasPathParam/__tests__/__snapshots__/index.ts.snap
     "path": Array [
       "paths",
       "/foo/{bar}/{bar}",
@@ -56,17 +40,10 @@ To fix, add a path parameter with the name \\"**bar**\\".",
 exports[`oasPathParam Error if no path parameter definition 1`] = `
 Array [
   Object {
-<<<<<<< HEAD:src/rulesets/oas/functions/oasPathParam/__tests__/__snapshots__/index.test.ts.snap
+    "code": "path-params",
     "message": "The path \\"**/foo/{bar}**\\" uses a parameter \\"**{bar}**\\" that does not have a corresponding definition.
 
 To fix, add a path parameter with the name \\"**bar**\\".",
-    "name": "path-params",
-=======
-    "code": "path-params",
-    "message": "Path parameter \\"**bar**\\" must have a \`required\` that is set to \`true\`.
-
-To fix, mark this parameter as required.",
->>>>>>> feat: make Spectral compatible with new diagnostic interfaces:src/rulesets/oas/functions/oasPathParam/__tests__/__snapshots__/index.ts.snap
     "path": Array [
       "paths",
       "/foo/{bar}",

--- a/src/rulesets/oas/functions/oasPathParam/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/rulesets/oas/functions/oasPathParam/__tests__/__snapshots__/index.test.ts.snap
@@ -22,6 +22,7 @@ To fix, update the path so that all parameter names are unique.",
       "parameters",
     ],
     "severity": 0,
+    "summary": "Path parameters are correct and valid.",
   },
 ]
 `;
@@ -47,6 +48,7 @@ To fix, add a path parameter with the name \\"**bar**\\".",
       "/foo/{bar}/{bar}",
     ],
     "severity": 0,
+    "summary": "Path parameters are correct and valid.",
   },
 ]
 `;
@@ -70,6 +72,7 @@ To fix, mark this parameter as required.",
       "/foo/{bar}",
     ],
     "severity": 0,
+    "summary": "Path parameters are correct and valid.",
   },
 ]
 `;
@@ -85,6 +88,7 @@ To fix, remove one of the paths or merge them together.",
       "paths",
     ],
     "severity": 0,
+    "summary": "Path parameters are correct and valid.",
   },
 ]
 `;

--- a/src/rulesets/oas/index.ts
+++ b/src/rulesets/oas/index.ts
@@ -1,4 +1,4 @@
-import { ValidationSeverity } from '@stoplight/types/validations';
+import { DiagnosticSeverity } from '@stoplight/types';
 import { FunctionCollection, RuleCollection, RuleFunction, RuleType } from '../../types';
 
 export const operationPath = "$..paths.*[?( name() !== 'parameters' )]";
@@ -59,7 +59,7 @@ export const commonOasRules = (): RuleCollection => ({
   'path-params': {
     summary: 'Path parameters are correct and valid.',
     type: RuleType.VALIDATION,
-    severity: ValidationSeverity.Error,
+    severity: DiagnosticSeverity.Error,
     given: '$',
     then: {
       function: 'oasPathParam',

--- a/src/rulesets/oas2/__tests__/__snapshots__/api-host.ts.snap
+++ b/src/rulesets/oas2/__tests__/__snapshots__/api-host.ts.snap
@@ -9,6 +9,7 @@ Array [
       "host",
     ],
     "severity": 1,
+    "summary": "OpenAPI \`host\` must be present and non-empty string.",
   },
 ]
 `;

--- a/src/rulesets/oas2/__tests__/__snapshots__/api-host.ts.snap
+++ b/src/rulesets/oas2/__tests__/__snapshots__/api-host.ts.snap
@@ -3,14 +3,22 @@
 exports[`api-host return errors if missing host 1`] = `
 Array [
   Object {
+    "code": "api-host",
     "message": "host is not truthy",
-    "name": "api-host",
     "path": Array [
       "host",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "OpenAPI \`host\` must be present and non-empty string.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas2/__tests__/__snapshots__/api-host.ts.snap
+++ b/src/rulesets/oas2/__tests__/__snapshots__/api-host.ts.snap
@@ -8,16 +8,6 @@ Array [
     "path": Array [
       "host",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas2/__tests__/__snapshots__/api-schemes.ts.snap
+++ b/src/rulesets/oas2/__tests__/__snapshots__/api-schemes.ts.snap
@@ -8,16 +8,6 @@ Array [
     "path": Array [
       "schemes",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]
@@ -31,16 +21,6 @@ Array [
     "path": Array [
       "schemes",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas2/__tests__/__snapshots__/api-schemes.ts.snap
+++ b/src/rulesets/oas2/__tests__/__snapshots__/api-schemes.ts.snap
@@ -3,14 +3,22 @@
 exports[`api-schemes return errors if schemes is an empty array  1`] = `
 Array [
   Object {
+    "code": "api-schemes",
     "message": "should NOT have fewer than 1 items",
-    "name": "api-schemes",
     "path": Array [
       "schemes",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "OpenAPI host \`schemes\` must be present and non-empty array.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;
@@ -18,14 +26,22 @@ Array [
 exports[`api-schemes return errors if schemes is missing  1`] = `
 Array [
   Object {
+    "code": "api-schemes",
     "message": "schemes does not exist",
-    "name": "api-schemes",
     "path": Array [
       "schemes",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "OpenAPI host \`schemes\` must be present and non-empty array.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas2/__tests__/__snapshots__/api-schemes.ts.snap
+++ b/src/rulesets/oas2/__tests__/__snapshots__/api-schemes.ts.snap
@@ -9,6 +9,7 @@ Array [
       "schemes",
     ],
     "severity": 1,
+    "summary": "OpenAPI host \`schemes\` must be present and non-empty array.",
   },
 ]
 `;
@@ -22,6 +23,7 @@ Array [
       "schemes",
     ],
     "severity": 1,
+    "summary": "OpenAPI host \`schemes\` must be present and non-empty array.",
   },
 ]
 `;

--- a/src/rulesets/oas2/__tests__/__snapshots__/host-not-example.ts.snap
+++ b/src/rulesets/oas2/__tests__/__snapshots__/host-not-example.ts.snap
@@ -9,6 +9,7 @@ Array [
       "host",
     ],
     "severity": 1,
+    "summary": "Server URL should not point at \`example.com\`.",
   },
 ]
 `;

--- a/src/rulesets/oas2/__tests__/__snapshots__/host-not-example.ts.snap
+++ b/src/rulesets/oas2/__tests__/__snapshots__/host-not-example.ts.snap
@@ -3,14 +3,22 @@
 exports[`host-not-example return errors if server is example.com 1`] = `
 Array [
   Object {
+    "code": "host-not-example",
     "message": "must not match the pattern 'example.com'",
-    "name": "host-not-example",
     "path": Array [
       "host",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Server URL should not point at \`example.com\`.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas2/__tests__/__snapshots__/host-not-example.ts.snap
+++ b/src/rulesets/oas2/__tests__/__snapshots__/host-not-example.ts.snap
@@ -8,16 +8,6 @@ Array [
     "path": Array [
       "host",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas2/__tests__/__snapshots__/host-trailing-slash.ts.snap
+++ b/src/rulesets/oas2/__tests__/__snapshots__/host-trailing-slash.ts.snap
@@ -9,6 +9,7 @@ Array [
       "host",
     ],
     "severity": 1,
+    "summary": "Server URL should not have a trailing slash.",
   },
 ]
 `;

--- a/src/rulesets/oas2/__tests__/__snapshots__/host-trailing-slash.ts.snap
+++ b/src/rulesets/oas2/__tests__/__snapshots__/host-trailing-slash.ts.snap
@@ -3,14 +3,22 @@
 exports[`host-trailing-slash return errors if host url ends with a slash 1`] = `
 Array [
   Object {
+    "code": "host-trailing-slash",
     "message": "must not match the pattern '/$'",
-    "name": "host-trailing-slash",
     "path": Array [
       "host",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Server URL should not have a trailing slash.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas2/__tests__/__snapshots__/host-trailing-slash.ts.snap
+++ b/src/rulesets/oas2/__tests__/__snapshots__/host-trailing-slash.ts.snap
@@ -8,16 +8,6 @@ Array [
     "path": Array [
       "host",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas2/__tests__/__snapshots__/model-description.ts.snap
+++ b/src/rulesets/oas2/__tests__/__snapshots__/model-description.ts.snap
@@ -10,16 +10,6 @@ Array [
       "user",
       "description",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas2/__tests__/__snapshots__/model-description.ts.snap
+++ b/src/rulesets/oas2/__tests__/__snapshots__/model-description.ts.snap
@@ -11,6 +11,7 @@ Array [
       "description",
     ],
     "severity": 1,
+    "summary": "Definition \`description\` must be present and non-empty string.",
   },
 ]
 `;

--- a/src/rulesets/oas2/__tests__/__snapshots__/model-description.ts.snap
+++ b/src/rulesets/oas2/__tests__/__snapshots__/model-description.ts.snap
@@ -3,16 +3,24 @@
 exports[`model-description return errors if a definition is missing description 1`] = `
 Array [
   Object {
+    "code": "model-description",
     "message": "definitions.user.description is not truthy",
-    "name": "model-description",
     "path": Array [
       "definitions",
       "user",
       "description",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Definition \`description\` must be present and non-empty string.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas2/__tests__/valid-example.ts
+++ b/src/rulesets/oas2/__tests__/valid-example.ts
@@ -146,8 +146,8 @@ describe('valid-example', () => {
     expect(results).toMatchInlineSnapshot(`
 Array [
   Object {
+    "code": "valid-example",
     "message": "should be string",
-    "name": "valid-example",
     "path": Array [
       "paths",
       "/pet",
@@ -162,8 +162,7 @@ Array [
       "properties",
       "c",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
+    "severity": 1,
     "summary": "Examples must be valid against their defined schema.",
   },
 ]

--- a/src/rulesets/oas2/index.ts
+++ b/src/rulesets/oas2/index.ts
@@ -1,6 +1,6 @@
 const merge = require('lodash/merge');
 
-import { ValidationSeverity } from '@stoplight/types/validations';
+import { DiagnosticSeverity } from '@stoplight/types';
 import { RuleFunction, RuleType } from '../../types';
 import { commonOasRules } from '../oas';
 import * as schema from './schemas/main.json';
@@ -13,7 +13,7 @@ export const oas2Rules = () => {
     'oas2-schema': {
       summary: 'Validate structure of OpenAPIv2 specification.',
       type: RuleType.VALIDATION,
-      severity: ValidationSeverity.Error,
+      severity: DiagnosticSeverity.Error,
       then: {
         function: RuleFunction.SCHEMA,
         functionOptions: {

--- a/src/rulesets/oas3/__tests__/__snapshots__/api-servers.ts.snap
+++ b/src/rulesets/oas3/__tests__/__snapshots__/api-servers.ts.snap
@@ -3,14 +3,22 @@
 exports[`api-servers return errors if servers is an empty array  1`] = `
 Array [
   Object {
+    "code": "api-servers",
     "message": "should NOT have fewer than 1 items",
-    "name": "api-servers",
     "path": Array [
       "servers",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "OpenAPI \`servers\` must be present and non-empty array.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;
@@ -18,14 +26,22 @@ Array [
 exports[`api-servers return errors if servers is missing  1`] = `
 Array [
   Object {
+    "code": "api-servers",
     "message": "servers does not exist",
-    "name": "api-servers",
     "path": Array [
       "servers",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "OpenAPI \`servers\` must be present and non-empty array.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas3/__tests__/__snapshots__/api-servers.ts.snap
+++ b/src/rulesets/oas3/__tests__/__snapshots__/api-servers.ts.snap
@@ -8,16 +8,6 @@ Array [
     "path": Array [
       "servers",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]
@@ -31,16 +21,6 @@ Array [
     "path": Array [
       "servers",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas3/__tests__/__snapshots__/api-servers.ts.snap
+++ b/src/rulesets/oas3/__tests__/__snapshots__/api-servers.ts.snap
@@ -9,6 +9,7 @@ Array [
       "servers",
     ],
     "severity": 1,
+    "summary": "OpenAPI \`servers\` must be present and non-empty array.",
   },
 ]
 `;
@@ -22,6 +23,7 @@ Array [
       "servers",
     ],
     "severity": 1,
+    "summary": "OpenAPI \`servers\` must be present and non-empty array.",
   },
 ]
 `;

--- a/src/rulesets/oas3/__tests__/__snapshots__/model-description.ts.snap
+++ b/src/rulesets/oas3/__tests__/__snapshots__/model-description.ts.snap
@@ -12,6 +12,7 @@ Array [
       "description",
     ],
     "severity": 1,
+    "summary": "Model \`description\` must be present and non-empty string.",
   },
 ]
 `;

--- a/src/rulesets/oas3/__tests__/__snapshots__/model-description.ts.snap
+++ b/src/rulesets/oas3/__tests__/__snapshots__/model-description.ts.snap
@@ -11,16 +11,6 @@ Array [
       "user",
       "description",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas3/__tests__/__snapshots__/model-description.ts.snap
+++ b/src/rulesets/oas3/__tests__/__snapshots__/model-description.ts.snap
@@ -3,17 +3,25 @@
 exports[`model-description return errors if a definition is missing description 1`] = `
 Array [
   Object {
+    "code": "model-description",
     "message": "components.schemas.user.description is not truthy",
-    "name": "model-description",
     "path": Array [
       "components",
       "schemas",
       "user",
       "description",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Model \`description\` must be present and non-empty string.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas3/__tests__/__snapshots__/server-not-example.ts.snap
+++ b/src/rulesets/oas3/__tests__/__snapshots__/server-not-example.ts.snap
@@ -10,16 +10,6 @@ Array [
       0,
       "url",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas3/__tests__/__snapshots__/server-not-example.ts.snap
+++ b/src/rulesets/oas3/__tests__/__snapshots__/server-not-example.ts.snap
@@ -3,16 +3,24 @@
 exports[`server-not-example.com return errors if server is example.com 1`] = `
 Array [
   Object {
+    "code": "server-not-example.com",
     "message": "must not match the pattern 'example.com'",
-    "name": "server-not-example.com",
     "path": Array [
       "servers",
       0,
       "url",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Server URL should not point at \`example.com\`.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas3/__tests__/__snapshots__/server-not-example.ts.snap
+++ b/src/rulesets/oas3/__tests__/__snapshots__/server-not-example.ts.snap
@@ -11,6 +11,7 @@ Array [
       "url",
     ],
     "severity": 1,
+    "summary": "Server URL should not point at \`example.com\`.",
   },
 ]
 `;

--- a/src/rulesets/oas3/__tests__/__snapshots__/server-trailing-slash.ts.snap
+++ b/src/rulesets/oas3/__tests__/__snapshots__/server-trailing-slash.ts.snap
@@ -10,16 +10,6 @@ Array [
       0,
       "url",
     ],
-    "range": Object {
-      "end": Object {
-        "character": -1,
-        "line": -1,
-      },
-      "start": Object {
-        "character": -1,
-        "line": -1,
-      },
-    },
     "severity": 1,
   },
 ]

--- a/src/rulesets/oas3/__tests__/__snapshots__/server-trailing-slash.ts.snap
+++ b/src/rulesets/oas3/__tests__/__snapshots__/server-trailing-slash.ts.snap
@@ -11,6 +11,7 @@ Array [
       "url",
     ],
     "severity": 1,
+    "summary": "Server URL should not have a trailing slash.",
   },
 ]
 `;

--- a/src/rulesets/oas3/__tests__/__snapshots__/server-trailing-slash.ts.snap
+++ b/src/rulesets/oas3/__tests__/__snapshots__/server-trailing-slash.ts.snap
@@ -3,16 +3,24 @@
 exports[`server-trailing-slash return errors if server url ends with a slash 1`] = `
 Array [
   Object {
+    "code": "server-trailing-slash",
     "message": "must not match the pattern '/$'",
-    "name": "server-trailing-slash",
     "path": Array [
       "servers",
       0,
       "url",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
-    "summary": "Server URL should not have a trailing slash.",
+    "range": Object {
+      "end": Object {
+        "character": -1,
+        "line": -1,
+      },
+      "start": Object {
+        "character": -1,
+        "line": -1,
+      },
+    },
+    "severity": 1,
   },
 ]
 `;

--- a/src/rulesets/oas3/__tests__/valid-example.ts
+++ b/src/rulesets/oas3/__tests__/valid-example.ts
@@ -121,8 +121,8 @@ describe('valid-example', () => {
     expect(results).toMatchInlineSnapshot(`
 Array [
   Object {
+    "code": "valid-example",
     "message": "should match format \\"email\\"",
-    "name": "valid-example",
     "path": Array [
       "paths",
       "/pet",
@@ -132,8 +132,7 @@ Array [
       "*/*",
       "schema",
     ],
-    "severity": 40,
-    "severityLabel": "warn",
+    "severity": 1,
     "summary": "Examples must be valid against their defined schema.",
   },
 ]

--- a/src/rulesets/oas3/index.ts
+++ b/src/rulesets/oas3/index.ts
@@ -1,6 +1,6 @@
 const merge = require('lodash/merge');
 
-import { ValidationSeverity } from '@stoplight/types/validations';
+import { DiagnosticSeverity } from '@stoplight/types';
 import { RuleFunction, RuleType } from '../../types';
 import { commonOasRules } from '../oas';
 import * as schema from './schemas/main.json';
@@ -13,7 +13,7 @@ export const oas3Rules = () => {
     'oas3-schema': {
       summary: 'Validate structure of OpenAPIv3 specification.',
       type: RuleType.VALIDATION,
-      severity: ValidationSeverity.Error,
+      severity: DiagnosticSeverity.Error,
       then: {
         function: RuleFunction.SCHEMA,
         functionOptions: {

--- a/src/types/function.ts
+++ b/src/types/function.ts
@@ -1,4 +1,4 @@
-import { ObjPath } from '@stoplight/types';
+import { JSONPath } from '@stoplight/types';
 
 export type IFunction<O = any> = (
   targetValue: any,
@@ -8,8 +8,8 @@ export type IFunction<O = any> = (
 ) => void | IFunctionResult[];
 
 export interface IFunctionPaths {
-  given: ObjPath;
-  target?: ObjPath;
+  given: JSONPath;
+  target?: JSONPath;
 }
 
 export interface IFunctionValues {
@@ -20,5 +20,5 @@ export interface IFunctionValues {
 
 export interface IFunctionResult {
   message: string;
-  path?: ObjPath;
+  path?: JSONPath;
 }

--- a/src/types/function.ts
+++ b/src/types/function.ts
@@ -1,4 +1,4 @@
-import { JSONPath } from '@stoplight/types';
+import { JsonPath } from '@stoplight/types';
 
 export type IFunction<O = any> = (
   targetValue: any,
@@ -8,8 +8,8 @@ export type IFunction<O = any> = (
 ) => void | IFunctionResult[];
 
 export interface IFunctionPaths {
-  given: JSONPath;
-  target?: JSONPath;
+  given: JsonPath;
+  target?: JsonPath;
 }
 
 export interface IFunctionValues {
@@ -20,5 +20,5 @@ export interface IFunctionValues {
 
 export interface IFunctionResult {
   message: string;
-  path?: JSONPath;
+  path?: JsonPath;
 }

--- a/src/types/rule.ts
+++ b/src/types/rule.ts
@@ -1,4 +1,4 @@
-import { ValidationSeverity, ValidationSeverityLabel } from '@stoplight/types/validations';
+import { DiagnosticSeverity } from '@stoplight/types';
 import { RuleFunction, RuleType } from './enums';
 
 export type Rule = IRule | TruthyRule | XorRule | LengthRule | AlphaRule | PatternRule | SchemaRule;
@@ -13,8 +13,7 @@ export interface IRule<T = string, O = any> {
   description?: string;
 
   // The severity of results this rule generates
-  severity?: ValidationSeverity;
-  severityLabel?: ValidationSeverityLabel;
+  severity?: DiagnosticSeverity;
 
   // Tags attached to the rule, which can be used for organizational purposes
   tags?: string[];

--- a/src/types/spectral.ts
+++ b/src/types/spectral.ts
@@ -1,4 +1,4 @@
-import { Dictionary, IDiagnostic, JSONPath } from '@stoplight/types';
+import { Dictionary, IDiagnostic, JSONPath, Omit } from '@stoplight/types';
 
 import { IFunction } from './function';
 import { IRule, Rule } from './rule';
@@ -37,7 +37,7 @@ export interface IRunResult {
   results: IRuleResult[];
 }
 
-export interface IRuleResult extends IDiagnostic {
+export interface IRuleResult extends Omit<IDiagnostic, 'range'> {
   path: JSONPath;
 }
 

--- a/src/types/spectral.ts
+++ b/src/types/spectral.ts
@@ -33,10 +33,6 @@ export interface IRunOpts {
   resolvedTarget?: object;
 }
 
-export interface IRunResult {
-  results: IRuleResult[];
-}
-
 export interface IRuleResult extends Omit<IDiagnostic, 'range'> {
   summary?: string;
   path: JsonPath;

--- a/src/types/spectral.ts
+++ b/src/types/spectral.ts
@@ -1,4 +1,4 @@
-import { Dictionary, IValidationResult, ObjPath } from '@stoplight/types';
+import { Dictionary, IDiagnostic, JSONPath } from '@stoplight/types';
 
 import { IFunction } from './function';
 import { IRule, Rule } from './rule';
@@ -33,12 +33,15 @@ export interface IRunOpts {
   resolvedTarget?: object;
 }
 
-export interface IRuleResult extends IValidationResult {
-  message: string;
-  path: ObjPath;
+export interface IRunResult {
+  results: IRuleResult[];
+}
+
+export interface IRuleResult extends IDiagnostic {
+  path: JSONPath;
 }
 
 export interface IGivenNode {
-  path: ObjPath;
+  path: JSONPath;
   value: any;
 }

--- a/src/types/spectral.ts
+++ b/src/types/spectral.ts
@@ -38,6 +38,7 @@ export interface IRunResult {
 }
 
 export interface IRuleResult extends Omit<IDiagnostic, 'range'> {
+  summary?: string;
   path: JSONPath;
 }
 

--- a/src/types/spectral.ts
+++ b/src/types/spectral.ts
@@ -1,4 +1,4 @@
-import { Dictionary, IDiagnostic, JSONPath, Omit } from '@stoplight/types';
+import { Dictionary, IDiagnostic, JsonPath, Omit } from '@stoplight/types';
 
 import { IFunction } from './function';
 import { IRule, Rule } from './rule';
@@ -39,10 +39,10 @@ export interface IRunResult {
 
 export interface IRuleResult extends Omit<IDiagnostic, 'range'> {
   summary?: string;
-  path: JSONPath;
+  path: JsonPath;
 }
 
 export interface IGivenNode {
-  path: JSONPath;
+  path: JsonPath;
   value: any;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1276,6 +1276,11 @@
   resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-3.0.0.tgz#2464b3149accd0ef4b822a6079a1a8ece416e9c3"
   integrity sha512-08VUdzyHUenrk5m8rP6DiCQjZ/6DIjmFDKryBTuBNCrQQ6dwlqqGRN+f4nCOPc+Ks6jhHRLjT3hUCn8TUwIKuw==
 
+"@stoplight/types@4.x.x":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-4.0.0.tgz#04669b13f4de54e0446392167087cd6a9a570556"
+  integrity sha512-xh7STKNeE7j4Z6w8vkw+QxSCaxhF5+c2mY7UBqT6BMiom/Ep/EdYmYq3dmvYfXqwbkiTMR6qbYymwqnoJo8Z6w==
+
 "@storybook/addon-actions@4.0.11":
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-4.0.11.tgz#4a329172baa8dc75a79af1dab72ed57ca2993440"


### PR DESCRIPTION
TODO:

- [x] Switch to npm version of `@stoplight/types` once released
- [x] Make IDiagnostic['range'] optional? `parseWithPointers` function exposed by [JSON](https://github.com/stoplightio/json/pull/12)/[YAML](https://github.com/stoplightio/yaml/pull/6)/[Markdown](https://github.com/stoplightio/markdown/pull/5) parsers will be capable of providing the required information, but Spectral would need to make use of it for text files (when CLI mode is added to Spectral). Not sure about object literals (current usage via API), as they aren't expressed in text format.
I guess we could simply treat each property as it would be placed on a separate line and indentation could be based on actual nesting depth (BASE * depth).

### Please check if the PR fulfills these requirements
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

Feature (breaking). 

### What is the current behavior?


### If this is a feature change, what is the new behavior?

The shape of a single validation object is different.

### Does this PR introduce a breaking change?

Yes, as stated above, the shape of single validation is different, so expect some properties to be missing, new ones to be added or their values to be changed.

#### What changes might users need to make in their application due to this PR?

Use new properties.

### Other information
