### PR TITLE
fix: identify parsed result correctly

### DIFF
--- a/src/__tests__/spectral.test.ts
+++ b/src/__tests__/spectral.test.ts
@@ -1,7 +1,8 @@
 import { DiagnosticSeverity } from '@stoplight/types';
 const merge = require('lodash/merge');
 
-import { Spectral } from '../spectral';
+import { IParsedResult } from '../../dist';
+import { isParsedResult, Spectral } from '../spectral';
 import { RuleFunction } from '../types';
 
 describe('spectral', () => {
@@ -111,5 +112,44 @@ describe('spectral', () => {
 
       expect(fakeResolver.resolve).toBeCalledWith(target);
     });
+  });
+
+  test('isParsedResult correctly identifies objects that fulfill the IParsedResult interface', () => {
+    // @ts-ignore
+    expect(isParsedResult()).toBe(false);
+
+    expect(isParsedResult('')).toBe(false);
+    expect(isParsedResult([])).toBe(false);
+    expect(isParsedResult({})).toBe(false);
+    expect(
+      isParsedResult({
+        parsed: undefined,
+      })
+    ).toBe(false);
+
+    expect(
+      isParsedResult({
+        parsed: [],
+      })
+    ).toBe(false);
+
+    expect(
+      isParsedResult({
+        parsed: {
+          data: {},
+        },
+      })
+    ).toBe(false);
+
+    const obj: IParsedResult = {
+      getLocationForJsonPath: jest.fn(),
+      parsed: {
+        data: {},
+        ast: {},
+        lineMap: [],
+        diagnostics: [],
+      },
+    };
+    expect(isParsedResult(obj)).toBe(true);
   });
 });

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -12,7 +12,7 @@ import {
 } from './types';
 
 export const runRules = (
-  parsed: IParsedResult,
+  parsedResult: IParsedResult,
   rules: RunRuleCollection,
   functions: FunctionCollection,
   opts: IRunOpts
@@ -30,7 +30,7 @@ export const runRules = (
     }
 
     try {
-      results = results.concat(runRule(parsed, rule, functions, opts));
+      results = results.concat(runRule(parsedResult, rule, functions, opts));
     } catch (e) {
       console.error(`Unable to run rule '${name}':\n${e}`);
     }
@@ -40,14 +40,15 @@ export const runRules = (
 };
 
 const runRule = (
-  parsed: IParsedResult,
+  parsedResult: IParsedResult,
   rule: IRunRule,
   functions: FunctionCollection,
   opts: IRunOpts
 ): IRuleResult[] => {
+  const { parsed } = parsedResult;
   const { data: target } = parsed;
-  let results: IRuleResult[] = [];
 
+  let results: IRuleResult[] = [];
   let nodes: IGivenNode[] = [];
 
   // don't have to spend time running jsonpath if given is $ - can just use the root object
@@ -70,7 +71,7 @@ const runRule = (
           continue;
         }
 
-        results = results.concat(lintNode(node, rule, then, func, opts, parsed));
+        results = results.concat(lintNode(node, rule, then, func, opts, parsedResult));
       }
     } catch (e) {
       console.warn(`Encountered error when running rule '${rule.name}' on node at path '${node.path}':\n${e}`);

--- a/src/types/spectral.ts
+++ b/src/types/spectral.ts
@@ -1,5 +1,4 @@
-import { Dictionary, IDiagnostic, IParserResult, JsonPath } from '@stoplight/types';
-import { YAMLNode } from 'yaml-ast-parser';
+import { Dictionary, GetLocationForJsonPath, IDiagnostic, IParserResult, JsonPath } from '@stoplight/types';
 
 import { IFunction } from './function';
 import { IRule, Rule } from './rule';
@@ -44,6 +43,8 @@ export interface IGivenNode {
   value: any;
 }
 
-export interface IParsedResult extends IParserResult<object, YAMLNode, number[]> {
+export interface IParsedResult {
+  parsed: IParserResult;
+  getLocationForJsonPath: GetLocationForJsonPath<any, any>;
   source?: string;
 }


### PR DESCRIPTION
Bug fix. This only affects our internal usage via graphite where we pass our own parsed result to `run`. Sometimes this parsed result comes from the `json` parser, which doesn't work with the `yaml` `getLocationForJsonPath` function that is currently hardcoded in spectral. This fixes that by allowing caller of `run` to pass in the appropriate `getLocationForJsonPath` function. Without this, graphite can't use spectral for json files since the json `getLocationForJsonPath` is different than the yaml `getLocationForJsonPath`.