### PR TITLE
chore: keep the indentation style homogeneous accross IDEs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+
+[*.{ts,js,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.{ts,js}]
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
Helps maintaining the code style across IDEs

cf. https://editorconfig.org/

**Checklist**

- [ ] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

While working on #635 I noticed that my IDE (VSCode) insisted on trying to format files with four spaces.

This file combined with the VSCode extension (https://editorconfig.org/#download) helps keeping the code style tamed.