### PR TITLE
Release only when a tag is published

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ workflows:
               only: master
       - upload_artifacts:
           filters:
-            branches:
-              only: master
+            tags:
+              only: /^v.*/          
           requires:
             - release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,6 @@ workflows:
       - upload_artifacts:
           filters:
             tags:
-              only: /^v.*/          
+              only: /^v.*/
           requires:
             - release


### PR DESCRIPTION
This will need to be tested somehow when we'll cut the real release. If you could ping me when this happens that'd be great.