### PR TITLE
Adds OS check to import of os-dependent binary in test-harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node": ">=8.3.0"
   },
   "scripts": {
-    "build.binary": "pkg . --targets linux,macos --out-path ./binaries",
+    "build.binary": "pkg . --output ./binaries/spectral",
     "build.oas-functions": "rollup -c",
     "build": "tsc -p ./tsconfig.build.json",
     "cli": "node -r ts-node/register -r tsconfig-paths/register src/cli/index.ts",

--- a/test-harness/index.ts
+++ b/test-harness/index.ts
@@ -10,7 +10,7 @@ import { parseScenarioFile } from './helpers';
 
 const glob = globFs({ gitignore: true });
 
-const spectralBin = path.join(__dirname, `../binaries/spectral-${os.platform() === 'darwin' ? 'macos' : 'linux'}`);
+const spectralBin = path.join(__dirname, '../binaries/spectral');
 
 type Replacement = {
   from: RegExp;

--- a/test-harness/index.ts
+++ b/test-harness/index.ts
@@ -10,7 +10,7 @@ import { parseScenarioFile } from './helpers';
 
 const glob = globFs({ gitignore: true });
 
-const spectralBin = path.join(__dirname, '../binaries/spectral-linux');
+const spectralBin = path.join(__dirname, `../binaries/spectral-${os.platform() === 'darwin' ? 'macos' : 'linux'}`);
 
 type Replacement = {
   from: RegExp;


### PR DESCRIPTION
**Checklist**

- [N/A] Tests added / updated
- [N/A] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

**Additional context**

Testing some new scenarios locally, I ran across this bug where the linux binary is hard coded in the test-harness. This adds an OS check via `process.os()` [docs](https://nodejs.org/api/os.html#os_os_platform), which should resolve as "darwin" on OSX, and fallback to linux otherwise.

I didn't see a Windows binary being created, so I believe this should cover both scenarios. Linting passed, but unsure of if/how to test. Please let me know if there is anything else I can do to help here, and thank you for taking a look!