### PR TITLE
fix: cli version mismatch on publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,9 @@
     "node": ">=8.3.0"
   },
   "scripts": {
-    "build": "sl-scripts build && oclif-dev manifest && node ./scripts/prepare-cli",
+    "build": "sl-scripts build && node ./scripts/prepare-cli",
     "build.docs": "sl-scripts build:typedoc",
+    "build.manifest": "cd dist && oclif-dev manifest",
     "commit": "git-cz",
     "lint": "tslint 'src/**/*.ts'",
     "lint.fix": "yarn lint --fix",
@@ -70,6 +71,7 @@
   "devDependencies": {
     "@oclif/dev-cli": "^1",
     "@oclif/test": "^1",
+    "@semantic-release/exec": "^3.3.2",
     "@stoplight/scripts": "^5.1.0",
     "@types/chalk": "^2.2.0",
     "@types/jest": "24.0.x",
@@ -109,6 +111,18 @@
     ]
   },
   "release": {
-    "extends": "@stoplight/scripts/release"
+    "pkgRoot": "dist",
+    "plugins": [
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator",
+      "@semantic-release/npm",
+      "@semantic-release/github",
+      [
+        "@semantic-release/exec",
+        {
+          "prepareCmd": "yarn build.manifest"
+        }
+      ]
+    ]
   }
 }

--- a/scripts/prepare-cli.js
+++ b/scripts/prepare-cli.js
@@ -1,13 +1,10 @@
-const { copySync, moveSync, readJSONSync, writeJSONSync } = require('fs-extra');
+const { copySync, readJSONSync, writeFileSync } = require('fs-extra');
 const { resolve } = require('path');
 
 const cwd = process.cwd();
 
 // copy bin directory over
 copySync(resolve(cwd, 'bin'), resolve(cwd, 'dist', 'bin'));
-
-// move generated manifest
-moveSync(resolve(cwd, 'oclif.manifest.json'), resolve(cwd, 'dist', 'oclif.manifest.json'));
 
 // update the dist package.json file with cli properties
 const pkgPath = resolve(cwd, 'dist', 'package.json');
@@ -24,7 +21,7 @@ pkg.oclif = {
 };
 
 // write it back
-writeJSONSync(pkgPath, pkg);
+writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
 
 // tslint-disable-next-line no-console
-console.log("updated dist folder with cli related files and changes");
+console.log('updated dist folder with cli related files and changes');

--- a/yarn.lock
+++ b/yarn.lock
@@ -608,6 +608,18 @@
   resolved "https://registry.yarnpkg.com/@semantic-release/error/-/error-2.2.0.tgz#ee9d5a09c9969eade1ec864776aeda5c5cddbbf0"
   integrity sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==
 
+"@semantic-release/exec@^3.3.2":
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/@semantic-release/exec/-/exec-3.3.2.tgz#33fb6001ddeaed4364975fa981bfd7306db7eabb"
+  integrity sha512-CzJnsTXYKY4LZ16WVEq/bt4OLzoiFf0DymCeMUZ5fthPHDbKprzky4+VIwaSDbRgLVEqRVeUD4gYVmlAeaWNCA==
+  dependencies:
+    "@semantic-release/error" "^2.1.0"
+    aggregate-error "^2.0.0"
+    debug "^4.0.0"
+    execa "^1.0.0"
+    lodash "^4.17.4"
+    parse-json "^4.0.0"
+
 "@semantic-release/git@7.0.8":
   version "7.0.8"
   resolved "https://registry.yarnpkg.com/@semantic-release/git/-/git-7.0.8.tgz#b9e1af094a19d4e96974b90a969ad0e6782c8727"
@@ -4556,12 +4568,7 @@ json5@2.x, json5@^2.1.0:
   dependencies:
     minimist "^1.2.0"
 
-jsonc-parser@2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-2.0.3.tgz#6d4199ccab7f21ff5d2a4225050c54e981fb21a2"
-  integrity sha512-WJi9y9ABL01C8CxTKxRRQkkSpY/x2bo4Gy0WuiZGrInxQqgxQpvkBCLNcDYcHOSdhx4ODgbFcgAvfL49C+PHgQ==
-
-"jsonc-parser@https://github.com/stoplightio/node-jsonc-parser.git#f45703496d842937ec822683550067dfe68d898e":
+jsonc-parser@2.0.3, "jsonc-parser@https://github.com/stoplightio/node-jsonc-parser.git#f45703496d842937ec822683550067dfe68d898e":
   version "2.0.3"
   resolved "https://github.com/stoplightio/node-jsonc-parser.git#f45703496d842937ec822683550067dfe68d898e"
 


### PR DESCRIPTION
Basically, during release this runs the oclif manifest generation after the npm prepare script updates the package json version number. Should result in the appropriate version number ending up in the manifest file. Note that this is difficult to verify without actually releasing unfortunately...