### PR TITLE
Add in an explicit example using functionOptions in custom functions

### DIFF
--- a/docs/guides/custom-functions.md
+++ b/docs/guides/custom-functions.md
@@ -48,26 +48,42 @@ rules:
       function: "abc"
 ```
 
-If your function accepts options, you should provide a JSON Schema that describes those options.
+If you are writing a function that accepts options, you should provide a JSON Schema that describes those options.
 
 You can do it as follows:
 
 ```yaml
 functions:
-- - abc
+- - equals
   # can be any valid JSONSchema7
   - properties:
-      sort:
-        type: boolean
-        description: enforces that abc is sorted
+      value:
+        type: string
+        description: Value to check equality for
 rules:
   my-rule:
     message: "{{error}}"
     given: "$.info"
     then:
-      function: "abc"
+      function: "equals"
       functionOptions:
-        sort: true
+        value: "abc"
+```
+
+Where the function **functions/equals.js** might look like:
+
+```js
+module.exports = (targetVal, opts) => {
+  const { value } = opts;
+
+  if (targetVal !== value) {
+    return [
+      {
+        message: `Value must equal {value}.`,
+      },
+    ];
+  }
+};
 ```
 
 If for some reason, you do not want to place your functions in a directory called `functions`, you can specify a custom directory.


### PR DESCRIPTION
Adds in another example of a `.js` file that implements optional arguments in a custom function.  The example in the docs also didn't really jive with me so I felt writing one that generalized the original example (checking equality against a string) was a good natural progression.

I ran into this issue, and someone on the community forum did as well, so I figured it was worth enhancing the docs a little bit to try and help future devs, especially given custom functions are so new.
https://community.stoplight.io/t/custom-functions-for-spectral-running-locally/877

I am not a JS developer, so please let me know if something looks off or broken.  

Thoughts?

**Checklist**

- [ ] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
