### PR TITLE
feat: remove deprecated IRule & IRuleResult summary property

### DIFF
--- a/docs/js-api.md
+++ b/docs/js-api.md
@@ -83,7 +83,6 @@ oas3Rules()
     },
     {
         "code": "info-contact",
-        "summary": "Info object should contain `contact` object.",
         "message": "Info object should contain `contact` object.",
         "path": [
             "info",
@@ -103,7 +102,6 @@ oas3Rules()
     },
     {
         "code": "info-description",
-        "summary": "OpenAPI object info `description` must be present and non-empty string.",
         "message": "OpenAPI object info `description` must be present and non-empty string.",
         "path": [
             "info",
@@ -123,7 +121,6 @@ oas3Rules()
     },
     {
         "code": "oas3-schema",
-        "summary": "should NOT have additional properties: responses",
         "message": "should NOT have additional properties: responses",
         "path": [],
         "severity": 0,
@@ -140,7 +137,6 @@ oas3Rules()
     },
     {
         "code": "api-servers",
-        "summary": "OpenAPI `servers` must be present and non-empty array.",
         "message": "OpenAPI `servers` must be present and non-empty array.",
         "path": [
             "servers"
@@ -180,7 +176,7 @@ const spectral = new Spectral();
 
 spectral.addRules({
   snake_case: {
-    summary: 'Checks for snake case pattern',
+    description: 'Checks for snake case pattern',
 
     // evaluate every property
     given: '$..*',
@@ -206,7 +202,6 @@ spectral.run({name: 'helloWorld',}).then(results => {
 [
     {
         "code": "snake_case",
-        "summary": "Checks for snake case pattern",
         "message": "Checks for snake case pattern",
         "path": [
             "name"
@@ -255,7 +250,7 @@ spectral.addFunctions({
 
 spectral.addRules({
   openapi_not_swagger: {
-    summary: 'Checks for use of Swagger, and suggests OpenAPI.',
+    description: 'Checks for use of Swagger, and suggests OpenAPI.',
 
     // check every property
     given: '$..*',
@@ -286,7 +281,6 @@ spectral.run({description: 'Swagger is pretty cool!',}).then(results => {
 [
     {
         "code": "openapi_not_swagger",
-        "summary": "Checks for use of Swagger, and suggests OpenAPI.",
         "message": "Checks for use of Swagger, and suggests OpenAPI.",
         "path": [
             "description"

--- a/src/__tests__/functions.test.ts
+++ b/src/__tests__/functions.test.ts
@@ -16,7 +16,7 @@ describe('functions', () => {
       expect(
         applyRuleToObject(
           {
-            summary: '',
+            message: '',
             given: '$.info',
             then: {
               function: RuleFunction.XOR,
@@ -39,7 +39,7 @@ describe('functions', () => {
       expect(
         applyRuleToObject(
           {
-            summary: '',
+            message: '',
             given: '$.info',
             then: {
               function: RuleFunction.XOR,
@@ -62,7 +62,7 @@ describe('functions', () => {
       expect(
         applyRuleToObject(
           {
-            summary: '',
+            message: '',
             given: '$.info',
             then: {
               function: RuleFunction.XOR,
@@ -87,7 +87,7 @@ describe('functions', () => {
       expect(
         applyRuleToObject(
           {
-            summary: '',
+            message: '',
             given: '$.info',
             then: {
               field: 'termsOfService',
@@ -110,7 +110,7 @@ describe('functions', () => {
       expect(
         applyRuleToObject(
           {
-            summary: '',
+            message: '',
             given: '$.responses',
             then: {
               field: '@key',
@@ -139,7 +139,7 @@ describe('functions', () => {
       expect(
         applyRuleToObject(
           {
-            summary: '',
+            message: '',
             given: '$.info.termsOfService',
             then: {
               function: RuleFunction.PATTERN,
@@ -161,7 +161,7 @@ describe('functions', () => {
       expect(
         applyRuleToObject(
           {
-            summary: '',
+            message: '',
             given: '$.responses',
             then: {
               field: '@key',
@@ -211,7 +211,7 @@ describe('functions', () => {
       expect(
         applyRuleToObject(
           {
-            summary: '',
+            message: '',
             given: '$..val',
             then: [
               {
@@ -235,7 +235,7 @@ describe('functions', () => {
       expect(
         applyRuleToObject(
           {
-            summary: '',
+            message: '',
             given: '$..val',
             then: [
               {
@@ -259,7 +259,7 @@ describe('functions', () => {
       expect(
         applyRuleToObject(
           {
-            summary: '',
+            message: '',
             given: '$..val',
             then: {
               function: RuleFunction.LENGTH,

--- a/src/__tests__/linter.test.ts
+++ b/src/__tests__/linter.test.ts
@@ -34,7 +34,7 @@ const target = {
 };
 const rules = {
   example: {
-    summary: '',
+    message: '',
     given: '$.responses',
     then: {
       function: fnName,
@@ -347,7 +347,7 @@ responses:: !!foo
       test('should pass through root object', async () => {
         spectral.addRules({
           example: {
-            summary: '',
+            message: '',
             given: '$',
             then: {
               function: fnName,
@@ -485,7 +485,7 @@ responses:: !!foo
       });
       spectral.addRules({
         example: {
-          summary: '',
+          message: '',
           given: '$.responses',
           then: [
             {
@@ -528,7 +528,7 @@ responses:: !!foo
       test('should call each one with the appropriate args', async () => {
         spectral.addRules({
           example: {
-            summary: '',
+            message: '',
             given: '$.responses',
             then: {
               field: '$..description',

--- a/src/__tests__/spectral.test.ts
+++ b/src/__tests__/spectral.test.ts
@@ -38,7 +38,7 @@ describe('spectral', () => {
       s.addRules({
         // @ts-ignore
         rule1: {
-          summary: '',
+          message: '',
           given: '$',
           severity: DiagnosticSeverity.Warning,
           then: {
@@ -49,7 +49,7 @@ describe('spectral', () => {
 
       s.mergeRules({
         rule2: {
-          summary: '',
+          message: '',
           given: '$',
           then: {
             function: RuleFunction.TRUTHY,
@@ -78,7 +78,7 @@ describe('spectral', () => {
         s.addRules({
           // @ts-ignore
           rule1: {
-            summary: '',
+            message: '',
             given: '$',
             recommended: false,
             then: {

--- a/src/cli/commands/__tests__/__fixtures__/ruleset-extends-invalid.yaml
+++ b/src/cli/commands/__tests__/__fixtures__/ruleset-extends-invalid.yaml
@@ -2,7 +2,7 @@ extends:
   - ruleset-invalid.yaml
 rules:
   no-swagger:
-    summary: Use OpenAPI instead ;)
+    message: Use OpenAPI instead ;)
     given: $..*
     type: style
     then:      

--- a/src/cli/commands/__tests__/__fixtures__/ruleset-extends-valid.yaml
+++ b/src/cli/commands/__tests__/__fixtures__/ruleset-extends-valid.yaml
@@ -2,7 +2,7 @@ extends:
   - ./ruleset-valid.yaml
 rules:
   no-swagger:
-    summary: Use OpenAPI instead ;)
+    message: Use OpenAPI instead ;)
     given: $..*
     type: style
     then:      

--- a/src/cli/commands/__tests__/__fixtures__/ruleset-invalid.yaml
+++ b/src/cli/commands/__tests__/__fixtures__/ruleset-invalid.yaml
@@ -1,8 +1,8 @@
 rules:
   rule-without-given-nor-them:
-    summary: 'deliberetely invalid'
+    message: 'deliberetely invalid'
   valid-rule:
-    summary: 'should be OK'
+    message: 'should be OK'
     given: '$.info'
     then:
       function: 'truthy'

--- a/src/cli/commands/__tests__/__fixtures__/ruleset-invalid.yaml
+++ b/src/cli/commands/__tests__/__fixtures__/ruleset-invalid.yaml
@@ -1,6 +1,6 @@
 rules:
   rule-without-given-nor-them:
-    message: 'deliberetely invalid'
+    message: 'deliberately invalid'
   valid-rule:
     message: 'should be OK'
     given: '$.info'

--- a/src/cli/commands/__tests__/__fixtures__/ruleset-valid.yaml
+++ b/src/cli/commands/__tests__/__fixtures__/ruleset-valid.yaml
@@ -1,6 +1,6 @@
 rules:
   info-matches-stoplight:
-    summary: Info must contain Stoplight
+    message: Info must contain Stoplight
     given: $.info
     type: style
     then:

--- a/src/cli/commands/__tests__/__fixtures__/spectral.yml
+++ b/src/cli/commands/__tests__/__fixtures__/spectral.yml
@@ -1,6 +1,6 @@
 rules:
   info-matches-stoplight:
-    summary: Info must contain Stoplight
+    message: Info must contain Stoplight
     given: $.info
     type: style
     then:

--- a/src/formatters/__tests__/json.test.ts
+++ b/src/formatters/__tests__/json.test.ts
@@ -4,7 +4,6 @@ import { json } from '../json';
 const results: IRuleResult[] = [
   {
     code: 'operation-description',
-    summary: 'Operation `description` must be present and non-empty string.',
     message: 'paths./pets.get.description is not truthy',
     path: ['paths', '/pets', 'get', 'description'],
     severity: 1,
@@ -22,7 +21,6 @@ const results: IRuleResult[] = [
   },
   {
     code: 'operation-tags',
-    summary: 'Operation should have non-empty `tags` array.',
     message: 'paths./pets.get.tags is not truthy',
     path: ['paths', '/pets', 'get', 'tags'],
     severity: 1,
@@ -70,13 +68,13 @@ describe('JSON formatter', () => {
     ]);
   });
 
-  test('should include summary', () => {
+  test('should include message', () => {
     expect(JSON.parse(json(results))).toEqual([
       expect.objectContaining({
-        summary: 'Operation `description` must be present and non-empty string.',
+        message: 'paths./pets.get.description is not truthy',
       }),
       expect.objectContaining({
-        summary: 'Operation should have non-empty `tags` array.',
+        message: 'paths./pets.get.tags is not truthy',
       }),
     ]);
   });

--- a/src/formatters/json.ts
+++ b/src/formatters/json.ts
@@ -6,7 +6,6 @@ export const json = (results: IRuleResult[]): string => {
       code: result.code,
       path: result.path,
       message: result.message,
-      summary: result.summary,
       severity: result.severity,
       range: result.range,
       source: result.source,

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -113,21 +113,16 @@ export const lintNode = (
     // NOTE: we might want to normalize that during merging (once we have it in place)
 
     results = results.concat(
-      targetResults.map(result => {
+      targetResults.map<IRuleResult>(result => {
         const path = result.path || targetPath;
         const location = resolved.getLocationForJsonPath(path, true);
 
         return {
           code: rule.name,
 
-          // @deprecated, points to message
-          get summary() {
-            return this.message;
-          },
-
           message:
             rule.message === undefined
-              ? rule.summary || result.message
+              ? rule.description || result.message
               : message(rule.message, {
                   error: result.message,
                   property: path.length > 0 ? path[path.length - 1] : '',

--- a/src/meta/rule.schema.json
+++ b/src/meta/rule.schema.json
@@ -57,7 +57,7 @@
             ],
             "type": "number"
         },
-        "summary": {
+        "message": {
             "type": "string"
         },
         "tags": {

--- a/src/rulesets/__tests__/__fixtures__/extends-oas2-ruleset.json
+++ b/src/rulesets/__tests__/__fixtures__/extends-oas2-ruleset.json
@@ -2,7 +2,7 @@
   "extends": [["spectral:oas2", "all"]],
   "rules": {
     "valid-rule": {
-      "summary": "should be OK",
+      "message": "should be OK",
       "given": "$.info",
       "then": {
         "function": "truthy"

--- a/src/rulesets/__tests__/__fixtures__/extends-oas2-with-override-ruleset.json
+++ b/src/rulesets/__tests__/__fixtures__/extends-oas2-with-override-ruleset.json
@@ -3,7 +3,7 @@
   "rules": {
     "operation-security-defined": "off",
     "operation-2xx-response": {
-      "summary": "should be OK",
+      "description": "should be overridden",
       "given": "$.info",
       "then": {
         "function": "truthy"

--- a/src/rulesets/__tests__/__fixtures__/invalid-ruleset.json
+++ b/src/rulesets/__tests__/__fixtures__/invalid-ruleset.json
@@ -1,10 +1,10 @@
 {
   "rules": {
     "no-given-no-then": {
-      "summary": "deliberetely invalid"
+      "message": "deliberetely invalid"
     },
     "valid-rule": {
-      "summary": "should be OK",
+      "message": "should be OK",
       "given": "$.info",
       "then": {
         "function": "truthy"

--- a/src/rulesets/__tests__/__fixtures__/valid-flat-ruleset.json
+++ b/src/rulesets/__tests__/__fixtures__/valid-flat-ruleset.json
@@ -1,7 +1,7 @@
 {
   "rules": {
     "valid-rule": {
-      "summary": "should be OK",
+      "message": "should be OK",
       "given": "$.info",
       "then": {
         "function": "truthy"

--- a/src/rulesets/__tests__/__fixtures__/valid-require-info-ruleset.yaml
+++ b/src/rulesets/__tests__/__fixtures__/valid-require-info-ruleset.yaml
@@ -1,6 +1,6 @@
 rules:
   require-info:
-    summary: should be OK
+    message: should be OK
     given: "$.info"
     then:
       function: truthy

--- a/src/rulesets/__tests__/merger.unit.ts
+++ b/src/rulesets/__tests__/merger.unit.ts
@@ -4,7 +4,7 @@ import { mergeRulesets } from '../merger';
 
 describe('Rulesets merger', () => {
   const baseRule: IRule = {
-    summary: 'Operation must have at least one `2xx` response.',
+    message: 'Operation must have at least one `2xx` response.',
     given:
       "$..paths.*[?( @property === 'get' || @property === 'put' || @property === 'post' || @property === 'delete' || @property === 'options' || @property === 'head' || @property === 'patch' || @property === 'trace' )]",
     then: {
@@ -93,7 +93,7 @@ describe('Rulesets merger', () => {
     mergeRulesets(ruleset, {
       rules: {
         test: {
-          summary: 'Operation must have at least one `2xx` response.',
+          message: 'Operation must have at least one `2xx` response.',
           given:
             "$..paths.*[?( @property === 'get' || @property === 'put' || @property === 'post' || @property === 'delete' || @property === 'options' || @property === 'head' || @property === 'patch' || @property === 'trace' )]",
           then: {
@@ -118,7 +118,7 @@ describe('Rulesets merger', () => {
     mergeRulesets(ruleset, {
       rules: {
         test: {
-          summary: 'Operation must have at least one `2xx` response.',
+          message: 'Operation must have at least one `2xx` response.',
           given:
             "$..paths.*[?( @property === 'get' || @property === 'put' || @property === 'post' || @property === 'delete' || @property === 'options' || @property === 'head' || @property === 'patch' || @property === 'trace' )]",
           then: {

--- a/src/rulesets/__tests__/reader.test.ts
+++ b/src/rulesets/__tests__/reader.test.ts
@@ -17,7 +17,7 @@ describe('Rulesets reader', () => {
     expect(await readRulesFromRulesets(validFlatRuleset)).toEqual({
       'valid-rule': {
         given: '$.info',
-        summary: 'should be OK',
+        message: 'should be OK',
         severity: DiagnosticSeverity.Warning,
         then: {
           function: 'truthy',
@@ -30,7 +30,7 @@ describe('Rulesets reader', () => {
     expect(await readRulesFromRulesets(validFlatRuleset, validFlatRuleset2)).toEqual({
       'valid-rule': {
         given: '$.info',
-        summary: 'should be OK',
+        message: 'should be OK',
         severity: DiagnosticSeverity.Warning,
         then: {
           function: 'truthy',
@@ -38,7 +38,7 @@ describe('Rulesets reader', () => {
       },
       'require-info': {
         given: '$.info',
-        summary: 'should be OK',
+        message: 'should be OK',
         severity: DiagnosticSeverity.Warning,
         then: {
           function: 'truthy',
@@ -63,7 +63,7 @@ describe('Rulesets reader', () => {
 
       'valid-rule': {
         given: '$.info',
-        summary: 'should be OK',
+        message: 'should be OK',
         severity: DiagnosticSeverity.Warning,
         then: {
           function: 'truthy',
@@ -76,7 +76,7 @@ describe('Rulesets reader', () => {
     return expect(readRulesFromRulesets(extendsOas2WithOverrideRuleset)).resolves.toHaveProperty(
       'operation-2xx-response',
       {
-        summary: 'should be OK',
+        description: 'should be overridden',
         given: '$.info',
         recommended: true,
         severity: DiagnosticSeverity.Warning,
@@ -96,7 +96,7 @@ describe('Rulesets reader', () => {
         given: '$',
         recommended: true,
         severity: 'off',
-        summary: 'Operation `security` values must match a scheme defined in the `securityDefinitions` object.',
+        description: 'Operation `security` values must match a scheme defined in the `securityDefinitions` object.',
         tags: ['operation'],
         then: {
           function: 'oasOpSecurityDefined',

--- a/src/rulesets/oas/__tests__/contact-properties.ts
+++ b/src/rulesets/oas/__tests__/contact-properties.ts
@@ -49,7 +49,6 @@ describe('contact-properties', () => {
         },
         severity: 1,
         source: undefined,
-        summary: 'Contact object should have `name`, `url` and `email`.',
       },
       {
         code: 'contact-properties',
@@ -66,7 +65,6 @@ describe('contact-properties', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'Contact object should have `name`, `url` and `email`.',
       },
       {
         code: 'contact-properties',
@@ -83,7 +81,6 @@ describe('contact-properties', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'Contact object should have `name`, `url` and `email`.',
       },
     ]);
   });

--- a/src/rulesets/oas/__tests__/example-value-or-externalValue.ts
+++ b/src/rulesets/oas/__tests__/example-value-or-externalValue.ts
@@ -39,7 +39,6 @@ describe('example-value-or-externalValue', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'Example should have either a `value` or `externalValue` field.',
       },
     ]);
   });
@@ -62,7 +61,6 @@ describe('example-value-or-externalValue', () => {
           },
         },
         severity: 1,
-        summary: 'Example should have either a `value` or `externalValue` field.',
       },
     ]);
   });

--- a/src/rulesets/oas/__tests__/info-contact.ts
+++ b/src/rulesets/oas/__tests__/info-contact.ts
@@ -42,7 +42,6 @@ describe('info-contact', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'Info object should contain `contact` object.',
       },
     ]);
   });

--- a/src/rulesets/oas/__tests__/info-description.ts
+++ b/src/rulesets/oas/__tests__/info-description.ts
@@ -42,7 +42,6 @@ describe('info-description', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'OpenAPI object info `description` must be present and non-empty string.',
       },
     ]);
   });

--- a/src/rulesets/oas/__tests__/info-license.ts
+++ b/src/rulesets/oas/__tests__/info-license.ts
@@ -46,7 +46,6 @@ describe('info-license', () => {
           },
         },
         severity: 1,
-        summary: 'OpenAPI object info `license` must be present and non-empty string.',
       },
     ]);
   });

--- a/src/rulesets/oas/__tests__/license-url.ts
+++ b/src/rulesets/oas/__tests__/license-url.ts
@@ -46,7 +46,6 @@ describe('license-url', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'License object should include `url`.',
       },
     ]);
   });

--- a/src/rulesets/oas/__tests__/no-eval-in-markdown.ts
+++ b/src/rulesets/oas/__tests__/no-eval-in-markdown.ts
@@ -48,7 +48,6 @@ describe('no-eval-in-markdown', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'Markdown descriptions should not contain `eval(`.',
       },
       {
         code: 'no-eval-in-markdown',
@@ -65,7 +64,6 @@ describe('no-eval-in-markdown', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'Markdown descriptions should not contain `eval(`.',
       },
     ]);
   });

--- a/src/rulesets/oas/__tests__/no-script-tags-in-markdown.ts
+++ b/src/rulesets/oas/__tests__/no-script-tags-in-markdown.ts
@@ -46,7 +46,6 @@ describe('no-script-tags-in-markdown', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'Markdown descriptions should not contain `<script>` tags.',
       },
     ]);
   });

--- a/src/rulesets/oas/__tests__/openapi-tags-alphabetical.ts
+++ b/src/rulesets/oas/__tests__/openapi-tags-alphabetical.ts
@@ -42,7 +42,6 @@ describe('openapi-tags-alphabetical', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'OpenAPI object should have alphabetical `tags`.',
       },
     ]);
   });

--- a/src/rulesets/oas/__tests__/openapi-tags.ts
+++ b/src/rulesets/oas/__tests__/openapi-tags.ts
@@ -41,7 +41,6 @@ describe('openapi-tags', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'OpenAPI object should have non-empty `tags` array.',
       },
     ]);
   });

--- a/src/rulesets/oas/__tests__/operation-2xx-response.ts
+++ b/src/rulesets/oas/__tests__/operation-2xx-response.ts
@@ -91,7 +91,7 @@ describe('operation-2xx-response', () => {
     expect(results).toEqual([
       expect.objectContaining({
         code: 'operation-2xx-response',
-        summary: 'Operation must have at least one `2xx` response.',
+        message: 'Operation must have at least one `2xx` response.',
         path: ['paths', '/path', 'get', 'responses'],
       }),
     ]);

--- a/src/rulesets/oas/__tests__/operation-default-response.ts
+++ b/src/rulesets/oas/__tests__/operation-default-response.ts
@@ -56,7 +56,6 @@ describe('operation-default-response', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'Operations must have a default response.',
       },
     ]);
   });

--- a/src/rulesets/oas/__tests__/operation-description.ts
+++ b/src/rulesets/oas/__tests__/operation-description.ts
@@ -50,7 +50,6 @@ describe('operation-description', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'Operation `description` must be present and non-empty string.',
       },
     ]);
   });

--- a/src/rulesets/oas/__tests__/operation-operationId-valid-in-url.ts
+++ b/src/rulesets/oas/__tests__/operation-operationId-valid-in-url.ts
@@ -52,7 +52,6 @@ describe('operation-operationId-valid-in-url', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'operationId may only use characters that are valid when used in a URL.',
       },
     ]);
   });

--- a/src/rulesets/oas/__tests__/operation-operationId.ts
+++ b/src/rulesets/oas/__tests__/operation-operationId.ts
@@ -50,7 +50,6 @@ describe('operation-operationId', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'Operation should have an `operationId`.',
       },
     ]);
   });

--- a/src/rulesets/oas/__tests__/operation-singular-tag.ts
+++ b/src/rulesets/oas/__tests__/operation-singular-tag.ts
@@ -52,7 +52,6 @@ describe('operation-singular-tag', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'Operation may only have one tag.',
       },
     ]);
   });

--- a/src/rulesets/oas/__tests__/operation-summary-formatted.ts
+++ b/src/rulesets/oas/__tests__/operation-summary-formatted.ts
@@ -52,7 +52,6 @@ describe('operation-summary-formatted', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'Operation `summary` should start with upper case and end with a dot.',
       },
     ]);
   });
@@ -84,7 +83,6 @@ describe('operation-summary-formatted', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'Operation `summary` should start with upper case and end with a dot.',
       },
     ]);
   });

--- a/src/rulesets/oas/__tests__/operation-tags.ts
+++ b/src/rulesets/oas/__tests__/operation-tags.ts
@@ -50,7 +50,6 @@ describe('operation-tags', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'Operation should have non-empty `tags` array.',
       },
     ]);
   });

--- a/src/rulesets/oas/__tests__/path-declarations-must-exist.ts
+++ b/src/rulesets/oas/__tests__/path-declarations-must-exist.ts
@@ -40,7 +40,6 @@ describe('path-declarations-must-exist', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'given declarations cannot be empty, ex.`/given/{}` is invalid.',
       },
     ]);
   });

--- a/src/rulesets/oas/__tests__/path-keys-no-trailing-slash.ts
+++ b/src/rulesets/oas/__tests__/path-keys-no-trailing-slash.ts
@@ -40,7 +40,6 @@ describe('path-keys-no-trailing-slash', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'given keys should not end with a slash.',
       },
     ]);
   });

--- a/src/rulesets/oas/__tests__/path-not-include-query.ts
+++ b/src/rulesets/oas/__tests__/path-not-include-query.ts
@@ -40,7 +40,6 @@ describe('path-not-include-query', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'given keys should not include a query string.',
       },
     ]);
   });

--- a/src/rulesets/oas/__tests__/tag-description.ts
+++ b/src/rulesets/oas/__tests__/tag-description.ts
@@ -42,7 +42,6 @@ describe('tag-description', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'Tag object should have a `description`.',
       },
     ]);
   });

--- a/src/rulesets/oas/functions/oasOp2xxResponse/__tests__/index.ts
+++ b/src/rulesets/oas/functions/oasOp2xxResponse/__tests__/index.ts
@@ -70,7 +70,6 @@ describe('oasOp2xxResponse', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'Operation must have at least one `2xx` response.',
       },
     ]);
   });
@@ -101,7 +100,6 @@ describe('oasOp2xxResponse', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'Operation must have at least one `2xx` response.',
       },
     ]);
   });

--- a/src/rulesets/oas/functions/oasOpFormDataConsumeCheck/__tests__/index.ts
+++ b/src/rulesets/oas/functions/oasOpFormDataConsumeCheck/__tests__/index.ts
@@ -58,8 +58,6 @@ describe('oasOpFormDataConsumeCheck', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary:
-          'Operations with an `in: formData` parameter must include `application/x-www-form-urlencoded` or `multipart/form-data` in their `consumes` property.',
       },
     ]);
   });

--- a/src/rulesets/oas/functions/oasOpIdUnique/__tests__/index.ts
+++ b/src/rulesets/oas/functions/oasOpIdUnique/__tests__/index.ts
@@ -67,7 +67,6 @@ describe('oasOpIdUnique', () => {
           },
         },
         severity: DiagnosticSeverity.Error,
-        summary: 'Every operation must have a unique `operationId`.',
       },
       {
         code: 'operation-operationId-unique',
@@ -84,7 +83,6 @@ describe('oasOpIdUnique', () => {
           },
         },
         severity: DiagnosticSeverity.Error,
-        summary: 'Every operation must have a unique `operationId`.',
       },
     ]);
   });
@@ -119,7 +117,6 @@ describe('oasOpIdUnique', () => {
           },
         },
         severity: DiagnosticSeverity.Error,
-        summary: 'Every operation must have a unique `operationId`.',
       },
       {
         code: 'operation-operationId-unique',
@@ -136,7 +133,6 @@ describe('oasOpIdUnique', () => {
           },
         },
         severity: DiagnosticSeverity.Error,
-        summary: 'Every operation must have a unique `operationId`.',
       },
     ]);
   });

--- a/src/rulesets/oas/functions/oasOpParams/__tests__/index.test.ts
+++ b/src/rulesets/oas/functions/oasOpParams/__tests__/index.test.ts
@@ -82,7 +82,6 @@ describe('oasOpParams', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'Operation parameters are unique and non-repeating.',
       },
     ]);
   });
@@ -123,7 +122,6 @@ describe('oasOpParams', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'Operation parameters are unique and non-repeating.',
       },
     ]);
   });
@@ -174,7 +172,6 @@ describe('oasOpParams', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'Operation parameters are unique and non-repeating.',
       },
     ]);
   });
@@ -205,7 +202,6 @@ describe('oasOpParams', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'Operation parameters are unique and non-repeating.',
       },
     ]);
   });

--- a/src/rulesets/oas/functions/oasOpSecurityDefined/__tests__/index.ts
+++ b/src/rulesets/oas/functions/oasOpSecurityDefined/__tests__/index.ts
@@ -71,7 +71,6 @@ describe('oasOpSecurityDefined', () => {
             },
           },
           severity: DiagnosticSeverity.Warning,
-          summary: 'Operation `security` values must match a scheme defined in the `securityDefinitions` object.',
         },
       ]);
     });
@@ -142,8 +141,6 @@ describe('oasOpSecurityDefined', () => {
             },
           },
           severity: DiagnosticSeverity.Warning,
-          summary:
-            'Operation `security` values must match a scheme defined in the `components.securitySchemes` object.',
         },
       ]);
     });

--- a/src/rulesets/oas/functions/oasPathParam/__tests__/index.test.ts
+++ b/src/rulesets/oas/functions/oasPathParam/__tests__/index.test.ts
@@ -51,8 +51,6 @@ describe('oasPathParam', () => {
           },
         },
         severity: DiagnosticSeverity.Error,
-        summary:
-          'The path "**/foo/{bar}**" uses a parameter "**{bar}**" that does not have a corresponding definition.\n\nTo fix, add a path parameter with the name "**bar**".',
       },
     ]);
   });
@@ -150,18 +148,8 @@ To fix, update the path so that all parameter names are unique.`,
           },
         },
         severity: DiagnosticSeverity.Error,
-        summary: `The path "**/foo/{bar}/{bar}**" uses the parameter "**{bar}**" multiple times.\n
-Path parameters must be unique.\n
-To fix, update the path so that all parameter names are unique.`,
       },
     ]);
-
-    expect(results[0].path).toEqual(['paths', '/foo/{bar}/{bar}']);
-    expect(results[0].message).toEqual(`The path "**/foo/{bar}/{bar}**" uses the parameter "**{bar}**" multiple times.
-
-Path parameters must be unique.
-
-To fix, update the path so that all parameter names are unique.`);
   });
 
   test('Error if $ref path parameter definition is not required', async () => {
@@ -201,7 +189,6 @@ To fix, update the path so that all parameter names are unique.`);
           },
         },
         severity: DiagnosticSeverity.Error,
-        summary: `Path parameter \"**bar**\" must have a \`required\` that is set to \`true\`.\n\nTo fix, mark this parameter as required.`,
       },
     ]);
   });
@@ -248,7 +235,6 @@ To fix, update the path so that all parameter names are unique.`);
           },
         },
         severity: DiagnosticSeverity.Error,
-        summary: `The paths \"**/foo/{boo}**\" and \"**/foo/{bar}**\" are equivalent.\n\nTo fix, remove one of the paths or merge them together.`,
       },
     ]);
   });

--- a/src/rulesets/oas/index.json
+++ b/src/rulesets/oas/index.json
@@ -1,7 +1,7 @@
 {
   "rules": {
     "operation-2xx-response": {
-      "summary": "Operation must have at least one `2xx` response.",
+      "description": "Operation must have at least one `2xx` response.",
       "recommended": true,
       "type": "style",
       "given": "$..paths.*[?( @property === 'get' || @property === 'put' || @property === 'post' || @property === 'delete' || @property === 'options' || @property === 'head' || @property === 'patch' || @property === 'trace' )]",
@@ -14,7 +14,7 @@
       ]
     },
     "operation-formData-consume-check": {
-      "summary": "Operations with an `in: formData` parameter must include `application/x-www-form-urlencoded` or `multipart/form-data` in their `consumes` property.",
+      "description": "Operations with an `in: formData` parameter must include `application/x-www-form-urlencoded` or `multipart/form-data` in their `consumes` property.",
       "recommended": true,
       "type": "validation",
       "given": "$..paths.*[?( @property === 'get' || @property === 'put' || @property === 'post' || @property === 'delete' || @property === 'options' || @property === 'head' || @property === 'patch' || @property === 'trace' )]",
@@ -26,7 +26,7 @@
       ]
     },
     "operation-operationId-unique": {
-      "summary": "Every operation must have a unique `operationId`.",
+      "description": "Every operation must have a unique `operationId`.",
       "recommended": true,
       "type": "validation",
       "severity": 0,
@@ -39,7 +39,7 @@
       ]
     },
     "operation-parameters": {
-      "summary": "Operation parameters are unique and non-repeating.",
+      "description": "Operation parameters are unique and non-repeating.",
       "recommended": true,
       "type": "validation",
       "given": "$",
@@ -51,7 +51,7 @@
       ]
     },
     "path-params": {
-      "summary": "Path parameters are correct and valid.",
+      "description": "Path parameters are correct and valid.",
       "message": "{{error}}",
       "type": "validation",
       "severity": 0,
@@ -65,7 +65,7 @@
       ]
     },
     "contact-properties": {
-      "summary": "Contact object should have `name`, `url` and `email`.",
+      "description": "Contact object should have `name`, `url` and `email`.",
       "recommended": false,
       "type": "style",
       "given": "$.info.contact",
@@ -88,7 +88,7 @@
       ]
     },
     "example-value-or-externalValue": {
-      "summary": "Example should have either a `value` or `externalValue` field.",
+      "description": "Example should have either a `value` or `externalValue` field.",
       "recommended": false,
       "type": "style",
       "given": "$..example",
@@ -103,7 +103,7 @@
       }
     },
     "info-contact": {
-      "summary": "Info object should contain `contact` object.",
+      "description": "Info object should contain `contact` object.",
       "recommended": true,
       "type": "style",
       "given": "$",
@@ -116,7 +116,7 @@
       ]
     },
     "info-description": {
-      "summary": "OpenAPI object info `description` must be present and non-empty string.",
+      "description": "OpenAPI object info `description` must be present and non-empty string.",
       "recommended": true,
       "type": "style",
       "given": "$",
@@ -129,7 +129,7 @@
       ]
     },
     "info-license": {
-      "summary": "OpenAPI object info `license` must be present and non-empty string.",
+      "description": "OpenAPI object info `license` must be present and non-empty string.",
       "recommended": false,
       "type": "style",
       "given": "$",
@@ -142,7 +142,7 @@
       ]
     },
     "license-url": {
-      "summary": "License object should include `url`.",
+      "description": "License object should include `url`.",
       "recommended": false,
       "type": "style",
       "given": "$",
@@ -155,7 +155,7 @@
       ]
     },
     "no-eval-in-markdown": {
-      "summary": "Markdown descriptions should not contain `eval(`.",
+      "description": "Markdown descriptions should not contain `eval(`.",
       "recommended": false,
       "type": "style",
       "given": "$..*",
@@ -177,7 +177,7 @@
       ]
     },
     "no-script-tags-in-markdown": {
-      "summary": "Markdown descriptions should not contain `<script>` tags.",
+      "description": "Markdown descriptions should not contain `<script>` tags.",
       "recommended": true,
       "type": "style",
       "given": "$..*",
@@ -199,7 +199,7 @@
       ]
     },
     "only-local-references": {
-      "summary": "References should start with `#/`.",
+      "description": "References should start with `#/`.",
       "recommended": false,
       "type": "style",
       "given": "$..['$ref']",
@@ -214,7 +214,7 @@
       ]
     },
     "openapi-tags-alphabetical": {
-      "summary": "OpenAPI object should have alphabetical `tags`.",
+      "description": "OpenAPI object should have alphabetical `tags`.",
       "recommended": false,
       "type": "style",
       "given": "$",
@@ -230,7 +230,7 @@
       ]
     },
     "openapi-tags": {
-      "summary": "OpenAPI object should have non-empty `tags` array.",
+      "description": "OpenAPI object should have non-empty `tags` array.",
       "recommended": false,
       "type": "style",
       "given": "$",
@@ -243,7 +243,7 @@
       ]
     },
     "operation-default-response": {
-      "summary": "Operations must have a default response.",
+      "description": "Operations must have a default response.",
       "recommended": false,
       "type": "style",
       "given": "$..paths.*.*.responses",
@@ -256,7 +256,7 @@
       ]
     },
     "operation-description": {
-      "summary": "Operation `description` must be present and non-empty string.",
+      "description": "Operation `description` must be present and non-empty string.",
       "recommended": true,
       "type": "style",
       "given": "$..paths.*[?( @property === 'get' || @property === 'put' || @property === 'post' || @property === 'delete' || @property === 'options' || @property === 'head' || @property === 'patch' || @property === 'trace' )]",
@@ -269,7 +269,7 @@
       ]
     },
     "operation-operationId": {
-      "summary": "Operation should have an `operationId`.",
+      "description": "Operation should have an `operationId`.",
       "recommended": true,
       "type": "style",
       "given": "$..paths.*[?( @property === 'get' || @property === 'put' || @property === 'post' || @property === 'delete' || @property === 'options' || @property === 'head' || @property === 'patch' || @property === 'trace' )]",
@@ -282,7 +282,7 @@
       ]
     },
     "operation-operationId-valid-in-url": {
-      "summary": "operationId may only use characters that are valid when used in a URL.",
+      "description": "operationId may only use characters that are valid when used in a URL.",
       "recommended": true,
       "type": "validation",
       "given": "$..paths.*[?( @property === 'get' || @property === 'put' || @property === 'post' || @property === 'delete' || @property === 'options' || @property === 'head' || @property === 'patch' || @property === 'trace' )]",
@@ -298,7 +298,7 @@
       ]
     },
     "operation-singular-tag": {
-      "summary": "Operation may only have one tag.",
+      "description": "Operation may only have one tag.",
       "recommended": false,
       "type": "style",
       "given": "$..paths.*[?( @property === 'get' || @property === 'put' || @property === 'post' || @property === 'delete' || @property === 'options' || @property === 'head' || @property === 'patch' || @property === 'trace' )]",
@@ -314,7 +314,7 @@
       ]
     },
     "operation-summary-formatted": {
-      "summary": "Operation `summary` should start with upper case and end with a dot.",
+      "description": "Operation `summary` should start with upper case and end with a dot.",
       "recommended": false,
       "type": "style",
       "given": "$..paths.*[?( @property === 'get' || @property === 'put' || @property === 'post' || @property === 'delete' || @property === 'options' || @property === 'head' || @property === 'patch' || @property === 'trace' )]",
@@ -330,7 +330,7 @@
       ]
     },
     "operation-tags": {
-      "summary": "Operation should have non-empty `tags` array.",
+      "description": "Operation should have non-empty `tags` array.",
       "recommended": true,
       "type": "style",
       "given": "$..paths.*[?( @property === 'get' || @property === 'put' || @property === 'post' || @property === 'delete' || @property === 'options' || @property === 'head' || @property === 'patch' || @property === 'trace' )]",
@@ -343,7 +343,7 @@
       ]
     },
     "parameter-description": {
-      "summary": "Parameter objects should have a `description`.",
+      "description": "Parameter objects should have a `description`.",
       "recommended": false,
       "type": "style",
       "given": "$..parameters[*]",
@@ -360,7 +360,7 @@
       ]
     },
     "path-declarations-must-exist": {
-      "summary": "given declarations cannot be empty, ex.`/given/{}` is invalid.",
+      "description": "given declarations cannot be empty, ex.`/given/{}` is invalid.",
       "recommended": true,
       "type": "style",
       "given": "$..paths",
@@ -376,7 +376,7 @@
       ]
     },
     "path-keys-no-trailing-slash": {
-      "summary": "given keys should not end with a slash.",
+      "description": "given keys should not end with a slash.",
       "recommended": true,
       "type": "style",
       "given": "$..paths",
@@ -392,7 +392,7 @@
       ]
     },
     "path-not-include-query": {
-      "summary": "given keys should not include a query string.",
+      "description": "given keys should not include a query string.",
       "recommended": true,
       "type": "style",
       "given": "$..paths",
@@ -408,7 +408,7 @@
       ]
     },
     "tag-description": {
-      "summary": "Tag object should have a `description`.",
+      "description": "Tag object should have a `description`.",
       "recommended": false,
       "type": "style",
       "given": "$.tags[*]",

--- a/src/rulesets/oas2/__tests__/api-host.ts
+++ b/src/rulesets/oas2/__tests__/api-host.ts
@@ -42,7 +42,6 @@ describe('api-host', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'OpenAPI `host` must be present and non-empty string.',
       },
     ]);
   });

--- a/src/rulesets/oas2/__tests__/api-schemes.ts
+++ b/src/rulesets/oas2/__tests__/api-schemes.ts
@@ -41,7 +41,6 @@ describe('api-schemes', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'OpenAPI host `schemes` must be present and non-empty array.',
       },
     ]);
   });
@@ -68,7 +67,6 @@ describe('api-schemes', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'OpenAPI host `schemes` must be present and non-empty array.',
       },
     ]);
   });

--- a/src/rulesets/oas2/__tests__/host-trailing-slash.ts
+++ b/src/rulesets/oas2/__tests__/host-trailing-slash.ts
@@ -42,7 +42,6 @@ describe('host-trailing-slash', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'Server URL should not have a trailing slash.',
       },
     ]);
   });

--- a/src/rulesets/oas2/__tests__/model-description.ts
+++ b/src/rulesets/oas2/__tests__/model-description.ts
@@ -48,7 +48,6 @@ describe('model-description', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'Definition `description` must be present and non-empty string.',
       },
     ]);
   });

--- a/src/rulesets/oas2/index.json
+++ b/src/rulesets/oas2/index.json
@@ -2,7 +2,7 @@
   "extends": ["spectral:oas"],
   "rules": {
     "oas2-schema": {
-      "summary": "Validate structure of OpenAPIv2 specification.",
+      "description": "Validate structure of OpenAPIv2 specification.",
       "message": "{{error}}",
       "type": "validation",
       "severity": 0,
@@ -1639,7 +1639,7 @@
       ]
     },
     "api-host": {
-      "summary": "OpenAPI `host` must be present and non-empty string.",
+      "description": "OpenAPI `host` must be present and non-empty string.",
       "recommended": true,
       "type": "style",
       "given": "$",
@@ -1652,7 +1652,7 @@
       ]
     },
     "api-schemes": {
-      "summary": "OpenAPI host `schemes` must be present and non-empty array.",
+      "description": "OpenAPI host `schemes` must be present and non-empty array.",
       "recommended": true,
       "type": "style",
       "given": "$",
@@ -1674,7 +1674,7 @@
       ]
     },
     "host-not-example": {
-      "summary": "Server URL should not point at `example.com`.",
+      "description": "Server URL should not point at `example.com`.",
       "recommended": false,
       "type": "style",
       "given": "$",
@@ -1687,7 +1687,7 @@
       }
     },
     "host-trailing-slash": {
-      "summary": "Server URL should not have a trailing slash.",
+      "description": "Server URL should not have a trailing slash.",
       "recommended": true,
       "type": "style",
       "given": "$",
@@ -1700,7 +1700,7 @@
       }
     },
     "model-description": {
-      "summary": "Definition `description` must be present and non-empty string.",
+      "description": "Definition `description` must be present and non-empty string.",
       "recommended": false,
       "type": "style",
       "given": "$..definitions[*]",
@@ -1710,7 +1710,7 @@
       }
     },
     "operation-security-defined": {
-      "summary": "Operation `security` values must match a scheme defined in the `securityDefinitions` object.",
+      "description": "Operation `security` values must match a scheme defined in the `securityDefinitions` object.",
       "recommended": true,
       "type": "validation",
       "given": "$",
@@ -1727,7 +1727,7 @@
       ]
     },
     "valid-example": {
-      "summary": "Examples must be valid against their defined schema.",
+      "description": "Examples must be valid against their defined schema.",
       "message": "\"{{property}}\" property {{error}}",
       "recommended": true,
       "type": "validation",

--- a/src/rulesets/oas3/__tests__/api-servers.ts
+++ b/src/rulesets/oas3/__tests__/api-servers.ts
@@ -41,7 +41,6 @@ describe('api-servers', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'OpenAPI `servers` must be present and non-empty array.',
       },
     ]);
   });
@@ -68,7 +67,6 @@ describe('api-servers', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'OpenAPI `servers` must be present and non-empty array.',
       },
     ]);
   });

--- a/src/rulesets/oas3/__tests__/model-description.ts
+++ b/src/rulesets/oas3/__tests__/model-description.ts
@@ -52,7 +52,6 @@ describe('model-description', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'Model `description` must be present and non-empty string.',
       },
     ]);
   });

--- a/src/rulesets/oas3/__tests__/server-trailing-slash.ts
+++ b/src/rulesets/oas3/__tests__/server-trailing-slash.ts
@@ -50,7 +50,6 @@ describe('server-trailing-slash', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        summary: 'Server URL should not have a trailing slash.',
       },
     ]);
   });

--- a/src/rulesets/oas3/index.json
+++ b/src/rulesets/oas3/index.json
@@ -2,7 +2,7 @@
   "extends": ["spectral:oas"],
   "rules": {
     "oas3-schema": {
-      "summary": "Validate structure of OpenAPIv3 specification.",
+      "description": "Validate structure of OpenAPIv3 specification.",
       "message": "{{error}}",
       "type": "validation",
       "severity": 0,
@@ -2315,7 +2315,7 @@
       ]
     },
     "api-servers": {
-      "summary": "OpenAPI `servers` must be present and non-empty array.",
+      "description": "OpenAPI `servers` must be present and non-empty array.",
       "recommended": true,
       "type": "style",
       "given": "$",
@@ -2337,7 +2337,7 @@
       ]
     },
     "model-description": {
-      "summary": "Model `description` must be present and non-empty string.",
+      "description": "Model `description` must be present and non-empty string.",
       "recommended": false,
       "type": "style",
       "given": "$.components.schemas[*]",
@@ -2347,7 +2347,7 @@
       }
     },
     "operation-security-defined": {
-      "summary": "Operation `security` values must match a scheme defined in the `components.securitySchemes` object.",
+      "description": "Operation `security` values must match a scheme defined in the `components.securitySchemes` object.",
       "recommended": true,
       "type": "validation",
       "given": "$",
@@ -2365,7 +2365,7 @@
       ]
     },
     "server-not-example.com": {
-      "summary": "Server URL should not point at `example.com`.",
+      "description": "Server URL should not point at `example.com`.",
       "recommended": false,
       "type": "style",
       "given": "$.servers[*]",
@@ -2378,7 +2378,7 @@
       }
     },
     "server-trailing-slash": {
-      "summary": "Server URL should not have a trailing slash.",
+      "description": "Server URL should not have a trailing slash.",
       "recommended": true,
       "type": "style",
       "given": "$.servers[*]",
@@ -2391,7 +2391,7 @@
       }
     },
     "valid-example": {
-      "summary": "Examples must be valid against their defined schema.",
+      "description": "Examples must be valid against their defined schema.",
       "message": "\"{{property}}\" property {{error}}",
       "recommended": true,
       "type": "validation",

--- a/src/types/rule.ts
+++ b/src/types/rule.ts
@@ -6,9 +6,6 @@ export type Rule = IRule | TruthyRule | XorRule | LengthRule | AlphaRule | Patte
 export interface IRule<T = string, O = any> {
   type?: RuleType;
 
-  // @deprecated - use message instead
-  summary?: string;
-
   // A meaningful feedback about the error
   message?: string;
 

--- a/src/types/spectral.ts
+++ b/src/types/spectral.ts
@@ -31,8 +31,6 @@ export interface IRunOpts {
 }
 
 export interface IRuleResult extends IDiagnostic {
-  // @deprecated, use message instead
-  summary?: string;
   path: JsonPath;
 }
 


### PR DESCRIPTION
BREAKING CHANGE: summary property was removed - use message property instead.

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated
- [x] Check this off Breaking change?

**Does this PR introduce a breaking change?**

- [x] Yes
- [ ] No

We remove deprecated `summary` property.
