### PR TITLE
fix: temporarily disable unknown format warnings

### DIFF
--- a/src/functions/__tests__/schema.test.ts
+++ b/src/functions/__tests__/schema.test.ts
@@ -5,39 +5,67 @@ function runSchema(target: any, schemaObj: object) {
 }
 
 describe('schema', () => {
-  const testSchema = {
-    type: 'array',
-    items: {
-      type: 'string',
-    },
-    maxItems: 1,
-  };
+  describe('when schema defines a simple array', () => {
+    const testSchema = {
+      type: 'array',
+      items: {
+        type: 'string',
+      },
+      maxItems: 1,
+    };
 
-  test('will error with totally invalid input', () => {
-    const input = { foo: 'bar' };
-    expect(runSchema(input, testSchema)).toMatchInlineSnapshot(`
-Array [
-  Object {
-    "message": "should be array",
-    "path": Array [
-      "$",
-    ],
-  },
-]
-`);
+    test('errors with totally invalid input', () => {
+      const input = { foo: 'bar' };
+      expect(runSchema(input, testSchema)).toEqual([
+        expect.objectContaining({
+          message: 'should be array',
+          path: ['$'],
+        }),
+      ]);
+    });
+
+    test('errors with subtly invalid input', () => {
+      const input = ['1', '2'];
+      expect(runSchema(input, testSchema)).toEqual([
+        expect.objectContaining({
+          message: 'should NOT have more than 1 items',
+          path: ['$'],
+        }),
+      ]);
+    });
   });
 
-  test('will error with subtly invalid input', () => {
-    const input = ['1', '2'];
-    expect(runSchema(input, testSchema)).toMatchInlineSnapshot(`
-Array [
-  Object {
-    "message": "should NOT have more than 1 items",
-    "path": Array [
-      "$",
-    ],
-  },
-]
-`);
+  describe('when schema defines common formats', () => {
+    const testSchema = {
+      type: 'string',
+      format: 'email',
+    };
+
+    test('errors for not emails', () => {
+      const input = 'not an email';
+      expect(runSchema(input, testSchema)).toEqual([
+        expect.objectContaining({
+          message: 'should match format "email"',
+          path: ['$'],
+        }),
+      ]);
+    });
+
+    test('considers emails valid', () => {
+      const input = 'email@example.com';
+      expect(runSchema(input, testSchema)).toEqual([]);
+    });
+  });
+
+  describe('when schema defines OpenAPI specific formats', () => {
+    const testSchema = {
+      type: 'number',
+      format: 'int32',
+    };
+
+    test('accepts a number of any format', () => {
+      const input = 123;
+      expect(runSchema(input, testSchema)).toEqual([]);
+    });
   });
 });

--- a/src/functions/schema.ts
+++ b/src/functions/schema.ts
@@ -6,6 +6,7 @@ const ajv = new AJV({
   meta: false,
   schemaId: 'auto',
   jsonPointers: true,
+  unknownFormats: 'ignore',
 });
 ajv.addMetaSchema(jsonSpecv4);
 // @ts-ignore

--- a/src/rulesets/oas3/__tests__/valid-example.ts
+++ b/src/rulesets/oas3/__tests__/valid-example.ts
@@ -149,4 +149,31 @@ Array [
 ]
 `);
   });
+
+  /*
+   * NOTE: This used to throw and error so we told AJV to ignore unknownFormats
+   *
+   *   Error: unknown format "int64" is used in schema at path "#"
+   *
+   * If this test starts to correctly report that 2886989840 is not a valid int64, then
+   * great, somebody must have trained AJV what a int64 is.
+   *
+   * More information: https://github.com/stoplightio/spectral/issues/187
+   */
+  test('does not report example mismatches for unknown AJV formats', async () => {
+    const results = await s.run({
+      xoxo: {
+        type: 'object',
+        properties: {
+          ip_address: {
+            type: 'integer',
+            format: 'int64',
+            example: 2886989840,
+          },
+        },
+      },
+    });
+
+    expect(results).toEqual([]);
+  });
 });


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

OpenAPI declares int64 is valid in the text doc, but formats are not defined in the OpenAPI metaschema so shoving that metaschema into a JSON Schema validator doesn't make it 100% into an OpenAPI validator as expected.

Until support is added for these OpenAPI specific formats, we are disabiling the 
error in AJV.

### What is the current behavior?

You get errors if you have OpenAPI specific formats in your API description documents.

### If this is a feature change, what is the new behavior?

We are just supressing those messages by changing AJV to ùnknownFormats: `'ignore'`.

### Does this PR introduce a breaking change?

Nope!

### Other information

Discovered by @akrabat in #187.