### PR TITLE
fix: improve no matched formats case handling

### DIFF
--- a/src/resolved.ts
+++ b/src/resolved.ts
@@ -10,7 +10,7 @@ export class Resolved implements IResolveResult {
   public result: unknown;
   public errors: IResolveError[];
   public runner: IResolveRunner;
-  public format?: string;
+  public format?: string | null;
 
   constructor(public spec: IParsedResult, result: IResolveResult, public parsedMap: IParseMap) {
     this.refMap = result.refMap;

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -19,7 +19,11 @@ export const runRules = (
     const rule = rules[name];
     if (!rule) continue;
 
-    if (resolved.format !== void 0 && rule.formats !== void 0 && !rule.formats.includes(resolved.format)) continue;
+    if (
+      rule.formats !== void 0 &&
+      (resolved.format === null || (resolved.format !== void 0 && !rule.formats.includes(resolved.format)))
+    )
+      continue;
 
     if (rule.severity !== undefined && getDiagnosticSeverity(rule.severity) === -1) {
       continue;

--- a/src/spectral.ts
+++ b/src/spectral.ts
@@ -115,7 +115,8 @@ export class Spectral {
     );
 
     if (resolved.format === void 0) {
-      resolved.format = Object.keys(this.formats).find(format => this.formats[format](resolved.result));
+      const foundFormat = Object.keys(this.formats).find(format => this.formats[format](resolved.result));
+      resolved.format = foundFormat === void 0 ? null : foundFormat;
     }
 
     return [


### PR DESCRIPTION
As discussed here https://github.com/stoplightio/spectral/pull/445

**Checklist**

- [x] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

Initially, I thought being lenient in terms of formats matching would make sense, but once I saw the example Phil wrote in the PR above, I realized it's not really developer-friendly and does not make that much sense in the end.
