### PR TITLE
fix: supress unknown format AJV error

### DIFF
--- a/src/functions/__tests__/schema.test.ts
+++ b/src/functions/__tests__/schema.test.ts
@@ -6,6 +6,27 @@ function runSchema(target: any, schemaObj: object) {
 }
 
 describe('schema', () => {
+  describe('when schema defines unknown format', () => {
+    const testSchema = {
+      type: 'string',
+      format: 'ISO-3166-1 alpha-2',
+    };
+
+    beforeEach(() => {
+      jest.spyOn(console, 'warn');
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    test('does not log a warning in the console', () => {
+      const input = 'some string';
+      expect(runSchema(input, testSchema)).toEqual([]);
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+  });
+
   describe('when schema defines a simple array', () => {
     const testSchema = {
       type: 'array',

--- a/src/functions/schema.ts
+++ b/src/functions/schema.ts
@@ -1,21 +1,34 @@
 import * as AJV from 'ajv';
-import * as jsonSpecv4 from 'ajv/lib/refs/json-schema-draft-04.json';
-const oasFormatValidator = require('ajv-oai/lib/format-validator');
 import { ValidateFunction } from 'ajv';
+import * as jsonSpecv4 from 'ajv/lib/refs/json-schema-draft-04.json';
 import { IOutputError } from 'better-ajv-errors';
 import { JSONSchema4, JSONSchema6 } from 'json-schema';
 import { IFunction, IFunctionResult, ISchemaOptions } from '../types';
+const oasFormatValidator = require('ajv-oai/lib/format-validator');
 const betterAjvErrors = require('better-ajv-errors/lib/modern');
 
 interface IAJVOutputError extends IOutputError {
   path?: string;
 }
 
+const logger = {
+  warn(...args: any[]) {
+    const firstArg = args[0];
+    if (typeof firstArg === 'string') {
+      if (firstArg.startsWith('unknown format')) return;
+      console.warn(...args);
+    }
+  },
+  log: console.log,
+  error: console.error,
+};
+
 const ajv = new AJV({
   meta: false,
   schemaId: 'auto',
   jsonPointers: true,
   unknownFormats: 'ignore',
+  logger,
 });
 ajv.addMetaSchema(jsonSpecv4);
 // @ts-ignore


### PR DESCRIPTION
Fixes https://github.com/stoplightio/spectral/issues/396

**Checklist**

- [x] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No


**Additional context**

Removes AJV warnings starting with 'unknown format'
