### PR TITLE
fix: support optional authentication for rule oas3-operation-security-defined

### DIFF
--- a/docs/reference/openapi-rules.md
+++ b/docs/reference/openapi-rules.md
@@ -417,6 +417,7 @@ Server URL should not have a trailing slash.
 ### oas2-operation-security-defined
 
 Operation `security` values must match a scheme defined in the `securityDefinitions` object.
+Ignores empty `security` values.
 
 **Recommended:** Yes
 

--- a/docs/reference/openapi-rules.md
+++ b/docs/reference/openapi-rules.md
@@ -417,7 +417,7 @@ Server URL should not have a trailing slash.
 ### oas2-operation-security-defined
 
 Operation `security` values must match a scheme defined in the `securityDefinitions` object.
-Ignores empty `security` values.
+Ignores empty `security` values for cases where authentication is explicitly not required or optional.
 
 **Recommended:** Yes
 

--- a/src/rulesets/oas/functions/oasOpSecurityDefined.ts
+++ b/src/rulesets/oas/functions/oasOpSecurityDefined.ts
@@ -25,9 +25,9 @@ export const oasOpSecurityDefined: IFunction<{
 
           for (const index in security) {
             if (security[index]) {
-              const securityKey = Object.keys(security[index])[0];
+              const securityKeys = Object.keys(security[index]);
 
-              if (!allDefs.includes(securityKey)) {
+              if (securityKeys.length > 0 && !allDefs.includes(securityKeys[0])) {
                 results.push({
                   message: 'operation referencing undefined security scheme',
                   path: ['paths', path, operation, 'security', index],

--- a/test-harness/scenarios/operation-security-defined.oas3.scenario
+++ b/test-harness/scenarios/operation-security-defined.oas3.scenario
@@ -1,0 +1,35 @@
+====test====
+Operation security defined, allow optional / no auth security
+====document====
+openapi: 3.0.2
+paths:
+  /pets:
+    get:
+      security:
+        - {}
+      responses:
+        '200':
+          description: abc
+    post:
+      security:
+        - {}
+        - Bearer: []
+      responses:
+        '200':
+          description: abc
+    delete:
+      security:
+        - Bearer: []
+      responses:
+        '200':
+          description: abc
+components:
+  securitySchemes:
+    Bearer:
+      type: http
+      scheme: bearer
+====command====
+{bin} lint {document} --ruleset ./rulesets/operation-security-defined.oas3.yaml
+====stdout====
+OpenAPI 3.x detected
+No results with a severity of 'error' or higher found!

--- a/test-harness/scenarios/operation-security-defined.oas3.scenario
+++ b/test-harness/scenarios/operation-security-defined.oas3.scenario
@@ -1,5 +1,9 @@
 ====test====
 Operation security defined, allow optional / no auth security
+====asset:ruleset====
+extends: [[spectral:oas, off]]
+rules:
+  oas3-operation-security-defined: error
 ====document====
 openapi: 3.0.2
 paths:
@@ -29,7 +33,7 @@ components:
       type: http
       scheme: bearer
 ====command====
-{bin} lint {document} --ruleset ./rulesets/operation-security-defined.oas3.yaml
+{bin} lint {document} --ruleset {asset:ruleset}
 ====stdout====
 OpenAPI 3.x detected
 No results with a severity of 'error' or higher found!

--- a/test-harness/scenarios/rulesets/operation-security-defined.oas3.yaml
+++ b/test-harness/scenarios/rulesets/operation-security-defined.oas3.yaml
@@ -1,3 +1,0 @@
-extends: [[spectral:oas, off]]
-rules:
-  oas3-operation-security-defined: error

--- a/test-harness/scenarios/rulesets/operation-security-defined.oas3.yaml
+++ b/test-harness/scenarios/rulesets/operation-security-defined.oas3.yaml
@@ -1,0 +1,3 @@
+extends: [[spectral:oas, off]]
+rules:
+  oas3-operation-security-defined: true

--- a/test-harness/scenarios/rulesets/operation-security-defined.oas3.yaml
+++ b/test-harness/scenarios/rulesets/operation-security-defined.oas3.yaml
@@ -1,3 +1,3 @@
 extends: [[spectral:oas, off]]
 rules:
-  oas3-operation-security-defined: true
+  oas3-operation-security-defined: error


### PR DESCRIPTION
Support optional authentication for rule oas3-operation-security-defined.

Fixes #892

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No