### PR TITLE
breaking: bump default fail severity to warn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
 workflows:
   commit:
     jobs:
-      - test-node-latest
+      # - test-node-latest TODO bring it back when circle supports node-13
       - test-node-12
       - test-node-10
   release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- CLI: Default `--fail-severity` is now `warn`, so getting an `info` or a `hint` will not return a exit status code [#706](https://github.com/stoplightio/spectral/pull/706)
+
+
 ## [4.2.0] - 2019-10-08
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Changed
+- Built-in OAS rule `openapi-tags` is now recommended [#706](https://github.com/stoplightio/spectral/pull/706)
 - CLI: Default `--fail-severity` is now `warn`, so getting an `info` or a `hint` will not return a exit status code [#706](https://github.com/stoplightio/spectral/pull/706)
-
 
 ## [4.2.0] - 2019-10-08
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -46,7 +46,7 @@ Here you can build a [custom ruleset](../getting-started/rulesets.md), or extend
 
 Spectral has a few different error severities: `error`, `warn`, `info` and `hint`, and they are in "order" from highest to lowest. By default, all results will be shown regardless of severity, but since v5.0, only the presence of warnings or errors will cause a failure status code of 1.
 
-The default behavior is can be modified with the `--fail-severity=` option. Setting fail severity to `--fail-severity=info` would return a failure status code of 1 for any info results or higher. Using `--fail-severity=error` will only cause a failure status code for errors.
+The default behavior can be modified with the `--fail-severity=` option. Setting fail severity to `--fail-severity=info` would return a failure status code of 1 for any info results or higher. Using `--fail-severity=error` will only cause a failure status code for errors.
 
 Changing the fail severity will not effect output. To change what results Spectral CLI prints to the screen, add the `--display-only-failures` switch (or just `-D` for short). This will strip out any results which are below the specified fail severity.
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -29,7 +29,7 @@ Other options include:
   --ruleset, -r                path/URL to a ruleset file                                    [string]
   --skip-rule, -s              ignore certain rules if they are causing trouble              [string]
   --fail-severity, -F          results of this level or above will trigger a failure exit code
-                                [string] [choices: "error", "warn", "info", "hint"] [default: "hint"]
+                                [string] [choices: "error", "warn", "info", "hint"] [default: "warn"]
   --display-only-failures, -D  only output results equal to or greater than --fail-severity
                                                                            [boolean] [default: false]
   --verbose, -v                increase verbosity                                           [boolean]
@@ -44,11 +44,11 @@ Here you can build a [custom ruleset](../getting-started/rulesets.md), or extend
 
 ## Error Results
 
-Spectral has a few different error severities: `error`, `warn`, `info` and `hint`, and they are in "order" from highest to lowest. By default, all results will be shown regardless of severity, and the presence of any results will cause a failure status code of 1.
+Spectral has a few different error severities: `error`, `warn`, `info` and `hint`, and they are in "order" from highest to lowest. By default, all results will be shown regardless of severity, but since v5.0, only the presence of warnings or errors will cause a failure status code of 1.
 
-The default behavior is can be modified with the `--fail-severity=` option. Setting fail severity to `--fail-severity=warn` would return a status code of 1 for any warning results or higher, so that would also include error. Using `--fail-severity=error` will only show errors.
+The default behavior is can be modified with the `--fail-severity=` option. Setting fail severity to `--fail-severity=info` would return a failure status code of 1 for any info results or higher. Using `--fail-severity=error` will only cause a failure status code for errors.
 
-Changing the fail severity will not effect output. To change what results Spectral CLI prints to the screen, add the `--display-only-failures` switch (or just `-D` for short). This will strip out any results which are below the fail severity.
+Changing the fail severity will not effect output. To change what results Spectral CLI prints to the screen, add the `--display-only-failures` switch (or just `-D` for short). This will strip out any results which are below the specified fail severity.
 
 ## Proxying
 

--- a/src/__tests__/linter.test.ts
+++ b/src/__tests__/linter.test.ts
@@ -149,6 +149,7 @@ describe('linter', () => {
     spectral.setRules(mergeRules(oas3Rules, {
       'valid-example-in-schemas': 'off',
       'components-schema-description': -1,
+      'openapi-tags': 'off',
     }) as RuleCollection);
 
     const result = await spectral.run(invalidSchema);
@@ -547,6 +548,9 @@ responses:: !!foo
       }),
       expect.objectContaining({
         code: 'operation-tag-defined',
+      }),
+      expect.objectContaining({
+        code: 'openapi-tags',
       }),
       expect.objectContaining({
         code: 'valid-example-in-schemas',

--- a/src/cli/commands/lint.ts
+++ b/src/cli/commands/lint.ts
@@ -67,7 +67,7 @@ const lintCommand: CommandModule = {
           alias: 'F',
           description: 'results of this level or above will trigger a failure exit code',
           choices: ['error', 'warn', 'info', 'hint'],
-          default: 'hint', // TODO: BREAKING: raise this to warn in 5.0
+          default: 'warn',
           type: 'string',
         },
         'display-only-failures': {

--- a/src/cli/services/__tests__/__fixtures__/openapi-3.0-valid.yaml
+++ b/src/cli/services/__tests__/__fixtures__/openapi-3.0-valid.yaml
@@ -10,3 +10,5 @@ servers:
   - description: thing
     url: http://localhost
 paths: {}
+tags:
+  - name: my-tag

--- a/src/cli/services/__tests__/linter.test.ts
+++ b/src/cli/services/__tests__/linter.test.ts
@@ -558,6 +558,13 @@ describe('Linter service', () => {
           },
           source: expect.stringContaining('__tests__/__fixtures__/refs/info.json'),
         }),
+        expect.objectContaining({
+          code: 'openapi-tags',
+          message: 'OpenAPI object should have non-empty `tags` array.',
+          path: [],
+          range: expect.any(Object),
+          source: expect.stringContaining('__tests__/__fixtures__/draft-ref.oas2.json'),
+        }),
       ]);
     });
 
@@ -601,6 +608,13 @@ describe('Linter service', () => {
             },
           },
           source: expect.stringContaining('__tests__/__fixtures__/refs/contact.json'),
+        }),
+        expect.objectContaining({
+          code: 'openapi-tags',
+          message: 'OpenAPI object should have non-empty `tags` array.',
+          path: [],
+          range: expect.any(Object),
+          source: expect.stringContaining('__tests__/__fixtures__/draft-nested-ref.oas2.json'),
         }),
         expect.objectContaining({
           code: 'operation-description',

--- a/src/rulesets/oas/index.json
+++ b/src/rulesets/oas/index.json
@@ -240,7 +240,7 @@
     },
     "openapi-tags": {
       "description": "OpenAPI object should have non-empty `tags` array.",
-      "recommended": false,
+      "recommended": true,
       "type": "style",
       "given": "$",
       "then": {

--- a/test-harness/scenarios/help-no-document.scenario
+++ b/test-harness/scenarios/help-no-document.scenario
@@ -18,7 +18,7 @@ Options:
   --output, -o                 output to a file instead of stdout  [string]
   --ruleset, -r                path/URL to a ruleset file  [string]
   --skip-rule, -s              ignore certain rules if they are causing trouble  [string]
-  --fail-severity, -F          results of this level or above will trigger a failure exit code  [string] [choices: "error", "warn", "info", "hint"] [default: "hint"]
+  --fail-severity, -F          results of this level or above will trigger a failure exit code  [string] [choices: "error", "warn", "info", "hint"] [default: "warn"]
   --display-only-failures, -D  only output results equal to or greater than --fail-severity  [boolean] [default: false]
   --verbose, -v                increase verbosity  [boolean]
   --quiet, -q                  no logging - output only  [boolean]

--- a/test-harness/scenarios/parameter-description-links.oas3.scenario
+++ b/test-harness/scenarios/parameter-description-links.oas3.scenario
@@ -25,4 +25,4 @@ components:
 lint --ruleset ./test-harness/scenarios/rulesets/parameter-description.oas3.yaml {document}
 ====stdout====
 OpenAPI 3.x detected
-No results with a severity of 'hint' or higher found!
+No results with a severity of 'warn' or higher found!

--- a/test-harness/scenarios/results-default-format-json-quiet.oas3.scenario
+++ b/test-harness/scenarios/results-default-format-json-quiet.oas3.scenario
@@ -6,6 +6,8 @@ info:
   version: 1.0.0
   title: Stoplight
 paths: {}
+tags:
+  - name: test
 ====command====
 lint --quiet {document} --format=json 
 ====stdout====
@@ -21,8 +23,8 @@ lint --quiet {document} --format=json
 				"character": 0
 			},
 			"end": {
-				"line": 4,
-				"character": 9
+				"line": 6,
+				"character": 14
 			}
 		},
 		"source": "{document}"

--- a/test-harness/scenarios/results-default-format-json.oas3.scenario
+++ b/test-harness/scenarios/results-default-format-json.oas3.scenario
@@ -6,6 +6,8 @@ info:
   version: 1.0.0
   title: Stoplight
 paths: {}
+tags:
+  - name: test
 ====command====
 lint {document} --format=json
 ====stdout====
@@ -22,8 +24,8 @@ OpenAPI 3.x detected
 				"character": 0
 			},
 			"end": {
-				"line": 4,
-				"character": 9
+				"line": 6,
+				"character": 14
 			}
 		},
 		"source": "{document}"

--- a/test-harness/scenarios/results-default-output.oas3.scenario
+++ b/test-harness/scenarios/results-default-output.oas3.scenario
@@ -12,7 +12,8 @@ lint {document} --output=./test-harness/tmp/results-default-output.txt > /dev/nu
 ====stdout====
 {document}
  1:1  warning  api-servers       OpenAPI `servers` must be present and non-empty array.
+ 1:1  warning  openapi-tags      OpenAPI object should have non-empty `tags` array.
  2:6  warning  info-contact      Info object should contain `contact` object.
  2:6  warning  info-description  OpenAPI object info `description` must be present and non-empty string.
 
-✖ 3 problems (0 errors, 3 warnings, 0 infos, 0 hints)
+✖ 4 problems (0 errors, 4 warnings, 0 infos, 0 hints)

--- a/test-harness/scenarios/results-default.oas3.scenario
+++ b/test-harness/scenarios/results-default.oas3.scenario
@@ -13,7 +13,8 @@ OpenAPI 3.x detected
 
 {document}
  1:1  warning  api-servers       OpenAPI `servers` must be present and non-empty array.
+ 1:1  warning  openapi-tags      OpenAPI object should have non-empty `tags` array.
  2:6  warning  info-contact      Info object should contain `contact` object.
  2:6  warning  info-description  OpenAPI object info `description` must be present and non-empty string.
 
-✖ 3 problems (0 errors, 3 warnings, 0 infos, 0 hints)
+✖ 4 problems (0 errors, 4 warnings, 0 infos, 0 hints)

--- a/test-harness/scenarios/results-format-stylish.oas3.scenario
+++ b/test-harness/scenarios/results-format-stylish.oas3.scenario
@@ -13,7 +13,8 @@ OpenAPI 3.x detected
 
 {document}
  1:1  warning  api-servers       OpenAPI `servers` must be present and non-empty array.
+ 1:1  warning  openapi-tags      OpenAPI object should have non-empty `tags` array.
  2:6  warning  info-contact      Info object should contain `contact` object.
  2:6  warning  info-description  OpenAPI object info `description` must be present and non-empty string.
 
-✖ 3 problems (0 errors, 3 warnings, 0 infos, 0 hints)
+✖ 4 problems (0 errors, 4 warnings, 0 infos, 0 hints)

--- a/test-harness/scenarios/results-skip-rule.oas3.scenario
+++ b/test-harness/scenarios/results-skip-rule.oas3.scenario
@@ -13,6 +13,7 @@ OpenAPI 3.x detected
 
 {document}
  1:1  warning  api-servers       OpenAPI `servers` must be present and non-empty array.
+ 1:1  warning  openapi-tags      OpenAPI object should have non-empty `tags` array.
  2:6  warning  info-description  OpenAPI object info `description` must be present and non-empty string.
 
-✖ 2 problems (0 errors, 2 warnings, 0 infos, 0 hints)
+✖ 3 problems (0 errors, 3 warnings, 0 infos, 0 hints)

--- a/test-harness/scenarios/results-skip-rules-multiple.oas3.scenario
+++ b/test-harness/scenarios/results-skip-rules-multiple.oas3.scenario
@@ -12,6 +12,7 @@ lint {document} --skip-rule=info-contact --skip-rule=info-description
 OpenAPI 3.x detected
 
 {document}
- 1:1  warning  api-servers  OpenAPI `servers` must be present and non-empty array.
+ 1:1  warning  api-servers   OpenAPI `servers` must be present and non-empty array.
+ 1:1  warning  openapi-tags  OpenAPI object should have non-empty `tags` array.
 
-✖ 1 problem (0 errors, 1 warning, 0 infos, 0 hints)
+✖ 2 problems (0 errors, 2 warnings, 0 infos, 0 hints)

--- a/test-harness/scenarios/severity/display-warnings.oas3.scenario
+++ b/test-harness/scenarios/severity/display-warnings.oas3.scenario
@@ -48,9 +48,10 @@ OpenAPI 3.x detected
 
 {document}
   1:1   warning  api-servers            OpenAPI `servers` must be present and non-empty array.
+  1:1   warning  openapi-tags           OpenAPI object should have non-empty `tags` array.
   2:6   warning  info-contact           Info object should contain `contact` object.
   2:6   warning  info-description       OpenAPI object info `description` must be present and non-empty string.
   9:9   warning  operation-description  Operation `description` must be present and non-empty string.
  13:11  warning  operation-tag-defined  Operation tags should be defined in global tags.
 
-✖ 5 problems (0 errors, 5 warnings, 0 infos, 0 hints)
+✖ 6 problems (0 errors, 6 warnings, 0 infos, 0 hints)

--- a/test-harness/scenarios/severity/fail-on-error-no-error.scenario
+++ b/test-harness/scenarios/severity/fail-on-error-no-error.scenario
@@ -26,6 +26,7 @@ OpenAPI 3.x detected
 
 {document}
   1:1   warning  api-servers            OpenAPI `servers` must be present and non-empty array.
+  1:1   warning  openapi-tags           OpenAPI object should have non-empty `tags` array.
   2:6   warning  info-contact           Info object should contain `contact` object.
   2:6   warning  info-description       OpenAPI object info `description` must be present and non-empty string.
   7:9   warning  operation-description  Operation `description` must be present and non-empty string.
@@ -33,4 +34,4 @@ OpenAPI 3.x detected
  12:10  warning  operation-description  Operation `description` must be present and non-empty string.
  12:10  warning  operation-tags         Operation should have non-empty `tags` array.
 
-✖ 7 problems (0 errors, 7 warnings, 0 infos, 0 hints)
+✖ 8 problems (0 errors, 8 warnings, 0 infos, 0 hints)

--- a/test-harness/scenarios/severity/fail-on-error.oas3.scenario
+++ b/test-harness/scenarios/severity/fail-on-error.oas3.scenario
@@ -26,6 +26,7 @@ OpenAPI 3.x detected
 
 {document}
   1:1   warning  api-servers                   OpenAPI `servers` must be present and non-empty array.
+  1:1   warning  openapi-tags                  OpenAPI object should have non-empty `tags` array.
   2:6   warning  info-contact                  Info object should contain `contact` object.
   2:6   warning  info-description              OpenAPI object info `description` must be present and non-empty string.
   7:9   warning  operation-description         Operation `description` must be present and non-empty string.
@@ -35,4 +36,4 @@ OpenAPI 3.x detected
  12:10  warning  operation-tags                Operation should have non-empty `tags` array.
  13:20    error  operation-operationId-unique  Every operation must have a unique `operationId`.
 
-✖ 9 problems (2 errors, 7 warnings, 0 infos, 0 hints)
+✖ 10 problems (2 errors, 8 warnings, 0 infos, 0 hints)

--- a/test-harness/scenarios/severity/stylish-display-proper-names.scenario
+++ b/test-harness/scenarios/severity/stylish-display-proper-names.scenario
@@ -90,6 +90,7 @@ OpenAPI 3.x detected
 
 {document}
   1:1       warning  api-servers             OpenAPI `servers` must be present and non-empty array.
+  1:1       warning  openapi-tags            OpenAPI object should have non-empty `tags` array.
   3:10        error  info-contact            Info object should contain `contact` object.
   3:10      warning  info-description        OpenAPI object info `description` must be present and non-empty string.
   5:14         hint  info-matches-stoplight  Info must contain Stoplight
@@ -100,4 +101,4 @@ OpenAPI 3.x detected
  59:14  information  operation-description   Operation `description` must be present and non-empty string.
  62:18      warning  operation-tag-defined   Operation tags should be defined in global tags.
 
-✖ 10 problems (3 errors, 4 warnings, 2 infos, 1 hint)
+✖ 11 problems (3 errors, 5 warnings, 2 infos, 1 hint)

--- a/test-harness/scenarios/valid-no-errors.oas2.scenario
+++ b/test-harness/scenarios/valid-no-errors.oas2.scenario
@@ -16,4 +16,4 @@ paths: {}
 lint {document}
 ====stdout====
 OpenAPI 2.0 (Swagger) detected
-No results with a severity of 'hint' or higher found!
+No results with a severity of 'warn' or higher found!

--- a/test-harness/scenarios/valid-no-errors.oas2.scenario
+++ b/test-harness/scenarios/valid-no-errors.oas2.scenario
@@ -12,6 +12,8 @@ host: localhost
 schemes: 
   - http
 paths: {}
+tags:
+  - name: my-tag
 ====command====
 lint {document}
 ====stdout====


### PR DESCRIPTION
Ever since the CLI was first added, the existence of _any_ results whatsoever would trigger an exit code, even if they were only info or hint. Users have requested this be fixed several times, but we could not do it as part of #368 as it would have been a breaking change. Let's merge this, and develop will be the basis of v5.0 and any other breaking changes we have to make. 