### PR TITLE
chore: typecheck the tests before build

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "compile-rulesets": "node ./scripts/compile-rulesets.js",
     "inline-version": "./scripts/inline-version.js",
     "lint.fix": "yarn lint --fix",
-    "lint": "tslint 'src/**/*.ts'",
+    "lint": "tsc --noEmit && tslint 'src/**/*.ts'",
     "postbuild.oas-functions": "copyfiles -u 1 \"dist/rulesets/oas*/functions/*.js\" ./",
     "postbuild": "yarn build.oas-functions && yarn compile-rulesets",
     "prebuild": "copyfiles -u 1 \"src/rulesets/oas*/**/*.json\" dist && copyfiles -u 1 \"src/rulesets/oas*/**/*.json\" ./",


### PR DESCRIPTION
**Checklist**

- [ ] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

While working on #635, I had to add a property to `IFunctionValues`. 
`yarn build` helped me find where I had to fix the code.
`yarn lint` was all good.

As the full test suite usually takes a long time to run on my box, I tend to only run the tests that impact the code I'm working on. And let the CI server deal with the rest.

Of course, I discovered that I had forgotten to also fix some tests by taking a look a the failed karma tests on the CI server.

This PR aims at reducing the feedback loop (a little) by also typechecking the tests (without emitting code) before the build _per se_. By doing so, It adds a little overhead to the build time and an additional moving piece to the pipeline.

What do you think?