### PR TITLE
docs: Markdown rendering error in core functions

### DIFF
--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -202,7 +202,7 @@ The value should not be `false`, `""`, `0`, `null` or `undefined`. Basically any
 
 The value must be `undefined`. When combined with `field: foo` on an object the `foo` property must be undefined.
 
-_**Note:** Due to the way YAML works, just having `foo: ` with no value set is not the same as being `undefined`. This would be `falsy`.
+_**Note:** Due to the way YAML works, just having `foo: ` with no value set is not the same as being `undefined`. This would be `falsy`._
 
 ## unreferencedReusableObject
 


### PR DESCRIPTION
Noticed a Markdown error. 

<img width="939" alt="image" src="https://user-images.githubusercontent.com/67381/68940054-119bc280-079a-11ea-9b9e-9929d00bc15d.png">
