### PR TITLE
feat(cli): display the amount of enabled rules

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -4,8 +4,10 @@ const { JSONPath } = require('jsonpath-plus');
 
 import { lintNode } from './linter';
 import { getDiagnosticSeverity } from './rulesets/severity';
-import { FunctionCollection, IGivenNode, IRuleResult, IRunRule, RunRuleCollection } from './types';
+import { FunctionCollection, IGivenNode, IRule, IRuleResult, IRunRule, RunRuleCollection } from './types';
 import { hasIntersectingElement } from './utils/';
+
+export const isRuleEnabled = (rule: IRule) => rule.severity !== void 0 && getDiagnosticSeverity(rule.severity) !== -1;
 
 export const runRules = (
   resolved: Resolved,
@@ -27,7 +29,7 @@ export const runRules = (
     )
       continue;
 
-    if (rule.severity !== void 0 && getDiagnosticSeverity(rule.severity) === -1) {
+    if (!isRuleEnabled(rule)) {
       continue;
     }
 

--- a/test-harness/scenarios/enabled-rules-amount.oas3.scenario
+++ b/test-harness/scenarios/enabled-rules-amount.oas3.scenario
@@ -1,0 +1,36 @@
+====test====
+The amount of enabled rules is printed in a parenthesis.
+====document====
+openapi: 3.0.2
+paths:
+  /pets:
+    parameters:
+      - name: abc
+        in: body
+    get:
+      parameters:
+        - name: ok
+          in: header
+      responses:
+        200:
+          description: abc
+components:
+  parameters:
+    skipParam:
+      name: skip
+      in: query
+      schema:
+        type: integer
+====command====
+lint {document} --ruleset ./test-harness/scenarios/rulesets/parameter-description.oas3.yaml -v
+====stdout====
+Linting {document}
+Found 52 rules (1 enabled)
+OpenAPI 3.x detected
+
+{document}
+  5:9   warning  oas3-parameter-description  Parameter objects should have a `description`.
+  9:11  warning  oas3-parameter-description  Parameter objects should have a `description`.
+ 16:15  warning  oas3-parameter-description  Parameter objects should have a `description`.
+
+✖ 3 problems (0 errors, 3 warnings, 0 infos, 0 hints)


### PR DESCRIPTION
Closes https://github.com/stoplightio/spectral/issues/435

**Checklist**

- [x] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Additional context**

I believe we could go even further and display the amount of skipped rules.
Thoughts?
