### PR TITLE
build: improve Dependabot integration

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,35 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"
+    version_requirement_updates: increase_versions
+
+    commit_message:
+      prefix: "fix"
+      include_scope: true
+
+    allowed_updates:
+      - match:
+          dependency_name: "@stoplight/*" # match all Stoplight deps, regardless of type
+          update_type: "all"
+      - match:
+          dependency_type: "production"
+          update_type: "all"
+      - match:
+          dependency_type: "development"
+          update_type: "security"
+
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "weekly" # we do not need to check for devDependencies updates on a daily basis
+    version_requirement_updates: increase_versions
+
+    commit_message:
+      prefix: "chore"
+      include_scope: true
+
+    allowed_updates:
+      - match:
+          dependency_type: "development"
+          update_type: "all"


### PR DESCRIPTION
At the moment we try to update dependencies on a daily basis regardless of their type.
This causes a small disruption in case of certain packages, i.e. `@types/*` or `rollup`, as they are updated more frequently, therefore plenty of PRs are created.

![github com_stoplightio_spectral_pulls_utf8=%E2%9C%93 q=is%3Apr+is%3Aclosed+rollup (1)](https://user-images.githubusercontent.com/9273484/71081868-57301e80-2190-11ea-8739-61e0a561050a.png)

Developer dependencies do not need to updated that often, as we usually use a small subset of their functionality and don't use them directly in a production environment, therefore as long as our own developer experience is not affected or they don't come up a significant improvement, we don't need to check for updates daily.

Production dependencies, on the other hand, are usually more important, as they contain actual bugfixes or features impacting end users. Moreover, by performing regular updates, we are less prone to be affected by breaking changes, since deprecation notices are thrown at us more often allowing us to get rid of the deprecated part.

The PR makes all production packages to be checked in a live mode (PRs should be created as soon as the change is up). Besides that, all Stoplight packages are updated in that mode as well, no matter what their type is. Last but not least, all security updates coming from dev dependencies are checked in real-time too. 

DevDependencies are scheduled to be updated on a weekly basis.

---
I hope I didn't screw the config :sweat_smile: 