### PR TITLE
docs(contributing.md): add instructions to run Spectral from source

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,11 +34,12 @@ Yarn is a package manager for your code, similar to npm. While you can use npm t
 2. Fork the [https://github.com/stoplightio/spectral](https://github.com/stoplightio/spectral) repo.
 3. Git clone your fork (i.e. git clone https://github.com/<your-username>/spectral.git) to your machine.
 4. Run `yarn` to install dependencies and setup the project.
-5. Run `git checkout -b [name_of_your_new_branch]` to create a new branch for your work. To help build nicer changelogs, we have a convention for branch names. Please start your branch with either `feature/{branch-name}`, `chore/{branch-name}`, or `fix/{branch-name}`. For example, if I was adding a CLI, I would make my branch name: `feature/add-cli`. 
-6. Make changes, write code and tests, etc. The fun stuff!
-7. Run `yarn test.prod` to test your changes.
-8. Ready to `git commit`? **Important:** We use a [commit message format](https://www.conventionalcommits.org/en/v1.0.0-beta.3/) to add more semantic meaning to our git history to create automated, rich changelogs, filter what tests to run, and more. After you have `git add`, run `yarn commit` to help you create this format, or you can put it together manually and then do a regular `git commit`. Commits outside of this format will be rejected.
-9. Don't forget to `git push` to your branch after you have committed changes. 
+5. Use `yarn build && bin/run lint openapi.yml` to run Spectral from your local source tree.
+6. Run `git checkout -b [name_of_your_new_branch]` to create a new branch for your work. To help build nicer changelogs, we have a convention for branch names. Please start your branch with either `feature/{branch-name}`, `chore/{branch-name}`, or `fix/{branch-name}`. For example, if I was adding a CLI, I would make my branch name: `feature/add-cli`. 
+7. Make changes, write code and tests, etc. The fun stuff!
+8. Run `yarn test.prod` to test your changes.
+9. Ready to `git commit`? **Important:** We use a [commit message format](https://www.conventionalcommits.org/en/v1.0.0-beta.3/) to add more semantic meaning to our git history to create automated, rich changelogs, filter what tests to run, and more. After you have `git add`, run `yarn commit` to help you create this format, or you can put it together manually and then do a regular `git commit`. Commits outside of this format will be rejected.
+10. Don't forget to `git push` to your branch after you have committed changes. 
 
 Now, you are ready to make a pull request to the Stoplight repo! 😃
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

docs update

### What is the current behavior?

I couldn't work out how to run this tool once I had cloned the source and installed the dependencies.

### If this is a feature change, what is the new behavior?

The `CONTRIBUTING.md` file describes how to run from source (thanks @philsturgeon for helping me figure this out)

### Does this PR introduce a breaking change?

No

What changes might users need to make in their application due to this PR?

None

### Other information

(e.g. detailed explanation, related issues, links for us to have context, eg. stackoverflow, issues outside of the repo, forum, etc.)

Also asked in the forum https://community.stoplight.io/t/contributing-to-spectral-how-to-run-from-source/597