### PR TITLE
Fix valid-example for $ref useage

### DIFF
--- a/src/functions/__tests__/schema-path.test.ts
+++ b/src/functions/__tests__/schema-path.test.ts
@@ -1,11 +1,16 @@
 import { schemaPath } from '../schema-path';
 
 function runSchemaPath(target: any, field: string, schemaPathStr: string) {
-  return schemaPath(target, { field, schemaPath: schemaPathStr }, { given: ['$'] }, { given: null, original: null });
+  return schemaPath(
+    target,
+    { field, schemaPath: schemaPathStr },
+    { given: [], target: [] },
+    { given: null, original: null, resolved: target }
+  );
 }
 
 describe('schema', () => {
-  // Check the example field matches the conents of schema
+  // Check the example field matches the contents of schema
   const fieldToCheck = 'example';
   const path = '$.schema';
 
@@ -58,9 +63,7 @@ describe('schema', () => {
 Array [
   Object {
     "message": "should have required property 'url'",
-    "path": Array [
-      "$",
-    ],
+    "path": Array [],
   },
 ]
 `);
@@ -79,9 +82,7 @@ Array [
 Array [
   Object {
     "message": "should match format \\"url\\"",
-    "path": Array [
-      "$",
-    ],
+    "path": Array [],
   },
 ]
 `);

--- a/src/rulesets/oas2/__tests__/valid-example.ts
+++ b/src/rulesets/oas2/__tests__/valid-example.ts
@@ -118,6 +118,34 @@ describe('valid-example', () => {
           properties: {
             _links: {
               type: 'object',
+              additionalProperties: {
+                allOf: [
+                  {
+                    $ref: '#/definitions/halLinkObject',
+                  },
+                  {
+                    type: 'array',
+                    items: [
+                      {
+                        $ref: '#/definitions/halLinkObject',
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+            _embedded: {
+              type: 'object',
+              additionalProperties: true,
+            },
+          },
+        },
+        halLinkObject: {
+          type: 'object',
+          required: ['href'],
+          properties: {
+            href: {
+              type: 'string',
             },
           },
         },
@@ -128,7 +156,7 @@ describe('valid-example', () => {
       expect.objectContaining({
         code: 'valid-example',
         summary: 'Examples must be valid against their defined schema.',
-        path: ['paths', '/path', 'get', 'responses'],
+        path: ['definitions', 'halRoot', '_links', 'self'],
       }),
     ]);
   });

--- a/src/rulesets/oas2/__tests__/valid-example.ts
+++ b/src/rulesets/oas2/__tests__/valid-example.ts
@@ -85,6 +85,54 @@ describe('valid-example', () => {
     expect(results).toHaveLength(1);
   });
 
+  test('works fine with allOf $ref', async () => {
+    const results = await s.run({
+      definitions: {
+        halRoot: {
+          type: 'object',
+          allOf: [
+            {
+              $ref: '#/definitions/halResource',
+            },
+          ],
+          example: {
+            _links: {
+              self: {
+                href: '/',
+              },
+              products: {
+                href: '/products',
+              },
+              product: {
+                href: '/products/{product_id}',
+              },
+              users: {
+                href: '/users',
+              },
+            },
+          },
+        },
+        halResource: {
+          title: 'HAL Resource Object',
+          type: 'object',
+          properties: {
+            _links: {
+              type: 'object',
+            },
+          },
+        },
+      },
+    });
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        code: 'valid-example',
+        summary: 'Examples must be valid against their defined schema.',
+        path: ['paths', '/path', 'get', 'responses'],
+      }),
+    ]);
+  });
+
   test('will pass for valid parents examples which contain invalid child examples', async () => {
     const results = await s.run({
       swagger: '2.0',


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

Fixing valid-examples so that examples with $ref in it, or schemas with $ref in it, will work properly.

### What is the current behavior?

Running valid-example on anything with $ref in it will cause lots of warnings to be thrown to the console, and invalid examples could sneak through. 

### Other information

Fixes #109