### PR TITLE
build: inline pkg version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,7 @@ jobs:
       - cached-dependencies
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run: npm version from-git
+      - run: yarn inline-version
       - run: yarn build
       - run: |
           if [[ "$CIRCLE_TAG" == *beta* ]] ; then

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "test.update": "yarn test --updateSnapshot",
     "test.watch": "yarn test --watch",
     "test.karma": "karma start",
+    "inline-version": "./scripts/inline-version.js",
     "schema.update": "yarn typescript-json-schema --id \"http://stoplight.io/schemas/rule.schema.json\" --required tsconfig.json IRule --out ./src/meta/rule.schema.json"
   },
   "dependencies": {
@@ -102,6 +103,7 @@
     "lint-staged": "^9.0.2",
     "nock": "~10.0.6",
     "pkg": "~4.4",
+    "recast": "^0.18.1",
     "ts-jest": "^24.0.2",
     "ts-node": "^8.1.0",
     "tslint": "~5.18",

--- a/scripts/inline-version.js
+++ b/scripts/inline-version.js
@@ -21,7 +21,10 @@ for (const node of body) {
     node.body.body = [
       b.returnStatement(
         b.callExpression(
-          b.memberExpression(b.identifier(node.params[0].name), b.identifier('replace')),
+          b.memberExpression(
+            b.callExpression(b.identifier('String'), [b.identifier(node.params[0].name)]),
+            b.identifier('replace'),
+          ),
           [
             b.stringLiteral(pkg.name),
             b.stringLiteral(`${pkg.name}@${pkg.version}`),

--- a/scripts/inline-version.js
+++ b/scripts/inline-version.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+const recast = require('recast');
+const { builders: b } = require('ast-types');
+const path = require('path');
+const fs = require('fs');
+const pkg = require('../package.json');
+
+const target = path.join(__dirname, '..', 'src', 'rulesets', 'finder.ts');
+
+const source = fs.readFileSync(target, 'utf8');
+const ast = recast.parse(source, {
+  parser: require('recast/parsers/typescript'),
+});
+
+const {
+  program: { body },
+} = ast;
+
+for (const node of body) {
+  if (node.type === 'FunctionDeclaration' && node.id.name === 'resolveSpectralVersion') {
+    node.body.body = [
+      b.returnStatement(
+        b.callExpression(
+          b.memberExpression(b.identifier(node.params[0].name), b.identifier('replace')),
+          [
+            b.stringLiteral(pkg.name),
+            b.stringLiteral(`${pkg.name}@${pkg.version}`),
+          ]
+        )
+      ),
+    ];
+  }
+}
+
+fs.writeFileSync(target, recast.print(ast, { quote: 'single' }).code);

--- a/src/rulesets/finder.ts
+++ b/src/rulesets/finder.ts
@@ -4,6 +4,12 @@ import { rulesetsMap } from './map';
 
 const SPECTRAL_SRC_ROOT = path.join(__dirname, '..');
 
+// DON'T RENAME THIS FUNCTION, you can move it within this file, but it must be kept as top-level declaration
+// parameter can be renamed, but don't this if you don't need to
+function resolveSpectralVersion(pkg: string) {
+  return pkg;
+}
+
 export async function findRuleset(from: string, to: string) {
   const mapped = rulesetsMap.get(to);
   if (mapped !== void 0) {
@@ -42,8 +48,7 @@ export async function findRuleset(from: string, to: string) {
   try {
     return require.resolve(to);
   } catch {
-    // todo: put hardcoded version here? might be good if we decide to make a breaking change in future.
-    return path.join('https://unpkg.com/', to); // try to point to npm module
+    return path.join('https://unpkg.com/', resolveSpectralVersion(to)); // try to point to npm module
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1042,6 +1042,11 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
+ast-types@0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.1.tgz#9461428a270c5a27fda44b738dd3bab2e9353003"
+  integrity sha512-b+EeK0WlzrSmpMw5jktWvQGxblpWnvMrV+vOp69RLjzGiHwWV0vgq75DPKtUjppKni3yWwSW8WLGV3Ch/XIWcQ==
+
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
@@ -5854,6 +5859,11 @@ pretty-format@^24.8.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
+private@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
+  integrity sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==
+
 process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
@@ -6133,6 +6143,16 @@ realpath-native@^1.1.0:
   integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
   dependencies:
     util.promisify "^1.0.0"
+
+recast@^0.18.1:
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.18.1.tgz#dd1788cfa403be8be06a10f201317f881adc602b"
+  integrity sha512-Ri42yIOwHetqKgEhQSS4N1B9wSLn+eYcyLoQfuSpvd661Jty1Q3P0FXkzjIQ9XxTN+3+kRu1JFXbRmUCUmde5Q==
+  dependencies:
+    ast-types "0.13.1"
+    esprima "~4.0.0"
+    private "^0.1.8"
+    source-map "~0.6.1"
 
 redent@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Fixes #[ISSUE_NUMBER].

**Checklist**

- [ ] Tests added / updated
- [ ] Docs added / updated
- [x] Check this off Breaking change?

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

:scream:

Let me explain...
In a browser environment without access to any kind of fs, Spectral will try to obtain rulesets from npm. This approach is fairly fine, but comes with a downside - you cannot change the location of rulesets if you don't want to break Spectral for users. This PR addresses this issue thanks to specifying the actual version of a given release.
I didn't want to rely on `package.json` on purpose - it would require `require` :laughing: or imports and so on. You know. The solution proposed here should, in theory, be more reliable.
