### PR TITLE
fix: print falsy value in error messages

### DIFF
--- a/src/rulesets/__tests__/message.spec.ts
+++ b/src/rulesets/__tests__/message.spec.ts
@@ -1,4 +1,4 @@
-import { message } from '../../message';
+import { message } from '../message';
 
 describe('message util', () => {
   test('interpolates correctly', () => {
@@ -11,6 +11,18 @@ describe('message util', () => {
         value: void 0,
       }),
     ).toEqual('oops... "description" is missing;error: expected property to be truthy');
+  });
+
+  test.each([0, false, null, undefined])('interpolates %s value correctly', value => {
+    const template = 'Value must not equal {{value}}';
+    expect(
+      message(template, {
+        property: 'description',
+        error: 'expected property to be truthy',
+        path: '',
+        value,
+      }),
+    ).toEqual(`Value must not equal ${value}`);
   });
 
   test('handles siblings', () => {

--- a/src/rulesets/message.ts
+++ b/src/rulesets/message.ts
@@ -18,7 +18,7 @@ export const message: MessageInterpolator = (str, values) => {
 
   // tslint:disable-next-line:no-conditional-assignment
   while ((result = BRACES.exec(str))) {
-    const newValue = String(values[result[1]] || '');
+    const newValue = result[1] in values ? String(values[result[1]]) : '';
     str = `${str.slice(0, result.index)}${newValue}${str.slice(BRACES.lastIndex)}`;
     BRACES.lastIndex = result.index + newValue.length;
   }


### PR DESCRIPTION

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No


**Additional context**

Fixes an issue where a falsy value (referenced via `{{value}}`) would not be printed in the error message.
