### PR TITLE
feat: include range & summary in json output

### DIFF
--- a/src/formatters/__tests__/json.test.ts
+++ b/src/formatters/__tests__/json.test.ts
@@ -1,0 +1,83 @@
+import { IRuleResult } from '../../../dist/types';
+import { json } from '../json';
+
+const results: IRuleResult[] = [
+  {
+    code: 'operation-description',
+    summary: 'Operation `description` must be present and non-empty string.',
+    message: 'paths./pets.get.description is not truthy',
+    path: ['paths', '/pets', 'get', 'description'],
+    severity: 1,
+    source: '/home/Stoplight/spectral/yaml/src/__tests__/fixtures/petstore.oas2.yaml',
+    range: {
+      start: {
+        line: 60,
+        character: 8,
+      },
+      end: {
+        line: 71,
+        character: 60,
+      },
+    },
+  },
+  {
+    code: 'operation-tags',
+    summary: 'Operation should have non-empty `tags` array.',
+    message: 'paths./pets.get.tags is not truthy',
+    path: ['paths', '/pets', 'get', 'tags'],
+    severity: 1,
+    source: '/home/Stoplight/spectral/yaml/src/__tests__/fixtures/petstore.oas2.yaml',
+    range: {
+      start: {
+        line: 60,
+        character: 8,
+      },
+      end: {
+        line: 71,
+        character: 60,
+      },
+    },
+  },
+];
+
+describe('JSON formatter', () => {
+  test('should include ranges', () => {
+    expect(JSON.parse(json(results))).toEqual([
+      expect.objectContaining({
+        range: {
+          start: {
+            line: 60,
+            character: 8,
+          },
+          end: {
+            line: 71,
+            character: 60,
+          },
+        },
+      }),
+      expect.objectContaining({
+        range: {
+          start: {
+            line: 60,
+            character: 8,
+          },
+          end: {
+            line: 71,
+            character: 60,
+          },
+        },
+      }),
+    ]);
+  });
+
+  test('should include summary', () => {
+    expect(JSON.parse(json(results))).toEqual([
+      expect.objectContaining({
+        summary: 'Operation `description` must be present and non-empty string.',
+      }),
+      expect.objectContaining({
+        summary: 'Operation should have non-empty `tags` array.',
+      }),
+    ]);
+  });
+});

--- a/src/formatters/json.ts
+++ b/src/formatters/json.ts
@@ -6,7 +6,9 @@ export const json = (results: IRuleResult[]): string => {
       code: result.code,
       path: result.path,
       message: result.message,
+      summary: result.summary,
       severity: result.severity,
+      range: result.range,
     };
   });
   return JSON.stringify(outputJson, null, '\t');


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

Range and summary are included in JSON putput.

### What is the current behavior?

No range and summary.

### If this is a feature change, what is the new behavior?

### Does this PR introduce a breaking change?

No.

### Other information

(e.g. detailed explanation, related issues, links for us to have context, eg. stackoverflow, issues outside of the repo, forum, etc.)
