### PR TITLE
fix: generate proper paths and ranges for documents with $refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@oclif/config": "^1.13.2",
     "@oclif/plugin-help": "^2.0",
     "@stoplight/json": "^3.0.4",
-    "@stoplight/json-ref-resolver": "^2.1.2",
+    "@stoplight/json-ref-resolver": "^2.2.0",
     "@stoplight/path": "^1.1.0",
     "@stoplight/types": "^11.0.0",
     "@stoplight/yaml": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@oclif/command": "^1.5.17",
     "@oclif/config": "^1.13.2",
     "@oclif/plugin-help": "^2.0",
-    "@stoplight/json": "^3.0.4",
+    "@stoplight/json": "^3.1.1",
     "@stoplight/json-ref-resolver": "^2.2.0",
     "@stoplight/path": "^1.1.0",
     "@stoplight/types": "^11.0.0",

--- a/src/__tests__/__fixtures__/document-with-external-refs.oas2.json
+++ b/src/__tests__/__fixtures__/document-with-external-refs.oas2.json
@@ -3,27 +3,16 @@
   "info": {
     "title": "To-dos",
     "version": "1.0",
-    "description": "This OpenAPI v2 (Swagger) file represents a real API that lives at http://todos.stoplight.io.\n\nIt exposes functionality to manage to-do lists.",
-    "contact": {
-      "name": "Stoplight",
-      "url": "https://stoplight.io"
-    },
-    "license": {
-      "name": "MIT"
-    }
+    "description": "This OpenAPI v2 (Swagger) file represents a real API that lives at http://todos.stoplight.io.\n\nIt exposes functionality to manage to-do lists."
   },
   "host": "todos.stoplight.io",
-  "schemes": [
-    "http"
-  ],
+  "schemes": ["http"],
   "paths": {
     "/todos/{todoId}": {
       "get": {
         "operationId": "GET_todo",
         "summary": "Get Todo",
-        "tags": [
-          "Todos"
-        ],
+        "tags": ["Todos"],
         "responses": {
           "200": {
             "description": "",

--- a/src/__tests__/__fixtures__/document-with-external-refs.oas2.json
+++ b/src/__tests__/__fixtures__/document-with-external-refs.oas2.json
@@ -1,0 +1,48 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "To-dos",
+    "version": "1.0",
+    "description": "This OpenAPI v2 (Swagger) file represents a real API that lives at http://todos.stoplight.io.\n\nIt exposes functionality to manage to-do lists.",
+    "contact": {
+      "name": "Stoplight",
+      "url": "https://stoplight.io"
+    },
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "todos.stoplight.io",
+  "schemes": [
+    "http"
+  ],
+  "paths": {
+    "/todos/{todoId}": {
+      "get": {
+        "operationId": "GET_todo",
+        "summary": "Get Todo",
+        "tags": [
+          "Todos"
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "./models/todo-full.v1.json"
+            },
+            "examples": {
+              "application/json": {
+                "id": 1,
+                "name": "get food",
+                "completed": false,
+                "completed_at": "1955-04-23T13:22:52.685Z",
+                "created_at": "1994-11-05T03:26:51.471Z",
+                "updated_at": "1989-07-29T11:30:06.701Z"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/__tests__/__fixtures__/models/todo-full.v1.json
+++ b/src/__tests__/__fixtures__/models/todo-full.v1.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Todo Full",
+  "allOf": [
+    {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1000000
+        },
+        "completed_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": [
+        "id",
+        "user"
+      ]
+    }
+  ],
+  "x-tags": [
+    "Todos"
+  ]
+}

--- a/src/__tests__/spectral.jest.test.ts
+++ b/src/__tests__/spectral.jest.test.ts
@@ -141,12 +141,32 @@ describe('Spectral', () => {
       expect.objectContaining({
         code: 'path-params',
         path: ['paths', '/todos/{todoId}'],
+        range: {
+          end: {
+            character: 5,
+            line: 45,
+          },
+          start: {
+            character: 23,
+            line: 19,
+          },
+        },
         source: undefined,
       }),
       expect.objectContaining({
         code: 'operation-description',
         path: ['paths', '/todos/{todoId}', 'get'],
         source: undefined,
+        range: {
+          end: {
+            character: 7,
+            line: 44,
+          },
+          start: {
+            character: 13,
+            line: 20,
+          },
+        },
       }),
     ]);
   });

--- a/src/__tests__/spectral.jest.test.ts
+++ b/src/__tests__/spectral.jest.test.ts
@@ -77,7 +77,7 @@ describe('Spectral', () => {
     });
   });
 
-  test('reports issues for correct files', async () => {
+  test('reports issues for correct files with correct ranges and paths', async () => {
     const documentUri = path.join(__dirname, './__fixtures__/document-with-external-refs.oas2.json');
     const spectral = new Spectral({ resolver: httpAndFileResolver });
     await spectral.loadRuleset('spectral:oas');
@@ -93,81 +93,84 @@ describe('Spectral', () => {
       },
     });
 
-    expect(results).toEqual([
-      expect.objectContaining({
-        code: 'oas2-schema',
-        path: ['paths', '/todos/{todoId}', 'get', 'responses', '200'],
-        range: {
-          end: {
-            character: 10,
-            line: 42,
+    expect(results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'oas2-schema',
+          path: ['paths', '/todos/{todoId}', 'get', 'responses', '200'],
+          range: {
+            end: {
+              character: 11,
+              line: 31,
+            },
+            start: {
+              character: 17,
+              line: 16,
+            },
           },
-          start: {
-            character: 17,
-            line: 27,
+          source: undefined,
+        }),
+        expect.objectContaining({
+          code: 'oas2-schema',
+          path: ['paths', '/todos/{todoId}', 'get', 'responses', '200', 'schema'],
+          range: {
+            end: {
+              character: 1,
+              line: 37,
+            },
+            start: {
+              character: 0,
+              line: 0,
+            },
           },
-        },
-      }),
-      expect.objectContaining({
-        code: 'oas2-schema',
-        path: ['paths', '/todos/{todoId}', 'get', 'responses', '200', 'schema'],
-        range: {
-          end: {
-            character: 1,
-            line: 37,
+          source: expect.stringContaining('__fixtures__/models/todo-full.v1.json'),
+        }),
+        expect.objectContaining({
+          code: 'path-params',
+          path: ['paths', '/todos/{todoId}'],
+          range: {
+            end: {
+              character: 5,
+              line: 34,
+            },
+            start: {
+              character: 23,
+              line: 10,
+            },
           },
-          start: {
-            character: 0,
-            line: 0,
+          source: undefined,
+        }),
+        expect.objectContaining({
+          code: 'info-contact',
+          path: ['info'],
+          range: {
+            end: {
+              character: 3,
+              line: 6,
+            },
+            start: {
+              character: 10,
+              line: 2,
+            },
           },
-        },
-        source: expect.stringContaining('__fixtures__/models/todo-full.v1.json'),
-      }),
-      expect.objectContaining({
-        code: 'oas2-schema',
-        path: ['paths', '/todos/{todoId}', 'get', 'responses', '200', 'schema'],
-        range: {
-          end: {
-            character: 1,
-            line: 37,
+          source: undefined,
+        }),
+        expect.objectContaining({
+          code: 'operation-description',
+          path: ['paths', '/todos/{todoId}', 'get'],
+          range: {
+            end: {
+              character: 7,
+              line: 33,
+            },
+            start: {
+              character: 13,
+              line: 11,
+            },
           },
-          start: {
-            character: 0,
-            line: 0,
-          },
-        },
-        source: expect.stringContaining('__fixtures__/models/todo-full.v1.json'),
-      }),
-      expect.objectContaining({
-        code: 'path-params',
-        path: ['paths', '/todos/{todoId}'],
-        range: {
-          end: {
-            character: 5,
-            line: 45,
-          },
-          start: {
-            character: 23,
-            line: 19,
-          },
-        },
-        source: undefined,
-      }),
-      expect.objectContaining({
-        code: 'operation-description',
-        path: ['paths', '/todos/{todoId}', 'get'],
-        source: undefined,
-        range: {
-          end: {
-            character: 7,
-            line: 44,
-          },
-          start: {
-            character: 13,
-            line: 20,
-          },
-        },
-      }),
-    ]);
+          source: undefined,
+        }),
+      ]),
+    );
   });
 });

--- a/src/resolved.ts
+++ b/src/resolved.ts
@@ -1,6 +1,5 @@
 import { IResolveError, IResolveResult } from '@stoplight/json-ref-resolver/types';
-import { Dictionary, ILocation, JsonPath } from '@stoplight/types';
-import { Segment } from '@stoplight/types/dist';
+import { Dictionary, ILocation, JsonPath, Segment } from '@stoplight/types';
 import { get } from 'lodash';
 import { IParseMap, REF_METADATA } from './spectral';
 import { IParsedResult } from './types';
@@ -35,7 +34,7 @@ export class Resolved {
       }
     }
 
-    if (target) {
+    if (target && target[REF_METADATA]) {
       return {
         path: [...get(target, [REF_METADATA, 'root'], []), ...newPath],
         doc: get(this.parsedMap.parsed, get(target, [REF_METADATA, 'ref']), this.spec),
@@ -43,7 +42,7 @@ export class Resolved {
     }
 
     return {
-      path: newPath,
+      path,
       doc: this.spec,
     };
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -604,36 +604,21 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@stoplight/fast-safe-stringify@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@stoplight/fast-safe-stringify/-/fast-safe-stringify-2.1.2.tgz#2811eff4989c3d4c5c9a3789f057e25358db0899"
-  integrity sha512-ayw3qQ9KNn2K5q6ggrLclh+rdZsSLwYIUz3uAer1NzaCpalJLR4g32G845ylgq7Xy2AunMHnNfD3FC3s0rUcsA==
-
-"@stoplight/json-ref-resolver@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@stoplight/json-ref-resolver/-/json-ref-resolver-2.1.2.tgz#56993d3245dba1264ff87052ee960fbe8d259c98"
-  integrity sha512-DaHxK2KI7HmnsI2BTMwdnsdmj65VNFFPTkvhg2FukszxUpcPlgYVbHjtzEigj4Jn4XryTexlWx7Id4fuRUM7Ug==
+"@stoplight/json-ref-resolver@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/json-ref-resolver/-/json-ref-resolver-2.2.0.tgz#f12fed6ca618d9cd6031f5d0405a3ae5ffd54fad"
+  integrity sha512-42z5MNkLKF7Ynq2rM8YSd6SoJvEX5k0ugQujpB8Co7K5m3vhq1LK+/faFhuMfuFy6As9BxVUnDbGchYERXK17Q==
   dependencies:
-    "@stoplight/json" "^2.2.2"
+    "@stoplight/json" "^3.1.0"
     "@stoplight/types" "^11.0.0"
     dependency-graph "~0.8.0"
     fast-memoize "^2.5.1"
-    immer "^3.1.3"
-    lodash "^4.17"
+    immer "^3.2.0"
+    lodash "^4.17.15"
     urijs "~1.19.1"
-    vscode-uri "^2.0.2"
+    vscode-uri "^2.0.3"
 
-"@stoplight/json@^2.2.2":
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/@stoplight/json/-/json-2.3.3.tgz#7f461f7e9234a244af7d7e3c0d37fd66fc944eac"
-  integrity sha512-iGRT6N/uUnoXbaGAGlcJJNbI7zZity+vLb1GBUezLeuW1ZHUevxfqK1kvrxK3iZD/2slOPeH23mDHIk56nswSA==
-  dependencies:
-    "@stoplight/fast-safe-stringify" "^2.1.2"
-    "@stoplight/types" "^9.1.2"
-    jsonc-parser "~2.1.0"
-    lodash "^4.10"
-
-"@stoplight/json@^3.0.4":
+"@stoplight/json@^3.0.4", "@stoplight/json@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@stoplight/json/-/json-3.1.0.tgz#a03bd8d065a62eb00cd42cf003df431f23d7a5dd"
   integrity sha512-8Fev+RW+UJNYtcpDgvQPH6MuHEf5cr95KnAyMBNNXlVIeRAIJqYK3r5FWZv4/KFH08ozQy4QpMM9MdsR8J3cZQ==
@@ -652,13 +637,6 @@
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-11.0.0.tgz#fd234cfcb1a1cee28ef9642735d9206e009a8fa6"
   integrity sha512-Tt8doUE2E5HACigjBHyBpMHS+Td+9tBmGvf4giDH9jK7mS6Q7dyLOeE2QSKyMrslmzd1mRuKBvPhS18g9EEjog==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-
-"@stoplight/types@^9.1.2":
-  version "9.1.2"
-  resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-9.1.2.tgz#0b2ed2032ae901491543b9dd19309ff3a0acf12a"
-  integrity sha512-eNeWwTZ1E47mrprEdgtOutovVKxYTbm8k/B7Lh4JAusGoiHbMmzVT+IDdayBpOCzq+qKLzuP0z3IZo74IXaaEg==
   dependencies:
     "@types/json-schema" "^7.0.3"
 
@@ -3566,10 +3544,10 @@ ignore@^5.1.1:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.2.tgz#e28e584d43ad7e92f96995019cc43b9e1ac49558"
   integrity sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==
 
-immer@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-3.1.3.tgz#59bc742b2aab6e2c676445edb653e588a23c70fc"
-  integrity sha512-HG5SXTXTTVy9lGNwS075cNhQoV375jHsIJO3UtMjuUWJOuwlMr0u42FlsKTJcppt5AzsFAsmj9r4kHvsSHh3hQ==
+immer@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-3.2.0.tgz#53686471e9dd2b070e0fb5500c6fdecd3a99375f"
+  integrity sha512-+a2R8z9eELHst6aht++nzVzJ8LJ+Hsg49qttfg9Kc/vmoxEdPXw5/rV6+4DYWGgnq+B36KbLr4OTaGtS9mDjtg==
 
 import-fresh@^2.0.0:
   version "2.0.0"
@@ -4587,7 +4565,7 @@ json5@2.x, json5@^2.1.0:
   dependencies:
     minimist "^1.2.0"
 
-jsonc-parser@~2.1.0, jsonc-parser@~2.1.1:
+jsonc-parser@~2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-2.1.1.tgz#83dc3d7a6e7186346b889b1280eefa04446c6d3e"
   integrity sha512-VC0CjnWJylKB1iov4u76/W/5Ef0ydDkjtYWxoZ9t3HdWlSnZQwZL5MgFikaB/EtQ4RmMEw3tmQzuYnZA2/Ja1g==
@@ -4945,7 +4923,7 @@ lodash@4.17.14:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
 
-lodash@>=4.17.5, lodash@^4.10, lodash@^4.17, lodash@^4.17.0, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.5, lodash@^4.2.1:
+lodash@>=4.17.5, lodash@^4.17.0, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.5, lodash@^4.2.1:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -7852,7 +7830,7 @@ void-elements@^2.0.0:
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
   integrity sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=
 
-vscode-uri@^2.0.2:
+vscode-uri@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.0.3.tgz#25e5f37f552fbee3cec7e5f80cef8469cefc6543"
   integrity sha512-4D3DI3F4uRy09WNtDGD93H9q034OHImxiIcSq664Hq1Y1AScehlP3qqZyTkX/RWxeu0MRMHGkrxYqm2qlDF/aw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -618,10 +618,20 @@
     urijs "~1.19.1"
     vscode-uri "^2.0.3"
 
-"@stoplight/json@^3.0.4", "@stoplight/json@^3.1.0":
+"@stoplight/json@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@stoplight/json/-/json-3.1.0.tgz#a03bd8d065a62eb00cd42cf003df431f23d7a5dd"
   integrity sha512-8Fev+RW+UJNYtcpDgvQPH6MuHEf5cr95KnAyMBNNXlVIeRAIJqYK3r5FWZv4/KFH08ozQy4QpMM9MdsR8J3cZQ==
+  dependencies:
+    "@stoplight/types" "^11.0.0"
+    jsonc-parser "~2.1.1"
+    lodash "^4.17.15"
+    safe-stable-stringify "^1.1"
+
+"@stoplight/json@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@stoplight/json/-/json-3.1.1.tgz#531d966a62247bf2ab1e8a06a685fa62e36cf890"
+  integrity sha512-DK2ufmnPvfW9Mv0q4DYtldjicTTcBY+j4kiEUOEmc9hL+mzMDV08+5ix4tmPtheUDZH6OtEqEmGcf8ZKCHFbpg==
   dependencies:
     "@stoplight/types" "^11.0.0"
     jsonc-parser "~2.1.1"


### PR DESCRIPTION
Fixes https://github.com/stoplightio/spectral/issues/498 

**Checklist**

- [x] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

Discovered when working in Studio. ~It's not completed yet.~
There is still one weird issue - duplicate validation results. ~I believe my PR could have introduced it, so will fix it here.~
Nope, my code does not seem to be the cause of the issue. ~I'll file a bug report shortly.~ https://github.com/stoplightio/spectral/issues/500 it is 

~Blocked by https://github.com/stoplightio/json/pull/31~