### PR TITLE
build: create macOS binary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ commands:
           command: yarn test --coverage --maxWorkers=2
       - run:
           name: Create the Spectral Binary
-          command: yarn build.binary
+          command: npx pkg . --targets linux,macos
       - run:
           name: Create output directory
           command: mkdir ./test-harness/tmp


### PR DESCRIPTION
Mac binary aren't getting generated because of the automatic command taking in consideration only the current machine; we need them for MacOs as well and so we'll use a custom one.