### PR TITLE
chore(yarn): add missing dependency version

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2686,7 +2686,7 @@ for-in@^1.0.1, for-in@^1.0.2:
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
 
-for-own@^0.1.3:
+for-own@^0.1.3, for-own@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
   integrity sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=


### PR DESCRIPTION
Running `yarn` from develop keeps on updating the yarn.lock file with this change.

Indeed this version is required by `object.omit` package, so having this resolution added makes sense.

![image](https://user-images.githubusercontent.com/92363/71764806-e35e7780-2eec-11ea-8fbd-21f603670c6f.png)
