### PR TITLE
chore(resolver): remove redundant parseResolveResult

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@stoplight/json": "^3.1.1",
     "@stoplight/json-ref-resolver": "^2.2.0",
-    "@stoplight/path": "^1.1.0",
+    "@stoplight/path": "^1.2.0",
     "@stoplight/types": "^11.0.0",
     "@stoplight/yaml": "^3.1.0",
     "abort-controller": "^3.0.0",

--- a/src/resolvers/http-and-file.ts
+++ b/src/resolvers/http-and-file.ts
@@ -1,6 +1,4 @@
 import { Resolver } from '@stoplight/json-ref-resolver';
-import { extname } from '@stoplight/path';
-import { parse } from '@stoplight/yaml';
 import * as fs from 'fs';
 
 import { httpReader } from './http';
@@ -15,23 +13,14 @@ export const httpAndFileResolver = new Resolver({
         return new Promise((resolve, reject) => {
           const path = ref.path();
           fs.readFile(path, 'utf8', (err, data) => {
-            if (err) reject(err);
-            resolve(data);
+            if (err) {
+              reject(err);
+            } else {
+              resolve(data);
+            }
           });
         });
       },
     },
-  },
-
-  parseResolveResult: async opts => {
-    const ext = extname(opts.targetAuthority.toString());
-
-    if (ext === '.yml' || ext === '.yaml') {
-      opts.result = parse(opts.result);
-    } else if (ext === '.json') {
-      opts.result = JSON.parse(opts.result);
-    }
-
-    return opts;
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -386,7 +386,7 @@
     lodash "^4.17.15"
     safe-stable-stringify "^1.1"
 
-"@stoplight/path@^1.1.0":
+"@stoplight/path@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@stoplight/path/-/path-1.2.0.tgz#0d0b828e10c2a492ab12c5fcffda2a4b4a4785b0"
   integrity sha512-0GE2585RbYhR7HXTRK+AB/BBwOrqMAdAdBTzuJ5itFQwx3b/Qo0qi0y0Qis5vX6pswVm/6vlx5xBfSBYysI9BQ==
@@ -4709,6 +4709,13 @@ make-dir@^2.1.0:
   dependencies:
     pify "^4.0.1"
     semver "^5.6.0"
+
+make-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.0.0.tgz#1b5f39f6b9270ed33f9f054c5c0f84304989f801"
+  integrity sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==
+  dependencies:
+    semver "^6.0.0"
 
 make-error@1.x, make-error@^1.1.1:
   version "1.3.5"


### PR DESCRIPTION
The code is never really executed, since we pass our own `parseResolveResult` in `Spectral#run`.