### PR TITLE
Upload artifacts on release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,23 @@ jobs:
       - cached-dependencies
       - run: yarn build
       - run: yarn release
+      - run: yarn build.binary
+      - persist_to_workspace:
+          root: ./dist
+          paths:
+            - bin
+  upload_artifacts:
+    docker:
+      - image: circleci/golang:1-stretch
+    steps:
+      - attach_workspace:
+          at: /tmp/
+      - run:
+          name: "Download GitHub Release Utility"
+          command: go get github.com/tcnksm/ghr
+      - run:
+          name: "Publish Release artifacts on GitHub"
+          command: ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} /tmp/bin
 
 workflows:
   version: 2
@@ -86,3 +103,9 @@ workflows:
           filters:
             branches:
               only: master
+      - upload_artifacts:
+          filters:
+            branches:
+              only: master
+          requires:
+            - release

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+install () {
+
+set -eu
+
+UNAME=$(uname)
+if [ "$UNAME" != "Linux" ] && [ "$UNAME" != "Darwin" ] ; then
+  echo "Sorry, OS/Architecture not supported: ${UNAME}/${ARCH}. Download binary from https://github.com/stoplightio/spectral/releases"
+  exit 1
+fi
+
+if [ "$UNAME" = "Darwin" ] ; then
+  PLATFORM="macos"
+elif [ "$UNAME" = "Linux" ] ; then
+  PLATFORM="linux"
+fi
+
+URL="https://github.com/stoplightio/spectral/releases/latest/download/spectral-cli-$PLATFORM"
+SRC=$(pwd)/spectral-$PLATFORM
+DEST=/usr/local/bin/spectral
+
+STATUS=$(curl -sL -w %{http_code} -o $SRC $URL)
+if [ $STATUS -ge 200 ] & [ $STATUS -le 308 ]; then
+  mv $SRC $DEST
+  chmod +x $DEST
+  echo "Spectral installation was successful"
+else
+  rm $SRC
+  echo "Error requesting. Download binary from ${URL}"
+  exit 1
+fi
+}
+
+install

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ elif [ "$UNAME" = "Linux" ] ; then
   PLATFORM="linux"
 fi
 
-URL="https://github.com/stoplightio/spectral/releases/latest/download/spectral-cli-$PLATFORM"
+URL="https://github.com/stoplightio/spectral/releases/latest/download/spectral-$PLATFORM"
 SRC=$(pwd)/spectral-$PLATFORM
 DEST=/usr/local/bin/spectral
 


### PR DESCRIPTION
This PR copies some automation I did for Prism to create and upload the artifacts on the GitHub release page and add an install.sh script for ease of consumption.

P.S: The Windows binary is broken. We need to use Azure Pipelines to produce a good one.