### PR TITLE
build: disable auto-merge for dependabot

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: automerge
+        if: github.actor != 'dependabot-preview[bot]' && github.actor != 'dependabot[bot]'
         uses: "pascalgn/automerge-action@v0.6.0"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Dependabot takes care of the PRs, so there is no need for github-actions to merge the develop branch.
The history quite a mess due to that + Dependabot is broken too when such a merge commit is pushed (see https://github.com/stoplightio/spectral/pull/832#issuecomment-566085874 as one of the examples).
In general, I believe automerging PRs bumping external packages may be unsafe, i.e what if it contains malicious code? we should at least briefly examine what the changes are all about.

According to Dependabot, it can even merge the PRs for you, so we don't need that action even for an actual merging.