### PR TITLE
fix: unescape json path properly

### DIFF
--- a/src/__tests__/__fixtures__/studio-default-fixture-oas3.json
+++ b/src/__tests__/__fixtures__/studio-default-fixture-oas3.json
@@ -1,0 +1,24 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Foo",
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3000"
+    }
+  ],
+  "paths": {
+    "/users": {
+      "get": {
+        "summary": "Your GET endpoint",
+        "tags": [],
+        "responses": {}
+      }
+    }
+  },
+  "components": {
+    "schemas": {}
+  }
+}

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -3,6 +3,7 @@ import { get, has } from 'lodash';
 
 const { JSONPath } = require('jsonpath-plus');
 
+import { decodePointerFragment } from '@stoplight/json';
 import { Resolved } from './resolved';
 import { message } from './rulesets/message';
 import { getDiagnosticSeverity } from './rulesets/severity';
@@ -94,7 +95,7 @@ export const lintNode = (
 
     results = results.concat(
       targetResults.map<IRuleResult>(result => {
-        const path = result.path || targetPath;
+        const path = (result.path || targetPath).map(segment => decodePointerFragment(String(segment)));
         const location = resolved.getLocationForJsonPath(path, true);
 
         return {

--- a/src/rulesets/oas2/__tests__/oas2-schema.ts
+++ b/src/rulesets/oas2/__tests__/oas2-schema.ts
@@ -36,15 +36,15 @@ describe('oas2-schema', () => {
       {
         code: 'oas2-schema',
         message: "/paths//test/get should have required property 'responses'",
-        path: ['paths', '~1test', 'get'],
+        path: ['paths', '/test', 'get'],
         range: {
           end: {
             character: 15,
             line: 4,
           },
           start: {
-            character: 10,
-            line: 2,
+            character: 12,
+            line: 4,
           },
         },
         severity: 0,


### PR DESCRIPTION
Fixes https://github.com/stoplightio/spectral/issues/457

**Checklist**

- [x] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

See the issue for more info. The issue itself is fairly subtle and minor, but it's something that might introduce confusion when the linted document is huge.