### PR TITLE
feat(cli): skip rules from cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Other options include:
   -h, --help                   show CLI help
   -m, --maxResults=maxResults  [default: all] maximum results to show
   -o, --output=output          output to a file instead of stdout
+  -s, --skip=skip              skip rules. Provide multiple rules seperated by ","
   -v, --verbose                increase verbosity
 ```
 


### PR DESCRIPTION
Added a flag "-s", which will ignore the given rules.

### Please check if the PR fulfills these requirements
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Tests & Docs are pending. Waiting on initial input.

### What kind of change does this PR introduce?

feature

### What is the current behavior?

https://github.com/stoplightio/spectral/issues/147

### If this is a feature change, what is the new behavior?
You can use the flag -s valid-rule,invalid-rule to skip rules.

### Does this PR introduce a breaking change?
No.
