### PR TITLE
chore: rewrite ts imports

### DIFF
--- a/src/cli/commands/__tests__/lint.test.ts
+++ b/src/cli/commands/__tests__/lint.test.ts
@@ -1,7 +1,7 @@
 import { test } from '@oclif/test';
 import * as fs from 'fs';
 import { resolve } from 'path';
-import SpyInstance = jest.SpyInstance;
+type SpyInstance = jest.SpyInstance;
 
 const invalidSpecPath = resolve(__dirname, '__fixtures__/openapi-3.0-no-contact.yaml');
 const validSpecPath = resolve(__dirname, '__fixtures__/openapi-3.0-valid.yaml');

--- a/src/functions/alphabetical.ts
+++ b/src/functions/alphabetical.ts
@@ -1,4 +1,4 @@
-import isEqual = require('lodash/isEqual');
+import { isEqual } from 'lodash';
 
 import { IAlphaRuleOptions, IFunction, IFunctionResult } from '../types';
 

--- a/src/functions/schema-path.ts
+++ b/src/functions/schema-path.ts
@@ -10,7 +10,7 @@
 import { IFunction, ISchemaPathOptions } from '../types';
 import { schema } from './schema';
 
-import jp = require('jsonpath');
+const jp = require('jsonpath');
 
 export const schemaPath: IFunction<ISchemaPathOptions> = (targetVal, opts, paths, otherValues) => {
   if (!targetVal || typeof targetVal !== 'object') return [];

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -1,7 +1,6 @@
 import { DiagnosticSeverity, JsonPath } from '@stoplight/types';
 import * as jp from 'jsonpath';
-import get = require('lodash/get');
-import has = require('lodash/has');
+import { get, has } from 'lodash';
 
 import { IFunction, IGivenNode, IParsedResult, IRuleResult, IRunOpts, IRunRule, IThen } from './types';
 

--- a/src/rulesets/reader.ts
+++ b/src/rulesets/reader.ts
@@ -1,4 +1,4 @@
-import merge = require('lodash/merge');
+import { merge } from 'lodash';
 import Lint from '../cli/commands/lint';
 import { readParsable } from '../fs/reader';
 import { RuleCollection } from '../types';

--- a/src/rulesets/validation.ts
+++ b/src/rulesets/validation.ts
@@ -1,7 +1,7 @@
-import AJV = require('ajv');
+const AJV = require('ajv');
 import { ErrorObject } from 'ajv';
-import ruleSchema = require('../meta/rule.schema.json');
-import rulesetSchema = require('../meta/ruleset.schema.json');
+const ruleSchema = require('../meta/rule.schema.json');
+const rulesetSchema = require('../meta/ruleset.schema.json');
 import { IRuleset } from '../types/ruleset';
 
 const ajv = new AJV({ allErrors: true, jsonPointers: true });

--- a/src/rulesets/validation.ts
+++ b/src/rulesets/validation.ts
@@ -1,7 +1,7 @@
 const AJV = require('ajv');
 import { ErrorObject } from 'ajv';
-const ruleSchema = require('../meta/rule.schema.json');
-const rulesetSchema = require('../meta/ruleset.schema.json');
+import * as ruleSchema from '../meta/rule.schema.json';
+import * as rulesetSchema from '../meta/ruleset.schema.json';
 import { IRuleset } from '../types/ruleset';
 
 const ajv = new AJV({ allErrors: true, jsonPointers: true });

--- a/src/spectral.ts
+++ b/src/spectral.ts
@@ -2,7 +2,7 @@ import { safeStringify } from '@stoplight/json';
 import { Resolver } from '@stoplight/json-ref-resolver';
 import { getLocationForJsonPath, parseWithPointers } from '@stoplight/yaml';
 
-import merge = require('lodash/merge');
+import { merge } from 'lodash';
 
 import { IParserResult } from '@stoplight/types';
 import { functions as defaultFunctions } from './functions';


### PR DESCRIPTION
This is one of the prerequisites to merge https://github.com/stoplightio/spectral/pull/185 
We've switched to a different (ESNext) module target recently, and mixed ESM-CJS like imports are no longer valid.

