### PR TITLE
feat: register rules against specific formats

### DIFF
--- a/src/cli/commands/__tests__/lint.test.ts
+++ b/src/cli/commands/__tests__/lint.test.ts
@@ -180,7 +180,7 @@ describe('lint', () => {
         .it('outputs warnings in default format', ctx => {
           expect(ctx.stdout).toContain('5:10  warning  info-matches-stoplight  Info must contain Stoplight');
           expect(ctx.stdout).not.toContain('Info object should contain `contact` object');
-          expect(ctx.stdout).not.toContain('OpenAPI 3.x detected');
+          expect(ctx.stdout).toContain('OpenAPI 3.x detected');
         });
 
       test
@@ -208,7 +208,7 @@ describe('lint', () => {
           expect(ctx.stdout).toContain(
             '3:6  warning  info-description  OpenAPI object info `description` must be present and non-empty string',
           );
-          expect(ctx.stdout).not.toContain('OpenAPI 3.x detected');
+          expect(ctx.stdout).toContain('OpenAPI 3.x detected');
         });
 
       test
@@ -219,7 +219,7 @@ describe('lint', () => {
             '46:24  warning  operation-description   Operation `description` must be present and non-empty string',
           );
           expect(ctx.stdout).toContain('28 problems (0 errors, 28 warnings, 0 infos)');
-          expect(ctx.stdout).not.toContain('OpenAPI 2.x detected');
+          expect(ctx.stdout).toContain('OpenAPI 2.0 (Swagger) detected');
         });
     });
   });

--- a/src/cli/commands/lint.ts
+++ b/src/cli/commands/lint.ts
@@ -11,7 +11,7 @@ import { json, stylish } from '../../formatters';
 import { readParsable } from '../../fs/reader';
 import { httpAndFileResolver } from '../../resolvers/http-and-file';
 import { getDefaultRulesetFile } from '../../rulesets/loader';
-import { isOpenApiv2_0, isOpenApiv3 } from '../../rulesets/lookups';
+import { isOpenApiv2, isOpenApiv3 } from '../../rulesets/lookups';
 import { oas2Functions, rules as oas2Rules } from '../../rulesets/oas2';
 import { oas3Functions, rules as oas3Rules } from '../../rulesets/oas3';
 import { readRulesFromRulesets } from '../../rulesets/reader';
@@ -151,8 +151,8 @@ async function lint(name: string, flags: ILintConfig, command: Lint, rules?: Rul
     mergeKeys: true,
   });
   const spectral = new Spectral({ resolver: httpAndFileResolver });
-  spectral.registerFormat('oas-2', document => {
-    if (isOpenApiv2_0(document)) {
+  spectral.registerFormat('oas2', document => {
+    if (isOpenApiv2(document)) {
       command.log('OpenAPI 2.0 (Swagger) detected');
       return true;
     }
@@ -160,7 +160,7 @@ async function lint(name: string, flags: ILintConfig, command: Lint, rules?: Rul
     return false;
   });
 
-  spectral.registerFormat('oas-3', document => {
+  spectral.registerFormat('oas3', document => {
     if (isOpenApiv3(document)) {
       command.log('OpenAPI 3.x detected');
       return true;

--- a/src/cli/commands/lint.ts
+++ b/src/cli/commands/lint.ts
@@ -11,7 +11,7 @@ import { json, stylish } from '../../formatters';
 import { readParsable } from '../../fs/reader';
 import { httpAndFileResolver } from '../../resolvers/http-and-file';
 import { getDefaultRulesetFile } from '../../rulesets/loader';
-import { isOAS2Spec, isOAS3Spec } from '../../rulesets/lookups';
+import { isOpenApiv2_0, isOpenApiv3 } from '../../rulesets/lookups';
 import { oas2Functions, rules as oas2Rules } from '../../rulesets/oas2';
 import { oas3Functions, rules as oas3Rules } from '../../rulesets/oas3';
 import { readRulesFromRulesets } from '../../rulesets/reader';
@@ -151,8 +151,8 @@ async function lint(name: string, flags: ILintConfig, command: Lint, rules?: Rul
     mergeKeys: true,
   });
   const spectral = new Spectral({ resolver: httpAndFileResolver });
-  spectral.registerFormat('oas2', document => {
-    if (isOAS2Spec(document)) {
+  spectral.registerFormat('oas-2', document => {
+    if (isOpenApiv2_0(document)) {
       command.log('OpenAPI 2.0 (Swagger) detected');
       return true;
     }
@@ -160,8 +160,8 @@ async function lint(name: string, flags: ILintConfig, command: Lint, rules?: Rul
     return false;
   });
 
-  spectral.registerFormat('oas3', document => {
-    if (isOAS3Spec(document)) {
+  spectral.registerFormat('oas-3', document => {
+    if (isOpenApiv3(document)) {
       command.log('OpenAPI 3.x detected');
       return true;
     }

--- a/src/meta/rule.schema.json
+++ b/src/meta/rule.schema.json
@@ -80,6 +80,13 @@
             },
             "type": "array"
         },
+        "formats": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "minItems": 1
+            }
+        },
         "then": {
             "anyOf": [
                 {

--- a/src/meta/ruleset.schema.json
+++ b/src/meta/ruleset.schema.json
@@ -9,6 +9,13 @@
                 "$ref": "rule.schema.json"
             }
         },
+        "formats": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "minLength": 1
+            }
+        },
         "extends": {
             "type": ["array", "string"],
             "items": {

--- a/src/resolved.ts
+++ b/src/resolved.ts
@@ -10,12 +10,14 @@ export class Resolved implements IResolveResult {
   public result: unknown;
   public errors: IResolveError[];
   public runner: IResolveRunner;
+  public format?: string;
 
   constructor(public spec: IParsedResult, result: IResolveResult, public parsedMap: IParseMap) {
     this.refMap = result.refMap;
     this.result = result.result;
     this.errors = result.errors;
     this.runner = result.runner;
+    this.format = spec.format;
   }
 
   public getParsedForJsonPath(path: JsonPath) {

--- a/src/rulesets/__tests__/__fixtures__/my-open-api-ruleset.json
+++ b/src/rulesets/__tests__/__fixtures__/my-open-api-ruleset.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["spectral:oas2", "spectral:oas3"],
+  "rules": {
+    "valid-rule": {
+      "message": "should be OK",
+      "given": "$.info",
+      "then": {
+        "function": "truthy"
+      }
+    }
+  }
+}

--- a/src/rulesets/__tests__/lookups.spec.ts
+++ b/src/rulesets/__tests__/lookups.spec.ts
@@ -1,4 +1,4 @@
-import { isOpenApiv2_0, isOpenApiv3, isOpenApiv3_0, isOpenApiv3_1 } from '../lookups';
+import { isOpenApiv2, isOpenApiv3, isOpenApiv3_1 } from '../lookups';
 
 // @oclif/test packages requires @types/mocha, therefore we have 2 packages coming up with similar typings
 // TS is confused and prefers the mocha ones, so we need to instrument it to pick up the Jest ones
@@ -7,22 +7,22 @@ declare var it: jest.It;
 describe('Format lookups', () => {
   describe('OpenAPI 2.0 aka Swagger', () => {
     it.each(['2.0.0', '2', '2.0'])('recognizes %s version correctly', version => {
-      expect(isOpenApiv2_0({ swagger: version })).toBe(true);
+      expect(isOpenApiv2({ swagger: version })).toBe(true);
     });
 
     it('does not recognize invalid document', () => {
-      expect(isOpenApiv2_0({ openapi: '2.0' })).toBe(false);
-      expect(isOpenApiv2_0({ openapi: null })).toBe(false);
-      expect(isOpenApiv2_0({ swagger: null })).toBe(false);
-      expect(isOpenApiv2_0({ swagger: '3.0' })).toBe(false);
-      expect(isOpenApiv2_0({ swagger: '1.0' })).toBe(false);
-      expect(isOpenApiv2_0({})).toBe(false);
-      expect(isOpenApiv2_0(null)).toBe(false);
+      expect(isOpenApiv2({ openapi: '2.0' })).toBe(false);
+      expect(isOpenApiv2({ openapi: null })).toBe(false);
+      expect(isOpenApiv2({ swagger: null })).toBe(false);
+      expect(isOpenApiv2({ swagger: '3.0' })).toBe(false);
+      expect(isOpenApiv2({ swagger: '1.0' })).toBe(false);
+      expect(isOpenApiv2({})).toBe(false);
+      expect(isOpenApiv2(null)).toBe(false);
     });
   });
 
-  describe('OpenAPI 3.x', () => {
-    it.each(['3.0.0', '3', '3.0', '3.1.0', '3.1'])('recognizes %s version correctly', version => {
+  describe('OpenAPI 3.0', () => {
+    it.each(['3.0.0', '3', '3.0'])('recognizes %s version correctly', version => {
       expect(isOpenApiv3({ openapi: version })).toBe(true);
     });
 
@@ -34,22 +34,6 @@ describe('Format lookups', () => {
       expect(isOpenApiv3({ swagger: '3.0' })).toBe(false);
       expect(isOpenApiv3({})).toBe(false);
       expect(isOpenApiv3(null)).toBe(false);
-    });
-  });
-
-  describe('OpenAPI 3.0', () => {
-    it.each(['3.0.0', '3', '3.0'])('recognizes %s version correctly', version => {
-      expect(isOpenApiv3_0({ openapi: version })).toBe(true);
-    });
-
-    it('does not recognize invalid document', () => {
-      expect(isOpenApiv3_0({ openapi: '4.0' })).toBe(false);
-      expect(isOpenApiv3_0({ openapi: '2.0' })).toBe(false);
-      expect(isOpenApiv3_0({ openapi: null })).toBe(false);
-      expect(isOpenApiv3_0({ swagger: null })).toBe(false);
-      expect(isOpenApiv3_0({ swagger: '3.0' })).toBe(false);
-      expect(isOpenApiv3_0({})).toBe(false);
-      expect(isOpenApiv3_0(null)).toBe(false);
     });
   });
 

--- a/src/rulesets/__tests__/lookups.spec.ts
+++ b/src/rulesets/__tests__/lookups.spec.ts
@@ -1,0 +1,72 @@
+import { isOpenApiv2_0, isOpenApiv3, isOpenApiv3_0, isOpenApiv3_1 } from '../lookups';
+
+// @oclif/test packages requires @types/mocha, therefore we have 2 packages coming up with similar typings
+// TS is confused and prefers the mocha ones, so we need to instrument it to pick up the Jest ones
+declare var it: jest.It;
+
+describe('Format lookups', () => {
+  describe('OpenAPI 2.0 aka Swagger', () => {
+    it.each(['2.0.0', '2', '2.0'])('recognizes %s version correctly', version => {
+      expect(isOpenApiv2_0({ swagger: version })).toBe(true);
+    });
+
+    it('does not recognize invalid document', () => {
+      expect(isOpenApiv2_0({ openapi: '2.0' })).toBe(false);
+      expect(isOpenApiv2_0({ openapi: null })).toBe(false);
+      expect(isOpenApiv2_0({ swagger: null })).toBe(false);
+      expect(isOpenApiv2_0({ swagger: '3.0' })).toBe(false);
+      expect(isOpenApiv2_0({ swagger: '1.0' })).toBe(false);
+      expect(isOpenApiv2_0({})).toBe(false);
+      expect(isOpenApiv2_0(null)).toBe(false);
+    });
+  });
+
+  describe('OpenAPI 3.x', () => {
+    it.each(['3.0.0', '3', '3.0', '3.1.0', '3.1'])('recognizes %s version correctly', version => {
+      expect(isOpenApiv3({ openapi: version })).toBe(true);
+    });
+
+    it('does not recognize invalid document', () => {
+      expect(isOpenApiv3({ openapi: '4.0' })).toBe(false);
+      expect(isOpenApiv3({ openapi: '2.0' })).toBe(false);
+      expect(isOpenApiv3({ openapi: null })).toBe(false);
+      expect(isOpenApiv3({ swagger: null })).toBe(false);
+      expect(isOpenApiv3({ swagger: '3.0' })).toBe(false);
+      expect(isOpenApiv3({})).toBe(false);
+      expect(isOpenApiv3(null)).toBe(false);
+    });
+  });
+
+  describe('OpenAPI 3.0', () => {
+    it.each(['3.0.0', '3', '3.0'])('recognizes %s version correctly', version => {
+      expect(isOpenApiv3_0({ openapi: version })).toBe(true);
+    });
+
+    it('does not recognize invalid document', () => {
+      expect(isOpenApiv3_0({ openapi: '4.0' })).toBe(false);
+      expect(isOpenApiv3_0({ openapi: '2.0' })).toBe(false);
+      expect(isOpenApiv3_0({ openapi: null })).toBe(false);
+      expect(isOpenApiv3_0({ swagger: null })).toBe(false);
+      expect(isOpenApiv3_0({ swagger: '3.0' })).toBe(false);
+      expect(isOpenApiv3_0({})).toBe(false);
+      expect(isOpenApiv3_0(null)).toBe(false);
+    });
+  });
+
+  describe('OpenAPI 3.1', () => {
+    it.each(['3.1.0', '3.1'])('recognizes %s version correctly', version => {
+      expect(isOpenApiv3_1({ openapi: version })).toBe(true);
+    });
+
+    it('does not recognize invalid document', () => {
+      expect(isOpenApiv3_1({ openapi: '4.0' })).toBe(false);
+      expect(isOpenApiv3_1({ openapi: 3.0 })).toBe(false);
+      expect(isOpenApiv3_1({ openapi: '2.0' })).toBe(false);
+      expect(isOpenApiv3_1({ openapi: null })).toBe(false);
+      expect(isOpenApiv3_1({ swagger: null })).toBe(false);
+      expect(isOpenApiv3_1({ swagger: '3.0' })).toBe(false);
+      expect(isOpenApiv3_1({})).toBe(false);
+      expect(isOpenApiv3_1(null)).toBe(false);
+    });
+  });
+});

--- a/src/rulesets/__tests__/merger.test.ts
+++ b/src/rulesets/__tests__/merger.test.ts
@@ -246,7 +246,7 @@ describe('Rulesets merger', () => {
           test2: JSON.parse(JSON.stringify(baseRule)),
         },
       },
-      'off',
+      { severity: 'off' },
     );
 
     expect(ruleset).toHaveProperty('rules.test.severity', -1);
@@ -269,7 +269,7 @@ describe('Rulesets merger', () => {
           },
         },
       },
-      'recommended',
+      { severity: 'recommended' },
     );
 
     expect(ruleset).toHaveProperty('rules.test.severity', DiagnosticSeverity.Warning);
@@ -314,7 +314,7 @@ describe('Rulesets merger', () => {
           },
         },
       },
-      'all',
+      { severity: 'all' },
     );
 
     expect(ruleset).toHaveProperty('rules.test.severity', DiagnosticSeverity.Warning);
@@ -351,7 +351,7 @@ describe('Rulesets merger', () => {
           test: 'hint',
         },
       },
-      'all',
+      { severity: 'all' },
     );
 
     expect(ruleset).toHaveProperty('rules.test.severity', DiagnosticSeverity.Hint);
@@ -373,5 +373,56 @@ describe('Rulesets merger', () => {
         } as any,
       }),
     ).toThrow('Invalid value for a rule');
+  });
+
+  it('injects spec-scoped formats to each rule without a format', () => {
+    const ruleset: IRulesetFile = {
+      rules: {},
+    };
+
+    mergeRulesets(ruleset, {
+      formats: ['oas2', 'oas3'],
+      rules: {
+        test: JSON.parse(JSON.stringify(baseRule)),
+        test2: JSON.parse(JSON.stringify(baseRule)),
+      },
+    });
+
+    expect(ruleset).not.toHaveProperty('formats'); // makes sure we do not attach formats in the final output
+    expect(ruleset.rules).toEqual({
+      test: expect.objectContaining({
+        formats: ['oas2', 'oas3'],
+      }),
+      test2: expect.objectContaining({
+        formats: ['oas2', 'oas3'],
+      }),
+    });
+  });
+
+  it('preserves own formats of a rule if any declared', () => {
+    const ruleset: IRulesetFile = {
+      rules: {},
+    };
+
+    mergeRulesets(ruleset, {
+      formats: ['oas2', 'oas3'],
+      rules: {
+        test: {
+          ...JSON.parse(JSON.stringify(baseRule)),
+          formats: ['markdown'],
+        },
+        test2: JSON.parse(JSON.stringify(baseRule)),
+      },
+    });
+
+    expect(ruleset).not.toHaveProperty('formats'); // makes sure we do not attach formats in the final output
+    expect(ruleset.rules).toEqual({
+      test: expect.objectContaining({
+        formats: ['markdown'],
+      }),
+      test2: expect.objectContaining({
+        formats: ['oas2', 'oas3'],
+      }),
+    });
   });
 });

--- a/src/rulesets/__tests__/reader.jest.test.ts
+++ b/src/rulesets/__tests__/reader.jest.test.ts
@@ -210,7 +210,7 @@ describe('Rulesets reader', () => {
     return expect(readRulesFromRulesets(myOpenAPIRuleset)).resolves.toEqual({
       ...Object.entries(oasRuleset.rules).reduce<Dictionary<unknown>>((rules, [name, rule]) => {
         rules[name] = expect.objectContaining({
-          formats: ['oas-2', 'oas-3'],
+          formats: ['oas2', 'oas3'],
         });
 
         return rules;
@@ -218,7 +218,7 @@ describe('Rulesets reader', () => {
 
       ...Object.entries(oas2Ruleset.rules).reduce<Dictionary<unknown>>((rules, [name, rule]) => {
         rules[name] = expect.objectContaining({
-          formats: ['oas-2'],
+          formats: ['oas2'],
         });
 
         return rules;
@@ -226,7 +226,7 @@ describe('Rulesets reader', () => {
 
       ...Object.entries(oas3Ruleset.rules).reduce<Dictionary<unknown>>((rules, [name, rule]) => {
         rules[name] = expect.objectContaining({
-          formats: ['oas-3'],
+          formats: ['oas3'],
         });
 
         return rules;

--- a/src/rulesets/__tests__/reader.jest.test.ts
+++ b/src/rulesets/__tests__/reader.jest.test.ts
@@ -210,7 +210,7 @@ describe('Rulesets reader', () => {
     return expect(readRulesFromRulesets(myOpenAPIRuleset)).resolves.toEqual({
       ...Object.entries(oasRuleset.rules).reduce<Dictionary<unknown>>((rules, [name, rule]) => {
         rules[name] = expect.objectContaining({
-          formats: ['oas2', 'oas3'],
+          formats: ['oas-2', 'oas-3'],
         });
 
         return rules;
@@ -218,7 +218,7 @@ describe('Rulesets reader', () => {
 
       ...Object.entries(oas2Ruleset.rules).reduce<Dictionary<unknown>>((rules, [name, rule]) => {
         rules[name] = expect.objectContaining({
-          formats: ['oas2'],
+          formats: ['oas-2'],
         });
 
         return rules;
@@ -226,7 +226,7 @@ describe('Rulesets reader', () => {
 
       ...Object.entries(oas3Ruleset.rules).reduce<Dictionary<unknown>>((rules, [name, rule]) => {
         rules[name] = expect.objectContaining({
-          formats: ['oas3'],
+          formats: ['oas-3'],
         });
 
         return rules;

--- a/src/rulesets/__tests__/validation.test.ts
+++ b/src/rulesets/__tests__/validation.test.ts
@@ -104,4 +104,53 @@ describe('Ruleset Validation', () => {
       }),
     ).toThrow();
   });
+
+  it('recognizes valid ruleset formats syntax', () => {
+    expect(
+      assertValidRuleset.bind(null, {
+        formats: ['oas3'],
+        rules: {},
+      }),
+    ).not.toThrow();
+  });
+
+  it.each([[2, 'a'], 2, ['']])('recognizes invalid ruleset formats syntax', formats => {
+    expect(
+      assertValidRuleset.bind(null, {
+        formats,
+        rules: {},
+      }),
+    ).toThrow();
+  });
+
+  it('recognizes valid rule formats syntax', () => {
+    expect(
+      assertValidRuleset.bind(null, {
+        formats: ['d'],
+        rules: {
+          rule: {
+            given: '$.info',
+            then: {
+              function: 'truthy',
+            },
+            formats: ['oas2'],
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it.each([[2, 'a'], 2, ['']])('recognizes invalid rule formats syntax', formats => {
+    expect(
+      assertValidRuleset.bind(null, {
+        rules: {
+          given: '$.info',
+          then: {
+            function: 'truthy',
+          },
+          formats,
+        },
+      }),
+    ).toThrow();
+  });
 });

--- a/src/rulesets/lookups.ts
+++ b/src/rulesets/lookups.ts
@@ -1,0 +1,9 @@
+const isObject = (thing: unknown): thing is object => thing !== null && typeof thing === 'object';
+
+type MaybeOAS2Spec = Partial<{ swagger: unknown }>;
+type MaybeOAS3Spec = Partial<{ openapi: unknown }>;
+
+export const isOAS2Spec = (document: unknown) =>
+  isObject(document) && 'swagger' in document && parseInt(String((document as MaybeOAS2Spec).swagger)) === 2;
+export const isOAS3Spec = (document: unknown) =>
+  isObject(document) && 'openapi' in document && parseInt(String((document as MaybeOAS3Spec).openapi)) === 3;

--- a/src/rulesets/lookups.ts
+++ b/src/rulesets/lookups.ts
@@ -3,16 +3,11 @@ const isObject = (thing: unknown): thing is object => thing !== null && typeof t
 type MaybeOAS2 = Partial<{ swagger: unknown }>;
 type MaybeOAS3 = Partial<{ openapi: unknown }>;
 
-export const isOpenApiv2_0 = (document: unknown) =>
+export const isOpenApiv2 = (document: unknown) =>
   isObject(document) && 'swagger' in document && parseInt(String((document as MaybeOAS2).swagger)) === 2;
 
-export { isOpenApiv2_0 as isOpenAPIv2 };
-
 export const isOpenApiv3 = (document: unknown) =>
-  isObject(document) && 'openapi' in document && parseInt(String((document as MaybeOAS3).openapi)) === 3;
-
-export const isOpenApiv3_0 = (document: unknown) =>
-  isOpenApiv3(document) && parseFloat(String((document as MaybeOAS3).openapi)) === 3;
+  isObject(document) && 'openapi' in document && parseFloat(String((document as MaybeOAS3).openapi)) === 3;
 
 export const isOpenApiv3_1 = (document: unknown) =>
-  isOpenApiv3(document) && parseFloat(String((document as MaybeOAS3).openapi)) === 3.1;
+  isObject(document) && 'openapi' in document && parseFloat(String((document as MaybeOAS3).openapi)) === 3.1;

--- a/src/rulesets/lookups.ts
+++ b/src/rulesets/lookups.ts
@@ -1,9 +1,18 @@
 const isObject = (thing: unknown): thing is object => thing !== null && typeof thing === 'object';
 
-type MaybeOAS2Spec = Partial<{ swagger: unknown }>;
-type MaybeOAS3Spec = Partial<{ openapi: unknown }>;
+type MaybeOAS2 = Partial<{ swagger: unknown }>;
+type MaybeOAS3 = Partial<{ openapi: unknown }>;
 
-export const isOAS2Spec = (document: unknown) =>
-  isObject(document) && 'swagger' in document && parseInt(String((document as MaybeOAS2Spec).swagger)) === 2;
-export const isOAS3Spec = (document: unknown) =>
-  isObject(document) && 'openapi' in document && parseInt(String((document as MaybeOAS3Spec).openapi)) === 3;
+export const isOpenApiv2_0 = (document: unknown) =>
+  isObject(document) && 'swagger' in document && parseInt(String((document as MaybeOAS2).swagger)) === 2;
+
+export { isOpenApiv2_0 as isOpenAPIv2 };
+
+export const isOpenApiv3 = (document: unknown) =>
+  isObject(document) && 'openapi' in document && parseInt(String((document as MaybeOAS3).openapi)) === 3;
+
+export const isOpenApiv3_0 = (document: unknown) =>
+  isOpenApiv3(document) && parseFloat(String((document as MaybeOAS3).openapi)) === 3;
+
+export const isOpenApiv3_1 = (document: unknown) =>
+  isOpenApiv3(document) && parseFloat(String((document as MaybeOAS3).openapi)) === 3.1;

--- a/src/rulesets/oas/index.json
+++ b/src/rulesets/oas/index.json
@@ -1,4 +1,5 @@
 {
+  "formats": ["oas2", "oas3"],
   "rules": {
     "operation-2xx-response": {
       "description": "Operation must have at least one `2xx` response.",

--- a/src/rulesets/oas/index.json
+++ b/src/rulesets/oas/index.json
@@ -1,5 +1,5 @@
 {
-  "formats": ["oas2", "oas3"],
+  "formats": ["oas-2", "oas-3"],
   "rules": {
     "operation-2xx-response": {
       "description": "Operation must have at least one `2xx` response.",

--- a/src/rulesets/oas/index.json
+++ b/src/rulesets/oas/index.json
@@ -1,5 +1,5 @@
 {
-  "formats": ["oas-2", "oas-3"],
+  "formats": ["oas2", "oas3"],
   "rules": {
     "operation-2xx-response": {
       "description": "Operation must have at least one `2xx` response.",

--- a/src/rulesets/oas2/index.json
+++ b/src/rulesets/oas2/index.json
@@ -1,5 +1,6 @@
 {
   "extends": ["spectral:oas"],
+  "formats": ["oas2"],
   "rules": {
     "api-host": {
       "description": "OpenAPI `host` must be present and non-empty string.",

--- a/src/rulesets/oas2/index.json
+++ b/src/rulesets/oas2/index.json
@@ -1,6 +1,6 @@
 {
   "extends": ["spectral:oas"],
-  "formats": ["oas2"],
+  "formats": ["oas-2"],
   "rules": {
     "api-host": {
       "description": "OpenAPI `host` must be present and non-empty string.",

--- a/src/rulesets/oas2/index.json
+++ b/src/rulesets/oas2/index.json
@@ -1,6 +1,6 @@
 {
   "extends": ["spectral:oas"],
-  "formats": ["oas-2"],
+  "formats": ["oas2"],
   "rules": {
     "api-host": {
       "description": "OpenAPI `host` must be present and non-empty string.",

--- a/src/rulesets/oas3/index.json
+++ b/src/rulesets/oas3/index.json
@@ -1,6 +1,6 @@
 {
   "extends": ["spectral:oas"],
-  "formats": ["oas3"],
+  "formats": ["oas-3"],
   "rules": {
     "api-servers": {
       "description": "OpenAPI `servers` must be present and non-empty array.",

--- a/src/rulesets/oas3/index.json
+++ b/src/rulesets/oas3/index.json
@@ -1,6 +1,6 @@
 {
   "extends": ["spectral:oas"],
-  "formats": ["oas-3"],
+  "formats": ["oas3"],
   "rules": {
     "api-servers": {
       "description": "OpenAPI `servers` must be present and non-empty array.",

--- a/src/rulesets/oas3/index.json
+++ b/src/rulesets/oas3/index.json
@@ -1,5 +1,6 @@
 {
   "extends": ["spectral:oas"],
+  "formats": ["oas3"],
   "rules": {
     "api-servers": {
       "description": "OpenAPI `servers` must be present and non-empty array.",

--- a/src/rulesets/reader.ts
+++ b/src/rulesets/reader.ts
@@ -35,10 +35,14 @@ async function readRulesFromRuleset(
     for (const extended of Array.isArray(extendedRulesets) ? extendedRulesets : [extendedRulesets]) {
       if (Array.isArray(extended)) {
         const parentSeverity = severity === undefined ? extended[1] : severity;
-        mergeRulesets(newRuleset, await readRulesFromRuleset(uri, extended[0], parentSeverity), parentSeverity);
+        mergeRulesets(newRuleset, await readRulesFromRuleset(uri, extended[0], parentSeverity), {
+          severity: parentSeverity,
+        });
       } else {
         const parentSeverity = severity === undefined ? 'recommended' : severity;
-        mergeRulesets(newRuleset, await readRulesFromRuleset(uri, extended, parentSeverity), parentSeverity);
+        mergeRulesets(newRuleset, await readRulesFromRuleset(uri, extended, parentSeverity), {
+          severity: parentSeverity,
+        });
       }
     }
   }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -19,6 +19,8 @@ export const runRules = (
     const rule = rules[name];
     if (!rule) continue;
 
+    if (resolved.format !== void 0 && rule.formats !== void 0 && !rule.formats.includes(resolved.format)) continue;
+
     if (rule.severity !== undefined && getDiagnosticSeverity(rule.severity) === -1) {
       continue;
     }

--- a/src/spectral.ts
+++ b/src/spectral.ts
@@ -20,12 +20,14 @@ import { Resolved } from './resolved';
 import { DEFAULT_SEVERITY_LEVEL, getDiagnosticSeverity } from './rulesets/severity';
 import { runRules } from './runner';
 import {
+  FormatLookup,
   FunctionCollection,
   IConstructorOpts,
   IParsedResult,
   IRuleResult,
   IRunOpts,
   PartialRuleCollection,
+  RegisteredFormats,
   RuleCollection,
   RuleDeclarationCollection,
   RunRuleCollection,
@@ -38,8 +40,11 @@ export class Spectral {
   private _functions: FunctionCollection = defaultFunctions;
   private _resolver: Resolver;
 
+  public formats: RegisteredFormats;
+
   constructor(opts?: IConstructorOpts) {
     this._resolver = opts && opts.resolver ? opts.resolver : new Resolver();
+    this.formats = {};
   }
 
   public async run(target: IParsedResult | object | string, opts: IRunOpts = {}): Promise<IRuleResult[]> {
@@ -106,6 +111,10 @@ export class Spectral {
       }),
       this._parsedMap,
     );
+
+    if (resolved.format === void 0) {
+      resolved.format = Object.keys(this.formats).find(format => this.formats[format](resolved.result));
+    }
 
     return [
       ...refDiagnostics,
@@ -174,6 +183,10 @@ export class Spectral {
         }
       }
     }
+  }
+
+  public registerFormat(format: string, fn: FormatLookup) {
+    this.formats[format] = fn;
   }
 
   private _parsedMap: IParseMap = {

--- a/src/types/rule.ts
+++ b/src/types/rule.ts
@@ -6,6 +6,8 @@ export type Rule = IRule | TruthyRule | XorRule | LengthRule | AlphaRule | Patte
 export interface IRule<T = string, O = any> {
   type?: RuleType;
 
+  formats?: string[];
+
   // A meaningful feedback about the error
   message?: string;
 

--- a/src/types/ruleset.ts
+++ b/src/types/ruleset.ts
@@ -16,5 +16,10 @@ export interface IRuleset {
 
 export interface IRulesetFile {
   extends?: Array<string | [string, FileRulesetSeverity]>;
+  formats?: string[];
   rules: FileRuleCollection;
+}
+
+export interface IRulesetFileMergingStrategy {
+  severity?: FileRulesetSeverity;
 }

--- a/src/types/spectral.ts
+++ b/src/types/spectral.ts
@@ -51,4 +51,8 @@ export interface IParsedResult<R extends IParserResult = IParserResult<unknown, 
   parsed: IParserResult;
   getLocationForJsonPath: GetLocationForJsonPath<R>;
   source?: string;
+  format?: string;
 }
+
+export type FormatLookup = (document: unknown) => boolean;
+export type RegisteredFormats = Dictionary<FormatLookup, string>;


### PR DESCRIPTION
Closes https://github.com/stoplightio/spectral/issues/369

**Checklist**

- [x] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

Heads up - I haven't written any documentation yet, but if we all agree on the proposed API, I'm more than happy to give it a stab.

A few words regarding the implementation I decided to go with.
The PR features support for both of the ideas described in the linked GH issue:
- rule-scoped formats as suggested by @philsturgeon 
- ruleset-scoped formats as suggested by @P0lip

There hasn't been anything said in terms of inheritance, so I decide to keep it simple and make formats ruleset-specific, with no inheritance at all.


Moreover, I hesitated from registering any default formats such as OAS2 or OAS3 globally and made them specific to CLI version only.
I exposed 2 simple functions that can be used for the spec detection, so if one wants to register oas2/oas3 formats, it should be pretty straightforward.


