### PR TITLE
feat: use latest openapi v3.0 metaschema

### DIFF
--- a/src/rulesets/oas3/schemas/main.json
+++ b/src/rulesets/oas3/schemas/main.json
@@ -1,6 +1,13 @@
 {
+  "id": "https://spec.openapis.org/oas/3.0/schema/2019-04-02",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Validation schema for OpenAPI Specification 3.0.X.",
   "type": "object",
-  "required": ["openapi", "info", "paths"],
+  "required": [
+    "openapi",
+    "info",
+    "paths"
+  ],
   "properties": {
     "openapi": {
       "type": "string",
@@ -28,7 +35,8 @@
       "type": "array",
       "items": {
         "$ref": "#/definitions/Tag"
-      }
+      },
+      "uniqueItems": true
     },
     "paths": {
       "$ref": "#/definitions/Paths"
@@ -38,15 +46,18 @@
     }
   },
   "patternProperties": {
-    "^x-": {}
+    "^x-": {
+    }
   },
   "additionalProperties": false,
   "definitions": {
     "Reference": {
       "type": "object",
-      "required": ["$ref"],
-      "properties": {
-        "$ref": {
+      "required": [
+        "$ref"
+      ],
+      "patternProperties": {
+        "^\\$ref$": {
           "type": "string",
           "format": "uri-reference"
         }
@@ -54,7 +65,10 @@
     },
     "Info": {
       "type": "object",
-      "required": ["title", "version"],
+      "required": [
+        "title",
+        "version"
+      ],
       "properties": {
         "title": {
           "type": "string"
@@ -77,7 +91,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -97,13 +112,16 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
     "License": {
       "type": "object",
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "properties": {
         "name": {
           "type": "string"
@@ -114,13 +132,16 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
     "Server": {
       "type": "object",
-      "required": ["url"],
+      "required": [
+        "url"
+      ],
       "properties": {
         "url": {
           "type": "string"
@@ -136,13 +157,16 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
     "ServerVariable": {
       "type": "object",
-      "required": ["default"],
+      "required": [
+        "default"
+      ],
       "properties": {
         "enum": {
           "type": "array",
@@ -158,7 +182,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -171,10 +196,10 @@
             "^[a-zA-Z0-9\\.\\-_]+$": {
               "oneOf": [
                 {
-                  "$ref": "#/definitions/Reference"
+                  "$ref": "#/definitions/Schema"
                 },
                 {
-                  "$ref": "#/definitions/Schema"
+                  "$ref": "#/definitions/Reference"
                 }
               ]
             }
@@ -302,7 +327,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -376,13 +402,21 @@
         },
         "enum": {
           "type": "array",
-          "items": {},
+          "items": {
+          },
           "minItems": 1,
-          "uniqueItems": true
+          "uniqueItems": false
         },
         "type": {
           "type": "string",
-          "enum": ["array", "boolean", "integer", "number", "object", "string"]
+          "enum": [
+            "array",
+            "boolean",
+            "integer",
+            "number",
+            "object",
+            "string"
+          ]
         },
         "not": {
           "oneOf": [
@@ -476,7 +510,8 @@
         "format": {
           "type": "string"
         },
-        "default": {},
+        "default": {
+        },
         "nullable": {
           "type": "boolean",
           "default": false
@@ -492,7 +527,8 @@
           "type": "boolean",
           "default": false
         },
-        "example": {},
+        "example": {
+        },
         "externalDocs": {
           "$ref": "#/definitions/ExternalDocumentation"
         },
@@ -505,13 +541,16 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
     "Discriminator": {
       "type": "object",
-      "required": ["propertyName"],
+      "required": [
+        "propertyName"
+      ],
       "properties": {
         "propertyName": {
           "type": "string"
@@ -532,7 +571,7 @@
         },
         "namespace": {
           "type": "string",
-          "format": "url"
+          "format": "uri"
         },
         "prefix": {
           "type": "string"
@@ -547,18 +586,22 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
     "Response": {
       "type": "object",
-      "required": ["description"],
+      "required": [
+        "description"
+      ],
       "properties": {
         "description": {
           "type": "string"
         },
         "headers": {
+          "type": "object",
           "additionalProperties": {
             "oneOf": [
               {
@@ -591,21 +634,12 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
     "MediaType": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/MediaTypeWithExample"
-        },
-        {
-          "$ref": "#/definitions/MediaTypeWithExamples"
-        }
-      ]
-    },
-    "MediaTypeWithExample": {
       "type": "object",
       "properties": {
         "schema": {
@@ -618,32 +652,7 @@
             }
           ]
         },
-        "example": {},
-        "encoding": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/Encoding"
-          }
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "MediaTypeWithExamples": {
-      "type": "object",
-      "required": ["examples"],
-      "properties": {
-        "schema": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Schema"
-            },
-            {
-              "$ref": "#/definitions/Reference"
-            }
-          ]
+        "example": {
         },
         "examples": {
           "type": "object",
@@ -666,9 +675,15 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExampleXORExamples"
+        }
+      ]
     },
     "Example": {
       "type": "object",
@@ -679,40 +694,21 @@
         "description": {
           "type": "string"
         },
-        "value": {},
+        "value": {
+        },
         "externalValue": {
           "type": "string",
           "format": "uri-reference"
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
     "Header": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/HeaderWithSchema"
-        },
-        {
-          "$ref": "#/definitions/HeaderWithContent"
-        }
-      ]
-    },
-    "HeaderWithSchema": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/HeaderWithSchemaWithExample"
-        },
-        {
-          "$ref": "#/definitions/HeaderWithSchemaWithExamples"
-        }
-      ]
-    },
-    "HeaderWithSchemaWithExample": {
       "type": "object",
-      "required": ["schema"],
       "properties": {
         "description": {
           "type": "string"
@@ -731,7 +727,9 @@
         },
         "style": {
           "type": "string",
-          "enum": ["simple"],
+          "enum": [
+            "simple"
+          ],
           "default": "simple"
         },
         "explode": {
@@ -751,53 +749,15 @@
             }
           ]
         },
-        "example": {}
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "HeaderWithSchemaWithExamples": {
-      "type": "object",
-      "required": ["schema", "examples"],
-      "properties": {
-        "description": {
-          "type": "string"
+        "content": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          },
+          "minProperties": 1,
+          "maxProperties": 1
         },
-        "required": {
-          "type": "boolean",
-          "default": false
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "allowEmptyValue": {
-          "type": "boolean",
-          "default": false
-        },
-        "style": {
-          "type": "string",
-          "enum": ["simple"],
-          "default": "simple"
-        },
-        "explode": {
-          "type": "boolean"
-        },
-        "allowReserved": {
-          "type": "boolean",
-          "default": false
-        },
-        "schema": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Schema"
-            },
-            {
-              "$ref": "#/definitions/Reference"
-            }
-          ]
+        "example": {
         },
         "examples": {
           "type": "object",
@@ -814,42 +774,18 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "HeaderWithContent": {
-      "type": "object",
-      "required": ["content"],
-      "properties": {
-        "description": {
-          "type": "string"
-        },
-        "required": {
-          "type": "boolean",
-          "default": false
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "allowEmptyValue": {
-          "type": "boolean",
-          "default": false
-        },
-        "content": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/MediaType"
-          },
-          "minProperties": 1,
-          "maxProperties": 1
+        "^x-": {
         }
       },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExampleXORExamples"
+        },
+        {
+          "$ref": "#/definitions/SchemaXORContent"
+        }
+      ]
     },
     "Paths": {
       "type": "object",
@@ -857,7 +793,8 @@
         "^\\/": {
           "$ref": "#/definitions/PathItem"
         },
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -872,30 +809,6 @@
         },
         "description": {
           "type": "string"
-        },
-        "get": {
-          "$ref": "#/definitions/Operation"
-        },
-        "put": {
-          "$ref": "#/definitions/Operation"
-        },
-        "post": {
-          "$ref": "#/definitions/Operation"
-        },
-        "delete": {
-          "$ref": "#/definitions/Operation"
-        },
-        "options": {
-          "$ref": "#/definitions/Operation"
-        },
-        "head": {
-          "$ref": "#/definitions/Operation"
-        },
-        "patch": {
-          "$ref": "#/definitions/Operation"
-        },
-        "trace": {
-          "$ref": "#/definitions/Operation"
         },
         "servers": {
           "type": "array",
@@ -914,17 +827,24 @@
                 "$ref": "#/definitions/Reference"
               }
             ]
-          }
+          },
+          "uniqueItems": true
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^(get|put|post|delete|options|head|patch|trace)$": {
+          "$ref": "#/definitions/Operation"
+        },
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
     "Operation": {
       "type": "object",
-      "required": ["responses"],
+      "required": [
+        "responses"
+      ],
       "properties": {
         "tags": {
           "type": "array",
@@ -955,7 +875,8 @@
                 "$ref": "#/definitions/Reference"
               }
             ]
-          }
+          },
+          "uniqueItems": true
         },
         "requestBody": {
           "oneOf": [
@@ -1001,7 +922,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -1020,7 +942,7 @@
         }
       },
       "patternProperties": {
-        "[1-5](?:\\d{2}|XX)": {
+        "^[1-5](?:\\d{2}|XX)$": {
           "oneOf": [
             {
               "$ref": "#/definitions/Response"
@@ -1030,17 +952,11 @@
             }
           ]
         },
-        "^x-": {}
+        "^x-": {
+        }
       },
       "minProperties": 1,
-      "additionalProperties": false,
-      "not": {
-        "type": "object",
-        "patternProperties": {
-          "^x-": {}
-        },
-        "additionalProperties": false
-      }
+      "additionalProperties": false
     },
     "SecurityRequirement": {
       "type": "object",
@@ -1053,7 +969,9 @@
     },
     "Tag": {
       "type": "object",
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "properties": {
         "name": {
           "type": "string"
@@ -1066,13 +984,16 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
     "ExternalDocumentation": {
       "type": "object",
-      "required": ["url"],
+      "required": [
+        "url"
+      ],
       "properties": {
         "description": {
           "type": "string"
@@ -1083,111 +1004,87 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
+    },
+    "ExampleXORExamples": {
+      "description": "Example and examples are mutually exclusive",
+      "not": {
+        "required": [
+          "example",
+          "examples"
+        ]
+      }
+    },
+    "SchemaXORContent": {
+      "description": "Schema and content are mutually exclusive, at least one is required",
+      "not": {
+        "required": [
+          "schema",
+          "content"
+        ]
+      },
+      "oneOf": [
+        {
+          "required": [
+            "schema"
+          ]
+        },
+        {
+          "required": [
+            "content"
+          ],
+          "description": "Some properties are not allowed if content is present",
+          "allOf": [
+            {
+              "not": {
+                "required": [
+                  "style"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "explode"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "allowReserved"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "example"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "examples"
+                ]
+              }
+            }
+          ]
+        }
+      ]
     },
     "Parameter": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/ParameterWithSchema"
-        },
-        {
-          "$ref": "#/definitions/ParameterWithContent"
-        }
-      ]
-    },
-    "ParameterWithSchema": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/ParameterWithSchemaWithExample"
-        },
-        {
-          "$ref": "#/definitions/ParameterWithSchemaWithExamples"
-        }
-      ]
-    },
-    "ParameterWithSchemaWithExample": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/ParameterWithSchemaWithExampleInPath"
-        },
-        {
-          "$ref": "#/definitions/ParameterWithSchemaWithExampleInQuery"
-        },
-        {
-          "$ref": "#/definitions/ParameterWithSchemaWithExampleInHeader"
-        },
-        {
-          "$ref": "#/definitions/ParameterWithSchemaWithExampleInCookie"
-        }
-      ]
-    },
-    "ParameterWithSchemaWithExampleInPath": {
       "type": "object",
-      "required": ["name", "in", "schema", "required"],
       "properties": {
         "name": {
           "type": "string"
         },
         "in": {
-          "type": "string",
-          "enum": ["path"]
-        },
-        "description": {
           "type": "string"
-        },
-        "required": {
-          "type": "boolean",
-          "enum": [true]
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "allowEmptyValue": {
-          "type": "boolean",
-          "default": false
-        },
-        "style": {
-          "type": "string",
-          "enum": ["matrix", "label", "simple"],
-          "default": "simple"
-        },
-        "explode": {
-          "type": "boolean"
-        },
-        "allowReserved": {
-          "type": "boolean",
-          "default": false
-        },
-        "schema": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Schema"
-            },
-            {
-              "$ref": "#/definitions/Reference"
-            }
-          ]
-        },
-        "example": {}
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "ParameterWithSchemaWithExampleInQuery": {
-      "type": "object",
-      "required": ["name", "in", "schema"],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "in": {
-          "type": "string",
-          "enum": ["query"]
         },
         "description": {
           "type": "string"
@@ -1205,9 +1102,7 @@
           "default": false
         },
         "style": {
-          "type": "string",
-          "enum": ["form", "spaceDelimited", "pipeDelimited", "deepObject"],
-          "default": "form"
+          "type": "string"
         },
         "explode": {
           "type": "boolean"
@@ -1225,443 +1120,6 @@
               "$ref": "#/definitions/Reference"
             }
           ]
-        },
-        "example": {}
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "ParameterWithSchemaWithExampleInHeader": {
-      "type": "object",
-      "required": ["name", "in", "schema"],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "in": {
-          "type": "string",
-          "enum": ["header"]
-        },
-        "description": {
-          "type": "string"
-        },
-        "required": {
-          "type": "boolean",
-          "default": false
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "allowEmptyValue": {
-          "type": "boolean",
-          "default": false
-        },
-        "style": {
-          "type": "string",
-          "enum": ["simple"],
-          "default": "simple"
-        },
-        "explode": {
-          "type": "boolean"
-        },
-        "allowReserved": {
-          "type": "boolean",
-          "default": false
-        },
-        "schema": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Schema"
-            },
-            {
-              "$ref": "#/definitions/Reference"
-            }
-          ]
-        },
-        "example": {}
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "ParameterWithSchemaWithExampleInCookie": {
-      "type": "object",
-      "required": ["name", "in", "schema"],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "in": {
-          "type": "string",
-          "enum": ["cookie"]
-        },
-        "description": {
-          "type": "string"
-        },
-        "required": {
-          "type": "boolean",
-          "default": false
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "allowEmptyValue": {
-          "type": "boolean",
-          "default": false
-        },
-        "style": {
-          "type": "string",
-          "enum": ["form"],
-          "default": "form"
-        },
-        "explode": {
-          "type": "boolean"
-        },
-        "allowReserved": {
-          "type": "boolean",
-          "default": false
-        },
-        "schema": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Schema"
-            },
-            {
-              "$ref": "#/definitions/Reference"
-            }
-          ]
-        },
-        "example": {}
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "ParameterWithSchemaWithExamples": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/ParameterWithSchemaWithExamplesInPath"
-        },
-        {
-          "$ref": "#/definitions/ParameterWithSchemaWithExamplesInQuery"
-        },
-        {
-          "$ref": "#/definitions/ParameterWithSchemaWithExamplesInHeader"
-        },
-        {
-          "$ref": "#/definitions/ParameterWithSchemaWithExamplesInCookie"
-        }
-      ]
-    },
-    "ParameterWithSchemaWithExamplesInPath": {
-      "type": "object",
-      "required": ["name", "in", "schema", "required", "examples"],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "in": {
-          "type": "string",
-          "enum": ["path"]
-        },
-        "description": {
-          "type": "string"
-        },
-        "required": {
-          "type": "boolean",
-          "enum": [true]
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "allowEmptyValue": {
-          "type": "boolean",
-          "default": false
-        },
-        "style": {
-          "type": "string",
-          "enum": ["matrix", "label", "simple"],
-          "default": "simple"
-        },
-        "explode": {
-          "type": "boolean"
-        },
-        "allowReserved": {
-          "type": "boolean",
-          "default": false
-        },
-        "schema": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Schema"
-            },
-            {
-              "$ref": "#/definitions/Reference"
-            }
-          ]
-        },
-        "examples": {
-          "type": "object",
-          "additionalProperties": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/Example"
-              },
-              {
-                "$ref": "#/definitions/Reference"
-              }
-            ]
-          }
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "ParameterWithSchemaWithExamplesInQuery": {
-      "type": "object",
-      "required": ["name", "in", "schema", "examples"],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "in": {
-          "type": "string",
-          "enum": ["query"]
-        },
-        "description": {
-          "type": "string"
-        },
-        "required": {
-          "type": "boolean",
-          "default": false
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "allowEmptyValue": {
-          "type": "boolean",
-          "default": false
-        },
-        "style": {
-          "type": "string",
-          "enum": ["form", "spaceDelimited", "pipeDelimited", "deepObject"],
-          "default": "form"
-        },
-        "explode": {
-          "type": "boolean"
-        },
-        "allowReserved": {
-          "type": "boolean",
-          "default": false
-        },
-        "schema": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Schema"
-            },
-            {
-              "$ref": "#/definitions/Reference"
-            }
-          ]
-        },
-        "examples": {
-          "type": "object",
-          "additionalProperties": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/Example"
-              },
-              {
-                "$ref": "#/definitions/Reference"
-              }
-            ]
-          }
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "ParameterWithSchemaWithExamplesInHeader": {
-      "type": "object",
-      "required": ["name", "in", "schema", "examples"],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "in": {
-          "type": "string",
-          "enum": ["header"]
-        },
-        "description": {
-          "type": "string"
-        },
-        "required": {
-          "type": "boolean",
-          "default": false
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "allowEmptyValue": {
-          "type": "boolean",
-          "default": false
-        },
-        "style": {
-          "type": "string",
-          "enum": ["simple"],
-          "default": "simple"
-        },
-        "explode": {
-          "type": "boolean"
-        },
-        "allowReserved": {
-          "type": "boolean",
-          "default": false
-        },
-        "schema": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Schema"
-            },
-            {
-              "$ref": "#/definitions/Reference"
-            }
-          ]
-        },
-        "examples": {
-          "type": "object",
-          "additionalProperties": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/Example"
-              },
-              {
-                "$ref": "#/definitions/Reference"
-              }
-            ]
-          }
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "ParameterWithSchemaWithExamplesInCookie": {
-      "type": "object",
-      "required": ["name", "in", "schema", "examples"],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "in": {
-          "type": "string",
-          "enum": ["cookie"]
-        },
-        "description": {
-          "type": "string"
-        },
-        "required": {
-          "type": "boolean",
-          "default": false
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "allowEmptyValue": {
-          "type": "boolean",
-          "default": false
-        },
-        "style": {
-          "type": "string",
-          "enum": ["form"],
-          "default": "form"
-        },
-        "explode": {
-          "type": "boolean"
-        },
-        "allowReserved": {
-          "type": "boolean",
-          "default": false
-        },
-        "schema": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Schema"
-            },
-            {
-              "$ref": "#/definitions/Reference"
-            }
-          ]
-        },
-        "examples": {
-          "type": "object",
-          "additionalProperties": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/Example"
-              },
-              {
-                "$ref": "#/definitions/Reference"
-              }
-            ]
-          }
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "ParameterWithContent": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/ParameterWithContentInPath"
-        },
-        {
-          "$ref": "#/definitions/ParameterWithContentNotInPath"
-        }
-      ]
-    },
-    "ParameterWithContentInPath": {
-      "type": "object",
-      "required": ["name", "in", "content"],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "in": {
-          "type": "string",
-          "enum": ["path"]
-        },
-        "description": {
-          "type": "string"
-        },
-        "required": {
-          "type": "boolean",
-          "enum": [true]
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "allowEmptyValue": {
-          "type": "boolean",
-          "default": false
         },
         "content": {
           "type": "object",
@@ -1670,56 +1128,131 @@
           },
           "minProperties": 1,
           "maxProperties": 1
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "ParameterWithContentNotInPath": {
-      "type": "object",
-      "required": ["name", "in", "content"],
-      "properties": {
-        "name": {
-          "type": "string"
         },
-        "in": {
-          "type": "string",
-          "enum": ["query", "header", "cookie"]
+        "example": {
         },
-        "description": {
-          "type": "string"
-        },
-        "required": {
-          "type": "boolean",
-          "default": false
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "allowEmptyValue": {
-          "type": "boolean",
-          "default": false
-        },
-        "content": {
+        "examples": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/MediaType"
-          },
-          "minProperties": 1,
-          "maxProperties": 1
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Example"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "in"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExampleXORExamples"
+        },
+        {
+          "$ref": "#/definitions/SchemaXORContent"
+        },
+        {
+          "$ref": "#/definitions/ParameterLocation"
+        }
+      ]
+    },
+    "ParameterLocation": {
+      "description": "Parameter location",
+      "oneOf": [
+        {
+          "description": "Parameter in path",
+          "required": [
+            "required"
+          ],
+          "properties": {
+            "in": {
+              "enum": [
+                "path"
+              ]
+            },
+            "style": {
+              "enum": [
+                "matrix",
+                "label",
+                "simple"
+              ],
+              "default": "simple"
+            },
+            "required": {
+              "enum": [
+                true
+              ]
+            }
+          }
+        },
+        {
+          "description": "Parameter in query",
+          "properties": {
+            "in": {
+              "enum": [
+                "query"
+              ]
+            },
+            "style": {
+              "enum": [
+                "form",
+                "spaceDelimited",
+                "pipeDelimited",
+                "deepObject"
+              ],
+              "default": "form"
+            }
+          }
+        },
+        {
+          "description": "Parameter in header",
+          "properties": {
+            "in": {
+              "enum": [
+                "header"
+              ]
+            },
+            "style": {
+              "enum": [
+                "simple"
+              ],
+              "default": "simple"
+            }
+          }
+        },
+        {
+          "description": "Parameter in cookie",
+          "properties": {
+            "in": {
+              "enum": [
+                "cookie"
+              ]
+            },
+            "style": {
+              "enum": [
+                "form"
+              ],
+              "default": "form"
+            }
+          }
+        }
+      ]
     },
     "RequestBody": {
       "type": "object",
-      "required": ["content"],
+      "required": [
+        "content"
+      ],
       "properties": {
         "description": {
           "type": "string"
@@ -1736,7 +1269,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -1758,98 +1292,109 @@
     },
     "APIKeySecurityScheme": {
       "type": "object",
-      "required": ["type", "name", "in"],
+      "required": [
+        "type",
+        "name",
+        "in"
+      ],
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["apiKey"]
+          "enum": [
+            "apiKey"
+          ]
         },
         "name": {
           "type": "string"
         },
         "in": {
           "type": "string",
-          "enum": ["header", "query", "cookie"]
+          "enum": [
+            "header",
+            "query",
+            "cookie"
+          ]
         },
         "description": {
           "type": "string"
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
     "HTTPSecurityScheme": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/NonBearerHTTPSecurityScheme"
-        },
-        {
-          "$ref": "#/definitions/BearerHTTPSecurityScheme"
-        }
-      ]
-    },
-    "NonBearerHTTPSecurityScheme": {
-      "not": {
-        "type": "object",
-        "properties": {
-          "scheme": {
-            "type": "string",
-            "enum": ["bearer"]
-          }
-        }
-      },
       "type": "object",
-      "required": ["scheme", "type"],
+      "required": [
+        "scheme",
+        "type"
+      ],
       "properties": {
         "scheme": {
           "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string",
-          "enum": ["http"]
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "BearerHTTPSecurityScheme": {
-      "type": "object",
-      "required": ["type", "scheme"],
-      "properties": {
-        "scheme": {
-          "type": "string",
-          "enum": ["bearer"]
         },
         "bearerFormat": {
           "type": "string"
         },
-        "type": {
-          "type": "string",
-          "enum": ["http"]
-        },
         "description": {
           "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "http"
+          ]
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "oneOf": [
+        {
+          "description": "Bearer",
+          "properties": {
+            "scheme": {
+              "enum": [
+                "bearer"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Non Bearer",
+          "not": {
+            "required": [
+              "bearerFormat"
+            ]
+          },
+          "properties": {
+            "scheme": {
+              "not": {
+                "enum": [
+                  "bearer"
+                ]
+              }
+            }
+          }
+        }
+      ]
     },
     "OAuth2SecurityScheme": {
       "type": "object",
-      "required": ["type", "flows"],
+      "required": [
+        "type",
+        "flows"
+      ],
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["oauth2"]
+          "enum": [
+            "oauth2"
+          ]
         },
         "flows": {
           "$ref": "#/definitions/OAuthFlows"
@@ -1859,28 +1404,35 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
     "OpenIdConnectSecurityScheme": {
       "type": "object",
-      "required": ["type", "openIdConnectUrl"],
+      "required": [
+        "type",
+        "openIdConnectUrl"
+      ],
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["openIdConnect"]
+          "enum": [
+            "openIdConnect"
+          ]
         },
         "openIdConnectUrl": {
           "type": "string",
-          "format": "url"
+          "format": "uri-reference"
         },
         "description": {
           "type": "string"
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -1901,13 +1453,17 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
     "ImplicitOAuthFlow": {
       "type": "object",
-      "required": ["authorizationUrl", "scopes"],
+      "required": [
+        "authorizationUrl",
+        "scopes"
+      ],
       "properties": {
         "authorizationUrl": {
           "type": "string",
@@ -1925,13 +1481,16 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
     "PasswordOAuthFlow": {
       "type": "object",
-      "required": ["tokenUrl"],
+      "required": [
+        "tokenUrl"
+      ],
       "properties": {
         "tokenUrl": {
           "type": "string",
@@ -1949,13 +1508,16 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
     "ClientCredentialsFlow": {
       "type": "object",
-      "required": ["tokenUrl"],
+      "required": [
+        "tokenUrl"
+      ],
       "properties": {
         "tokenUrl": {
           "type": "string",
@@ -1973,13 +1535,17 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
     "AuthorizationCodeOAuthFlow": {
       "type": "object",
-      "required": ["authorizationUrl", "tokenUrl"],
+      "required": [
+        "authorizationUrl",
+        "tokenUrl"
+      ],
       "properties": {
         "authorizationUrl": {
           "type": "string",
@@ -2001,32 +1567,28 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
     "Link": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/LinkWithOperationRef"
-        },
-        {
-          "$ref": "#/definitions/LinkWithOperationId"
-        }
-      ]
-    },
-    "LinkWithOperationRef": {
       "type": "object",
       "properties": {
+        "operationId": {
+          "type": "string"
+        },
         "operationRef": {
           "type": "string",
           "format": "uri-reference"
         },
         "parameters": {
           "type": "object",
-          "additionalProperties": {}
+          "additionalProperties": {
+          }
         },
-        "requestBody": {},
+        "requestBody": {
+        },
         "description": {
           "type": "string"
         },
@@ -2035,32 +1597,17 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "LinkWithOperationId": {
-      "type": "object",
-      "properties": {
-        "operationId": {
-          "type": "string"
-        },
-        "parameters": {
-          "type": "object",
-          "additionalProperties": {}
-        },
-        "requestBody": {},
-        "description": {
-          "type": "string"
-        },
-        "server": {
-          "$ref": "#/definitions/Server"
+        "^x-": {
         }
       },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "not": {
+        "description": "Operation Id and Operation Ref are mutually exclusive",
+        "required": [
+          "operationId",
+          "operationRef"
+        ]
+      }
     },
     "Callback": {
       "type": "object",
@@ -2068,7 +1615,8 @@
         "$ref": "#/definitions/PathItem"
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       }
     },
     "Encoding": {
@@ -2085,7 +1633,12 @@
         },
         "style": {
           "type": "string",
-          "enum": ["form", "spaceDelimited", "pipeDelimited", "deepObject"]
+          "enum": [
+            "form",
+            "spaceDelimited",
+            "pipeDelimited",
+            "deepObject"
+          ]
         },
         "explode": {
           "type": "boolean"


### PR DESCRIPTION
### What kind of change does this PR introduce?

Kinda a feature I suppose. OpenAPI v3.0 has a proper metaschema now and have done for a few months, but we're still using the one grabbed from the PR a loooong time ago.

### What is the current behavior?

Validates OpenAPI 3.0 description files properly I hope.

### If this is a feature change, what is the new behavior?

It should validate openapi 3.0 :D