### PR TITLE
docs: missing recommended true

### DIFF
--- a/docs/getting-started/rulesets.md
+++ b/docs/getting-started/rulesets.md
@@ -12,6 +12,7 @@ rules:
     description: Tags must have a description.
     given: $.tags[*]
     severity: error
+    recommended: true
     then:
       field: description
       function: truthy

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -24,9 +24,11 @@ Other options include:
   --quiet, -q                  no logging - output only                                     [boolean]
 ```
 
-> Note: The Spectral CLI supports both YAML and JSON.
+The Spectral CLI supports loading documents as YAML or JSON, and validation of OpenAPI v2/v3 documents via our built-in ruleset. 
 
-Currently, Spectral CLI supports validation of OpenAPI v2/v3 documents via our built-in ruleset, or you can create [custom rulesets](../getting-started/rulesets.md) to work with any JSON/YAML documents.
+You can also provide your own ruleset file. By default, the Spectral CLI will look for a ruleset file called `.spectral.yml` or `.spectral.json` in the current working directory. You can tell spectral to use a different file by using the `--ruleset` CLI option.
+
+Here you can build a [custom ruleset](../getting-started/rulesets.md), or extend and modify our [core OpenAPI ruleset](https://stoplight.io/p/docs/gh/stoplightio/spectral/docs/reference/openapi-rules.md).
 
 ## Error Results
 


### PR DESCRIPTION
closes #559

More work needs to be done on how recommended works and is documented, because this stuff is not clear right now. This will be done as part of #447, but this will at least help in the mean time. 