### PR TITLE
refactor(resolving): accept any object implementing IResolver

### DIFF
--- a/src/linter.ts
+++ b/src/linter.ts
@@ -116,18 +116,7 @@ export const lintNode = (
           path,
           severity: getDiagnosticSeverity(rule.severity),
           source: location.uri,
-          ...(location || {
-            range: {
-              start: {
-                character: 0,
-                line: 0,
-              },
-              end: {
-                character: 0,
-                line: 0,
-              },
-            },
-          }),
+          range: location.range,
         };
       }),
     );

--- a/src/resolved.ts
+++ b/src/resolved.ts
@@ -1,7 +1,7 @@
-import { IResolveError, IResolveResult } from '@stoplight/json-ref-resolver/types';
+import { IResolveError } from '@stoplight/json-ref-resolver/types';
 import { Dictionary, ILocation, IRange, JsonPath, Segment } from '@stoplight/types';
 import { get, has } from 'lodash';
-import { IParseMap, REF_METADATA } from './spectral';
+import { IParseMap, REF_METADATA, ResolveResult } from './spectral';
 import { IParsedResult } from './types';
 
 const getDefaultRange = (): IRange => ({
@@ -16,18 +16,19 @@ const getDefaultRange = (): IRange => ({
 });
 
 export class Resolved {
-  public refMap: Dictionary<string>;
-  public resolved: unknown;
-  public unresolved: unknown;
-  public errors: IResolveError[];
+  public readonly refMap: Dictionary<string>;
+  public readonly resolved: unknown;
+  public readonly unresolved: unknown;
+  public readonly errors: IResolveError[];
   public formats?: string[] | null;
 
-  constructor(public spec: IParsedResult, resolveResult: IResolveResult, public parsedMap: IParseMap) {
+  constructor(public spec: IParsedResult, resolveResult: ResolveResult, public parsedMap: IParseMap) {
+    this.unresolved = spec.parsed.data;
+    this.formats = spec.formats;
+
     this.refMap = resolveResult.refMap;
     this.resolved = resolveResult.result;
-    this.unresolved = spec.parsed.data;
     this.errors = resolveResult.errors;
-    this.formats = spec.formats;
   }
 
   public getParsedForJsonPath(path: JsonPath) {

--- a/src/resolved.ts
+++ b/src/resolved.ts
@@ -1,8 +1,19 @@
 import { IResolveError, IResolveResult } from '@stoplight/json-ref-resolver/types';
-import { Dictionary, ILocation, JsonPath, Segment } from '@stoplight/types';
-import { get } from 'lodash';
+import { Dictionary, ILocation, IRange, JsonPath, Segment } from '@stoplight/types';
+import { get, has } from 'lodash';
 import { IParseMap, REF_METADATA } from './spectral';
 import { IParsedResult } from './types';
+
+const getDefaultRange = (): IRange => ({
+  start: {
+    line: 0,
+    character: 0,
+  },
+  end: {
+    line: 0,
+    character: 0,
+  },
+});
 
 export class Resolved {
   public refMap: Dictionary<string>;
@@ -41,6 +52,10 @@ export class Resolved {
       };
     }
 
+    if (path.length > 0 && !has(this.spec.parsed.data, path)) {
+      return null;
+    }
+
     return {
       path,
       doc: this.spec,
@@ -49,23 +64,17 @@ export class Resolved {
 
   public getLocationForJsonPath(path: JsonPath, closest?: boolean): ILocation {
     const parsedResult = this.getParsedForJsonPath(path);
+    if (parsedResult === null) {
+      return {
+        range: getDefaultRange(),
+      };
+    }
+
     const location = parsedResult.doc.getLocationForJsonPath(parsedResult.doc.parsed, parsedResult.path, closest);
 
     return {
       ...(parsedResult.doc.source && { uri: parsedResult.doc.source }),
-      range:
-        location !== undefined
-          ? location.range
-          : {
-              start: {
-                line: 0,
-                character: 0,
-              },
-              end: {
-                line: 0,
-                character: 0,
-              },
-            },
+      range: location !== void 0 ? location.range : getDefaultRange(),
     };
   }
 }

--- a/src/spectral.ts
+++ b/src/spectral.ts
@@ -5,7 +5,7 @@ import {
   safeStringify,
 } from '@stoplight/json';
 import { Resolver } from '@stoplight/json-ref-resolver';
-import { ICache, IUriParser } from '@stoplight/json-ref-resolver/types';
+import { ICache, IResolver, IUriParser } from '@stoplight/json-ref-resolver/types';
 import { extname } from '@stoplight/path';
 import { Dictionary } from '@stoplight/types';
 import {
@@ -43,9 +43,9 @@ import { IRuleset } from './types/ruleset';
 export * from './types';
 
 export class Spectral {
-  private readonly _resolver: Resolver;
+  private readonly _resolver: IResolver;
   private readonly _parsedMap: IParseMap;
-  private static readonly _parsedCache = new WeakMap<ICache, IParseMap>();
+  private static readonly _parsedCache = new WeakMap<ICache | IResolver, IParseMap>();
   public functions: FunctionCollection = { ...defaultFunctions };
   public rules: RunRuleCollection = {};
 
@@ -55,7 +55,8 @@ export class Spectral {
     this._resolver = opts && opts.resolver ? opts.resolver : new Resolver();
     this.formats = {};
 
-    const _parsedMap = Spectral._parsedCache.get(this._resolver.uriCache);
+    const cacheKey = this._resolver instanceof Resolver ? this._resolver.uriCache : this._resolver;
+    const _parsedMap = Spectral._parsedCache.get(cacheKey);
     if (_parsedMap) {
       this._parsedMap = _parsedMap;
     } else {
@@ -65,7 +66,7 @@ export class Spectral {
         pointers: {},
       };
 
-      Spectral._parsedCache.set(this._resolver.uriCache, this._parsedMap);
+      Spectral._parsedCache.set(cacheKey, this._parsedMap);
     }
   }
 

--- a/src/spectral.ts
+++ b/src/spectral.ts
@@ -5,7 +5,7 @@ import {
   safeStringify,
 } from '@stoplight/json';
 import { Resolver } from '@stoplight/json-ref-resolver';
-import { ICache, IResolver, IUriParser } from '@stoplight/json-ref-resolver/types';
+import { ICache, IUriParser } from '@stoplight/json-ref-resolver/types';
 import { extname } from '@stoplight/path';
 import { Dictionary } from '@stoplight/types';
 import {
@@ -30,6 +30,7 @@ import {
   FunctionCollection,
   IConstructorOpts,
   IParsedResult,
+  IResolver,
   IRuleResult,
   IRunOpts,
   ISpectralFullResult,

--- a/src/types/spectral.ts
+++ b/src/types/spectral.ts
@@ -1,4 +1,4 @@
-import { IResolver } from '@stoplight/json-ref-resolver/types';
+import { IResolveOpts, IResolveResult } from '@stoplight/json-ref-resolver/types';
 import {
   DiagnosticSeverity,
   Dictionary,
@@ -57,6 +57,12 @@ export interface IParsedResult<R extends IParserResult = IParserResult<unknown, 
   getLocationForJsonPath: GetLocationForJsonPath<R>;
   source?: string;
   formats?: string[];
+}
+
+export type ResolveResult = Omit<IResolveResult, 'runner'>;
+
+export interface IResolver {
+  resolve(source: unknown, opts?: IResolveOpts): Promise<ResolveResult>;
 }
 
 export type FormatLookup = (document: unknown) => boolean;

--- a/src/types/spectral.ts
+++ b/src/types/spectral.ts
@@ -1,4 +1,4 @@
-import { Resolver } from '@stoplight/json-ref-resolver';
+import { IResolver } from '@stoplight/json-ref-resolver/types';
 import {
   DiagnosticSeverity,
   Dictionary,
@@ -29,7 +29,7 @@ export type SpectralDiagnosticSeverity = DiagnosticSeverity | -1;
 export type RuleDeclarationCollection = Dictionary<boolean, string>;
 
 export interface IConstructorOpts {
-  resolver?: Resolver;
+  resolver?: IResolver;
 }
 
 export interface IRunOpts {


### PR DESCRIPTION
A small piece of $ref resolving puzzle.

This is mostly internal refactoring that does not affect any consumers, including these using their own resolvers.

