### PR TITLE
feat: arrayish given

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 [*]
 charset = utf-8
 
-[*.{ts,js,yaml}]
+[*.{ts,js,yaml,scenario}]
 indent_style = space
 indent_size = 2
 

--- a/docs/getting-started/rulesets.md
+++ b/docs/getting-started/rulesets.md
@@ -120,9 +120,15 @@ Now all the rules in this ruleset will only be applied if the specified format i
 
 Custom formats can be registered via the [JS API](../guides/javascript.md), but the CLI is limited to using the predefined ones.
 
+## Given
+
+The `given` keyword is, besides `then`, the only required property on each rule definition. 
+It can be any valid JSONPath expression or an array of JSONPath expressions.
+[JSONPath Online Evaluator](http://jsonpath.com/) is a helpful tool to determine what `given` path you want.
+
 ## Severity
 
-The `severity` keyword is optional and can be `error`, `warn`, `info`, or `hint`.
+The `severity` keyword is optional and can be `error`, `warn`, `info`, or `hint`. The default value is `warn`.
 
 ## Then
 

--- a/src/__tests__/linter.test.ts
+++ b/src/__tests__/linter.test.ts
@@ -700,6 +700,26 @@ responses:: !!foo
         expect(fakeLintingFunction.mock.calls[0][2].given).toEqual(['responses']);
         expect(fakeLintingFunction.mock.calls[0][3].given).toEqual(target.responses);
       });
+
+      test('given array of paths, should pass each given path through to lint function', async () => {
+        spectral.setRules({
+          example: {
+            message: '',
+            given: ['$.responses', '$..200'],
+            then: {
+              function: fnName,
+            },
+          },
+        });
+
+        await spectral.run(target);
+
+        expect(fakeLintingFunction).toHaveBeenCalledTimes(2);
+        expect(fakeLintingFunction.mock.calls[0][2].given).toEqual(['responses']);
+        expect(fakeLintingFunction.mock.calls[0][3].given).toEqual(target.responses);
+        expect(fakeLintingFunction.mock.calls[1][2].given).toEqual(['responses', '200']);
+        expect(fakeLintingFunction.mock.calls[1][3].given).toEqual(target.responses['200']);
+      });
     });
 
     describe('when given path is not set', () => {

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -68,7 +68,7 @@ export const lintNode = (
     });
   }
 
-  let results: IRuleResult[] = [];
+  const results: IRuleResult[] = [];
 
   for (const target of targets) {
     const targetPath = givenPath.concat(target.path);
@@ -88,8 +88,8 @@ export const lintNode = (
         },
       ) || [];
 
-    results = results.concat(
-      targetResults.map<IRuleResult>(result => {
+    results.push(
+      ...targetResults.map<IRuleResult>(result => {
         const escapedJsonPath = (result.path || targetPath).map(segment => decodePointerFragment(String(segment)));
         const path = getClosestJsonPath(
           rule.resolved === false ? resolved.unresolved : resolved.resolved,

--- a/src/meta/rule.schema.json
+++ b/src/meta/rule.schema.json
@@ -66,7 +66,17 @@
                     "type": "boolean"
                 },
                 "given": {
-                    "type": "string"
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
                 },
                 "resolved": {
                     "type": "boolean"

--- a/src/types/rule.ts
+++ b/src/types/rule.ts
@@ -25,7 +25,7 @@ export interface IRule<T = string, O = any> {
   recommended?: boolean;
 
   // Filter the target down to a subset[] with a JSON path
-  given: string;
+  given: string | string[];
 
   // If false, rule will operate on original (unresolved) data
   // If undefined or true, resolved data will be supplied

--- a/test-harness/scenarios/rules-matching-multiple-places.scenario
+++ b/test-harness/scenarios/rules-matching-multiple-places.scenario
@@ -1,0 +1,40 @@
+====test====
+Rules matching multiple properties in the document
+====document====
+schemas:
+  user:
+    type: object
+    properties:
+      name:
+        type: number
+      age:
+        type: number
+      occupation:
+        type: boolean
+  address:
+====command====
+{bin} lint {document} -r {asset:ruleset}
+====asset:ruleset====
+rules:
+  valid-user-properties:
+    severity: error
+    given: [$.schemas.user.properties.name, $.schemas.user.properties.occupation]
+    then:
+      field: type
+      function: pattern
+      functionOptions:
+        match: /^string$/
+  require-user-and-address:
+    severity: error
+    given: [$.schemas.user, $.schemas.address]
+    then:
+      function: truthy
+====status====
+1
+====stdout====
+{document}
+  6:15  error  valid-user-properties     must match the pattern '/^string$/'
+ 10:15  error  valid-user-properties     must match the pattern '/^string$/'
+ 11:11  error  require-user-and-address  schemas.address is not truthy
+
+✖ 3 problems (3 errors, 0 warnings, 0 infos, 0 hints)


### PR DESCRIPTION
**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

Currently we only allow a single JSON path expression to be provided at a time for each rule.
That limitation may lead to a situation where a complex json path expression needs to be provided in order to match all intended properties. In most cases, those expressions could be split into 2-3 that would be much simpler.
