### PR TITLE
fix: unused error format in oasPathParam rule

### DIFF
--- a/src/rulesets/oas/functions/__tests__/oasPathParam.test.ts
+++ b/src/rulesets/oas/functions/__tests__/oasPathParam.test.ts
@@ -35,8 +35,7 @@ describe('oasPathParam', () => {
     expect(results).toEqual([
       {
         code: 'path-params',
-        message:
-          'The path "**/foo/{bar}**" uses a parameter "**{bar}**" that does not have a corresponding definition.\n\nTo fix, add a path parameter with the name "**bar**".',
+        message: 'The path "/foo/{bar}" uses a parameter "{bar}" that does not have a corresponding definition.',
         path: ['paths', '/foo/{bar}'],
         range: {
           end: {
@@ -131,9 +130,7 @@ describe('oasPathParam', () => {
     expect(results).toEqual([
       {
         code: 'path-params',
-        message: `The path "**/foo/{bar}/{bar}**" uses the parameter "**{bar}**" multiple times.\n
-Path parameters must be unique.\n
-To fix, update the path so that all parameter names are unique.`,
+        message: `The path "/foo/{bar}/{bar}" uses the parameter "{bar}" multiple times. Path parameters must be unique.`,
         path: ['paths', '/foo/{bar}/{bar}'],
         range: {
           end: {
@@ -174,7 +171,7 @@ To fix, update the path so that all parameter names are unique.`,
     expect(results).toEqual([
       {
         code: 'path-params',
-        message: `Path parameter \"**bar**\" must have a \`required\` that is set to \`true\`.\n\nTo fix, mark this parameter as required.`,
+        message: `Path parameter "bar" must have a "required" property that is set to "true".`,
         path: ['paths', '/foo/{bar}', 'parameters'],
         range: {
           end: {
@@ -220,7 +217,7 @@ To fix, update the path so that all parameter names are unique.`,
     expect(results).toEqual([
       {
         code: 'path-params',
-        message: `The paths \"**/foo/{boo}**\" and \"**/foo/{bar}**\" are equivalent.\n\nTo fix, remove one of the paths or merge them together.`,
+        message: `The paths "/foo/{boo}" and "/foo/{bar}" are equivalent.`,
         path: ['paths'],
         range: {
           end: {

--- a/src/rulesets/oas/functions/__tests__/oasPathParam.test.ts
+++ b/src/rulesets/oas/functions/__tests__/oasPathParam.test.ts
@@ -35,7 +35,7 @@ describe('oasPathParam', () => {
     expect(results).toEqual([
       {
         code: 'path-params',
-        message: 'The path "/foo/{bar}" uses a parameter "{bar}" that does not have a corresponding definition.',
+        message: 'The path `/foo/{bar}` uses a parameter `{bar}` that does not have a corresponding definition.',
         path: ['paths', '/foo/{bar}'],
         range: {
           end: {
@@ -130,7 +130,7 @@ describe('oasPathParam', () => {
     expect(results).toEqual([
       {
         code: 'path-params',
-        message: `The path "/foo/{bar}/{bar}" uses the parameter "{bar}" multiple times. Path parameters must be unique.`,
+        message: `The path \`/foo/{bar}/{bar}\` uses the parameter \`{bar}\` multiple times. Path parameters must be unique.`,
         path: ['paths', '/foo/{bar}/{bar}'],
         range: {
           end: {
@@ -171,7 +171,7 @@ describe('oasPathParam', () => {
     expect(results).toEqual([
       {
         code: 'path-params',
-        message: `Path parameter "bar" must have a "required" property that is set to "true".`,
+        message: `Path parameter \`bar\` must have a \`required\` property that is set to \`true\`.`,
         path: ['paths', '/foo/{bar}', 'parameters'],
         range: {
           end: {
@@ -217,7 +217,7 @@ describe('oasPathParam', () => {
     expect(results).toEqual([
       {
         code: 'path-params',
-        message: `The paths "/foo/{boo}" and "/foo/{bar}" are equivalent.`,
+        message: `The paths \`/foo/{boo}\` and \`/foo/{bar}\` are equivalent.`,
         path: ['paths'],
         range: {
           end: {

--- a/src/rulesets/oas/functions/oasPathParam.ts
+++ b/src/rulesets/oas/functions/oasPathParam.ts
@@ -30,7 +30,7 @@ export const oasPathParam: IFunction<Rule> = (targetVal, _options, paths, vals) 
     const normalized = path.replace(pathRegex, '%'); // '%' is used here since its invalid in paths
     if (uniquePaths[normalized]) {
       results.push(
-        generateResult(`The paths "${uniquePaths[normalized]}" and "${path}" are equivalent.`, [
+        generateResult(`The paths \`${uniquePaths[normalized]}\` and \`${path}\` are equivalent.`, [
           ...paths.given,
           'paths',
         ]),
@@ -49,7 +49,7 @@ export const oasPathParam: IFunction<Rule> = (targetVal, _options, paths, vals) 
         if (pathElements[p]) {
           results.push(
             generateResult(
-              `The path "${path}" uses the parameter "{${p}}" multiple times. Path parameters must be unique.`,
+              `The path \`${path}\` uses the parameter \`{${p}}\` multiple times. Path parameters must be unique.`,
               [...paths.given, 'paths', path],
             ),
           );
@@ -128,7 +128,7 @@ export const oasPathParam: IFunction<Rule> = (targetVal, _options, paths, vals) 
       if (!topParams[p] && !operationParams[p]) {
         results.push(
           generateResult(
-            `The path "${path}" uses a parameter "{${p}}" that does not have a corresponding definition.`,
+            `The path \`${path}\` uses a parameter \`{${p}}\` that does not have a corresponding definition.`,
             [...paths.given, 'paths', path],
           ),
         );
@@ -144,7 +144,7 @@ export const oasPathParam: IFunction<Rule> = (targetVal, _options, paths, vals) 
         if (!pathElements[p]) {
           const resPath = paramObj[p];
           results.push(
-            generateResult(`Parameter "${p}" is not used in the path "${path}".`, [...paths.given, ...resPath]),
+            generateResult(`Parameter \`${p}\` is not used in the path \`${path}\`.`, [...paths.given, ...resPath]),
           );
         }
       }
@@ -162,9 +162,9 @@ function generateResult(message: string, path: Array<string | number>): IFunctio
 }
 
 const requiredMessage = (name: string) =>
-  `Path parameter "${name}" must have a "required" property that is set to "true".`;
+  `Path parameter \`${name}\` must have a \`required\` property that is set to \`true\`.`;
 
 const uniqueDefinitionMessage = (name: string) =>
-  `Path parameter "${name}" is defined multiple times. Path parameters must be unique.`;
+  `Path parameter \`${name}\` is defined multiple times. Path parameters must be unique.`;
 
 export default oasPathParam;

--- a/src/rulesets/oas/functions/oasPathParam.ts
+++ b/src/rulesets/oas/functions/oasPathParam.ts
@@ -30,12 +30,10 @@ export const oasPathParam: IFunction<Rule> = (targetVal, _options, paths, vals) 
     const normalized = path.replace(pathRegex, '%'); // '%' is used here since its invalid in paths
     if (uniquePaths[normalized]) {
       results.push(
-        generateResult(
-          `The paths "**${uniquePaths[normalized]}**" and "**${path}**" are equivalent.
-
-To fix, remove one of the paths or merge them together.`,
-          [...paths.given, 'paths'],
-        ),
+        generateResult(`The paths "${uniquePaths[normalized]}" and "${path}" are equivalent.`, [
+          ...paths.given,
+          'paths',
+        ]),
       );
     } else {
       uniquePaths[normalized] = path;
@@ -51,11 +49,7 @@ To fix, remove one of the paths or merge them together.`,
         if (pathElements[p]) {
           results.push(
             generateResult(
-              `The path "**${path}**" uses the parameter "**{${p}}**" multiple times.
-
-Path parameters must be unique.
-
-To fix, update the path so that all parameter names are unique.`,
+              `The path "${path}" uses the parameter "{${p}}" multiple times. Path parameters must be unique.`,
               [...paths.given, 'paths', path],
             ),
           );
@@ -134,9 +128,7 @@ To fix, update the path so that all parameter names are unique.`,
       if (!topParams[p] && !operationParams[p]) {
         results.push(
           generateResult(
-            `The path "**${path}**" uses a parameter "**{${p}}**" that does not have a corresponding definition.
-
-To fix, add a path parameter with the name "**${p}**".`,
+            `The path "${path}" uses a parameter "{${p}}" that does not have a corresponding definition.`,
             [...paths.given, 'paths', path],
           ),
         );
@@ -152,14 +144,7 @@ To fix, add a path parameter with the name "**${p}**".`,
         if (!pathElements[p]) {
           const resPath = paramObj[p];
           results.push(
-            generateResult(
-              `Parameter "**${p}**" is not used in the path "**${path}**".
-
-Unused parameters are not allowed.
-
-To fix, remove this parameter.`,
-              [...paths.given, ...resPath],
-            ),
+            generateResult(`Parameter "${p}" is not used in the path "${path}".`, [...paths.given, ...resPath]),
           );
         }
       }
@@ -176,16 +161,10 @@ function generateResult(message: string, path: Array<string | number>): IFunctio
   };
 }
 
-const requiredMessage = (
-  name: string,
-) => `Path parameter "**${name}**" must have a \`required\` that is set to \`true\`.
+const requiredMessage = (name: string) =>
+  `Path parameter "${name}" must have a "required" property that is set to "true".`;
 
-To fix, mark this parameter as required.`;
-
-const uniqueDefinitionMessage = (name: string) => `Path parameter '**${name}**' is defined multiple times.
-
-Path parameters must be unique.
-
-To fix, remove the duplicate parameters.`;
+const uniqueDefinitionMessage = (name: string) =>
+  `Path parameter "${name}" is defined multiple times. Path parameters must be unique.`;
 
 export default oasPathParam;


### PR DESCRIPTION
Wanted to get my hands into that sweet open source. 

Fixes #537

**Checklist**
- [x] Tests added / updated

**Does this PR introduce a breaking change?**
- [x] No

**Additional context**
Some context on why some spectral messages contain new lines, asterisks, etc. The messages were originally written in markdown! This was so that we could display them nicely in Stoplight Next. I don't think this is really needed anymore with the new use case. In general the messaging syntax is still pretty ugly but at least now its consistently ugly!
