### PR TITLE
fix: use non-secure version of nanoid

### DIFF
--- a/src/rulesets/__tests__/reader.jest.test.ts
+++ b/src/rulesets/__tests__/reader.jest.test.ts
@@ -6,9 +6,9 @@ import * as nock from 'nock';
 import { Spectral } from '../../spectral';
 import { IRule, RuleType } from '../../types';
 import { readRuleset } from '../reader';
-const nanoid = require('nanoid');
+const nanoid = require('nanoid/non-secure');
 
-jest.mock('nanoid');
+jest.mock('nanoid/non-secure');
 jest.mock('fs');
 
 const validFlatRuleset = path.join(__dirname, './__fixtures__/valid-flat-ruleset.json');

--- a/src/rulesets/mergers/__tests__/functions.jest.test.ts
+++ b/src/rulesets/mergers/__tests__/functions.jest.test.ts
@@ -1,9 +1,9 @@
 import { RuleCollection } from '../../../types';
 import { RulesetFunctionCollection } from '../../../types/ruleset';
 import { mergeFunctions } from '../functions';
-const nanoid = require('nanoid');
+const nanoid = require('nanoid/non-secure');
 
-jest.mock('nanoid');
+jest.mock('nanoid/non-secure');
 
 describe('Ruleset functions merging', () => {
   beforeEach(() => {

--- a/src/rulesets/mergers/functions.ts
+++ b/src/rulesets/mergers/functions.ts
@@ -1,7 +1,7 @@
 import { Dictionary } from '@stoplight/types/dist';
 import { RuleCollection } from '../../types';
 import { RulesetFunctionCollection } from '../../types/ruleset';
-const nanoid = require('nanoid');
+const nanoid = require('nanoid/non-secure');
 
 export function mergeFunctions(
   target: RulesetFunctionCollection,


### PR DESCRIPTION
Fixes #846 

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No


**Additional context**

https://github.com/ai/nanoid#non-secure 
Security is a not a concern for us, since we just want random IDs to be generated for custom functions.