### PR TITLE
build: binary install was broken for linux

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,24 @@
+name: automerge
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  status: {}
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge
+        uses: "pascalgn/automerge-action@v0.6.0"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,20 +11,20 @@ if [ "$UNAME" != "Linux" ] && [ "$UNAME" != "Darwin" ] ; then
 fi
 
 if [ "$UNAME" = "Darwin" ] ; then
-  PLATFORM="macos"
+  FILENAME="spectral-macos"
 elif [ "$UNAME" = "Linux" ] ; then
-  PLATFORM="linux"
+  FILENAME="spectral"
 fi
 
-URL="https://github.com/stoplightio/spectral/releases/latest/download/spectral-$PLATFORM"
-SRC=$(pwd)/spectral-$PLATFORM
+URL="https://github.com/stoplightio/spectral/releases/latest/download/${FILENAME}"
+SRC="$(pwd)/${FILENAME}"
 DEST=/usr/local/bin/spectral
 
 STATUS=$(curl -sL -w %{http_code} -o $SRC $URL)
 if [ $STATUS -ge 200 ] & [ $STATUS -le 308 ]; then
   mv $SRC $DEST
   chmod +x $DEST
-  echo "Spectral installation was successful"
+  echo "Spectral was installed to: ${DEST}"
 else
   rm $SRC
   echo "Error requesting. Download binary from ${URL}"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2715,7 +2715,7 @@ for-in@^1.0.1, for-in@^1.0.2:
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
 
-for-own@^0.1.3, for-own@^0.1.4:
+for-own@^0.1.3:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
   integrity sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=


### PR DESCRIPTION
Note - we won't this need change for develop, as develop already generates correct binaries.
https://github.com/stoplightio/spectral/blob/develop/.circleci/config.yml#L88

Theoretically I could upload spectral-linux and let it be, but I'd rather not touch it at all.

