### PR TITLE
fix(schema): support draft 6 and 7

### DIFF
--- a/src/functions/__tests__/schema.test.ts
+++ b/src/functions/__tests__/schema.test.ts
@@ -6,6 +6,60 @@ function runSchema(target: any, schemaObj: object) {
 }
 
 describe('schema', () => {
+  describe('validates falsy values such as', () => {
+    test('empty string', () => {
+      const testSchema: JSONSchema6 = {
+        type: 'number',
+      };
+
+      expect(runSchema('', testSchema)).toEqual([
+        {
+          message: 'type should be number',
+          path: [],
+        },
+      ]);
+    });
+
+    test('zero', () => {
+      const testSchema: JSONSchema6 = {
+        type: 'string',
+      };
+
+      expect(runSchema(0, testSchema)).toEqual([
+        {
+          message: 'type should be string',
+          path: [],
+        },
+      ]);
+    });
+
+    test('false', () => {
+      const testSchema: JSONSchema6 = {
+        type: 'string',
+      };
+
+      expect(runSchema(false, testSchema)).toEqual([
+        {
+          message: 'type should be string',
+          path: [],
+        },
+      ]);
+    });
+
+    test('null', () => {
+      const testSchema: JSONSchema6 = {
+        type: 'string',
+      };
+
+      expect(runSchema(null, testSchema)).toEqual([
+        {
+          message: 'type should be string',
+          path: [],
+        },
+      ]);
+    });
+  });
+
   describe('when schema defines unknown format', () => {
     const testSchema = {
       type: 'string',

--- a/src/functions/__tests__/schema.test.ts
+++ b/src/functions/__tests__/schema.test.ts
@@ -144,7 +144,7 @@ describe('schema', () => {
     });
   });
 
-  describe('handles duplicate JSONSchema4 ids', () => {
+  test('handles duplicate JSONSchema Draft 4 ids', () => {
     const testSchema: JSONSchema4 = {
       id: 'test',
       type: 'string',
@@ -164,7 +164,7 @@ describe('schema', () => {
     expect(runSchema('a', testSchema2)).toEqual([]);
   });
 
-  describe('handles duplicate JSONSchema6 ids', () => {
+  test('handles duplicate JSONSchema Draft 6 and 7 $ids', () => {
     const testSchema: JSONSchema6 = {
       $id: 'test',
       type: 'string',
@@ -182,5 +182,14 @@ describe('schema', () => {
       },
     ]);
     expect(runSchema('a', testSchema2)).toEqual([]);
+  });
+
+  test.each([4, 6, 7])('accepts draft %d', draft => {
+    const testSchema: JSONSchema6 = {
+      $schema: `http://json-schema.org/draft-0${draft}/schema#`,
+      type: 'string',
+    };
+
+    expect(runSchema.bind(null, 'd', testSchema)).not.toThrow();
   });
 });

--- a/src/functions/schema.ts
+++ b/src/functions/schema.ts
@@ -1,6 +1,8 @@
 import * as AJV from 'ajv';
 import { ValidateFunction } from 'ajv';
 import * as jsonSpecv4 from 'ajv/lib/refs/json-schema-draft-04.json';
+import * as jsonSpecv6 from 'ajv/lib/refs/json-schema-draft-06.json';
+import * as jsonSpecv7 from 'ajv/lib/refs/json-schema-draft-07.json';
 import { IOutputError } from 'better-ajv-errors';
 import { JSONSchema4, JSONSchema6 } from 'json-schema';
 import { IFunction, IFunctionResult, ISchemaOptions } from '../types';
@@ -31,6 +33,8 @@ const ajv = new AJV({
   logger,
 });
 ajv.addMetaSchema(jsonSpecv4);
+ajv.addMetaSchema(jsonSpecv6);
+ajv.addMetaSchema(jsonSpecv7);
 // @ts-ignore
 ajv._opts.defaultMeta = jsonSpecv4.id;
 // @ts-ignore

--- a/src/functions/schema.ts
+++ b/src/functions/schema.ts
@@ -82,7 +82,7 @@ export const schema: IFunction<ISchemaOptions> = (targetVal, opts, paths) => {
 
   const path = paths.target || paths.given;
 
-  if (!targetVal)
+  if (targetVal === void 0)
     return [
       {
         path,

--- a/test-harness/scenarios/external-schemas-ruleset.scenario
+++ b/test-harness/scenarios/external-schemas-ruleset.scenario
@@ -1,0 +1,17 @@
+====test====
+Schemas referenced via $refs are resolved and used
+====document====
+openapi: 3.0.2
+info:
+  title: foo
+  description: baz
+====command====
+lint {document} --ruleset ./test-harness/scenarios/rulesets/external-schemas-ruleset.yaml
+====stdout====
+OpenAPI 3.x detected
+
+{document}
+ 3:10  error  info-title        should be equal to one of the allowed values
+ 4:16  error  info-description  should be equal to one of the allowed values
+
+✖ 2 problems (2 errors, 0 warnings, 0 infos, 0 hints)

--- a/test-harness/scenarios/rulesets/external-schemas-ruleset.yaml
+++ b/test-harness/scenarios/rulesets/external-schemas-ruleset.yaml
@@ -1,0 +1,23 @@
+rules:
+  info-description:
+    message: "{{error}}"
+    severity: error
+    given: $.info.description
+    type: style
+    recommended: true
+    then:
+      function: schema # note, this rule could use pattern function, but for test purposes I made the rule use schema function
+      functionOptions:
+        schema:
+          $ref: ./schemas/foo-description.yaml#
+  info-title:
+    message: "{{error}}"
+    severity: error
+    given: $.info.title
+    type: style
+    recommended: true
+    then:
+      function: schema # note, as above, this rule could use pattern function, but for test purposes I made the rule use schema function
+      functionOptions:
+        schema:
+          $ref: ./schemas/stoplight-title.yaml#

--- a/test-harness/scenarios/rulesets/schemas/foo-description.yaml
+++ b/test-harness/scenarios/rulesets/schemas/foo-description.yaml
@@ -1,0 +1,6 @@
+$schema: http://json-schema.org/draft-07/schema#
+type: string
+enum:
+  - foo
+  - foo-bar
+  - bar-foo

--- a/test-harness/scenarios/rulesets/schemas/stoplight-title.yaml
+++ b/test-harness/scenarios/rulesets/schemas/stoplight-title.yaml
@@ -1,0 +1,6 @@
+$schema: http://json-schema.org/draft-06/schema#
+type: string
+enum:
+  - Stoplight
+  - Stoplight.io
+  - StoplightIO


### PR DESCRIPTION
Fixes https://github.com/stoplightio/spectral/issues/573

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Additional context**

Contains 2 unrelated fixes (see commit messages).

Regarding ajv-better-errors and the exception that's thrown - I'll try to provide a fix for the package.

This is where it fails:
https://github.com/atlassian/better-ajv-errors/blob/126ee2e45ee829e69e3b2f3f6d56eb49d5c42135/src/validation-errors/enum.js#L52
https://github.com/janl/node-jsonpointer/blob/master/jsonpointer.js#L60
Basically, jsonpointer does not expect non-object value.