### PR TITLE
fix: resolve the source of errors for top-level references

### DIFF
--- a/src/cli/services/__tests__/linter.test.ts
+++ b/src/cli/services/__tests__/linter.test.ts
@@ -708,14 +708,26 @@ describe('Linter service', () => {
 
   describe('--resolver', () => {
     it('uses provided resolver for $ref resolving', async () => {
-      expect(await run(`lint --resolver ${fooResolver} ${fooDocument}`)).toEqual([
-        expect.objectContaining({
-          code: 'oas3-api-servers',
-        }),
-        expect.objectContaining({
-          code: 'openapi-tags',
-        }),
-      ]);
+      expect(await run(`lint --resolver ${fooResolver} ${fooDocument}`)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'info-contact',
+            source: 'foo://openapi-3.0-no-contact.yaml/',
+          }),
+          expect.objectContaining({
+            code: 'info-description',
+            source: 'foo://openapi-3.0-no-contact.yaml/',
+          }),
+          expect.objectContaining({
+            code: 'oas3-api-servers',
+            source: 'foo://openapi-3.0-no-contact.yaml/',
+          }),
+          expect.objectContaining({
+            code: 'openapi-tags',
+            source: 'foo://openapi-3.0-no-contact.yaml/',
+          }),
+        ]),
+      );
     });
   });
 });


### PR DESCRIPTION
It's a cherry-pick of the fix originally provided in https://github.com/stoplightio/spectral/pull/685/commits/05e909dcac1216e6634aac176fc79d1ea58680e7. Since it's unrelated, let's merge it ASAP, while I'm addressing the comments regarding the actual part of that PR. Will also reduce the noise in that PR making it easier to review.

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No


**Additional context**

Minor fix for top-level $refs. Right now, the source of error would not always be detected correctly for such a document
```yaml
$ref: ./remote-document.yaml#
```
Rather unlikely to be an often case, but it's still good detect it correctly.
