### PR TITLE
fix: use our fork of better-ajv-errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@stoplight/yaml": "^2.5",
     "ajv": "^6.7",
     "ajv-oai": "^1.1.1",
-    "better-ajv-errors": "https://github.com/stoplightio/better-ajv-errors#4dbb2d633af8dad1ebfeef5b742acbf48f80b327",
+    "better-ajv-errors": "stoplightio/better-ajv-errors#4dbb2d633af8dad1ebfeef5b742acbf48f80b327",
     "chalk": "^2.4.2",
     "jsonpath-plus": "~0.20",
     "lodash": ">=4.17.5",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@stoplight/yaml": "^2.5",
     "ajv": "^6.7",
     "ajv-oai": "^1.1.1",
-    "better-ajv-errors": "^0.6.4",
+    "better-ajv-errors": "https://github.com/stoplightio/better-ajv-errors#4dbb2d633af8dad1ebfeef5b742acbf48f80b327",
     "chalk": "^2.4.2",
     "jsonpath-plus": "~0.20",
     "lodash": ">=4.17.5",

--- a/src/__tests__/linter.test.ts
+++ b/src/__tests__/linter.test.ts
@@ -166,6 +166,11 @@ describe('linter', () => {
       expect.objectContaining({
         code: 'invalid-ref',
       }),
+      expect.objectContaining({
+        code: 'oas3-schema',
+        message: "/paths//pets/get/responses/200 should have required property '$ref'",
+        path: ['paths', '~1pets', 'get', 'responses', '200'],
+      }),
     ]);
   });
 
@@ -272,6 +277,11 @@ responses:: !!foo
       }),
       expect.objectContaining({
         code: 'invalid-ref',
+      }),
+      expect.objectContaining({
+        code: 'oas3-schema',
+        message: "/paths//pets/get/responses/200 should have required property '$ref'",
+        path: ['paths', '~1pets', 'get', 'responses', '200'],
       }),
       expect.objectContaining({
         code: 'valid-example',

--- a/src/rulesets/oas2/__tests__/oas2-schema.ts
+++ b/src/rulesets/oas2/__tests__/oas2-schema.ts
@@ -24,6 +24,23 @@ describe('oas2-schema', () => {
         version: '1.0.0',
       },
     });
-    expect(results).toEqual([]);
+    expect(results).toEqual([
+      {
+        code: 'oas2-schema',
+        message: "/paths//test/get should have required property 'responses'",
+        path: ['paths', '~1test', 'get'],
+        range: {
+          end: {
+            character: 15,
+            line: 4,
+          },
+          start: {
+            character: 10,
+            line: 2,
+          },
+        },
+        severity: 0,
+      },
+    ]);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1079,9 +1079,9 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-"better-ajv-errors@https://github.com/stoplightio/better-ajv-errors#4dbb2d633af8dad1ebfeef5b742acbf48f80b327":
+better-ajv-errors@stoplightio/better-ajv-errors#4dbb2d633af8dad1ebfeef5b742acbf48f80b327:
   version "0.6.4"
-  resolved "https://github.com/stoplightio/better-ajv-errors#4dbb2d633af8dad1ebfeef5b742acbf48f80b327"
+  resolved "https://codeload.github.com/stoplightio/better-ajv-errors/tar.gz/4dbb2d633af8dad1ebfeef5b742acbf48f80b327"
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/runtime" "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1079,10 +1079,9 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-better-ajv-errors@^0.6.4:
+"better-ajv-errors@https://github.com/stoplightio/better-ajv-errors#4dbb2d633af8dad1ebfeef5b742acbf48f80b327":
   version "0.6.4"
-  resolved "https://registry.yarnpkg.com/better-ajv-errors/-/better-ajv-errors-0.6.4.tgz#1e3c6b93dc11e72c94a0b042594515eb917f2957"
-  integrity sha512-+spBhtcCzovXWeHpt5dGylFsn3p5l9w+KcUqh/b4MFdLV+q1sT1olxD9izvwi0D3WuP06eVgeZAGLtxtTnUIDg==
+  resolved "https://github.com/stoplightio/better-ajv-errors#4dbb2d633af8dad1ebfeef5b742acbf48f80b327"
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/runtime" "^7.0.0"


### PR DESCRIPTION
Relates to #33 

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated
- [x] Check this off Breaking change?

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

Yeah, I know, yet another fork, but we are quite short on time and I really doubt the PR I mentioned in #33 will be merged anytime soon. Submitting our own PR might be the best choice - I went with a slightly different implementation, so hopefully, this is accepted earlier? Not sure, I pinged all folks in that PR and let's see what their responses are.

Note on red CI checks - we seem to experience some Yarn caching issue, can anyone wipe the cache?