### PR TITLE
chore: reorganize rule types declaration

### DIFF
--- a/src/functions/__tests__/casing.test.ts
+++ b/src/functions/__tests__/casing.test.ts
@@ -1,5 +1,4 @@
-import { ICasingOptions } from '../../types';
-import { casing } from '../casing';
+import { casing, ICasingOptions } from '../casing';
 
 function runCasing(target: unknown, type: ICasingOptions['type'], disallowDigits?: boolean) {
   return casing(

--- a/src/functions/alphabetical.ts
+++ b/src/functions/alphabetical.ts
@@ -1,5 +1,12 @@
 import { isObject } from 'lodash';
-import { IAlphaRuleOptions, IFunction, IFunctionResult } from '../types';
+import { IFunction, IFunctionResult, IRule, RuleFunction } from '../types';
+
+export interface IAlphaRuleOptions {
+  /** if sorting array of objects, which key to use for comparison */
+  keyedBy?: string;
+}
+
+export type AlphaRule = IRule<RuleFunction.ALPHABETICAL, IAlphaRuleOptions>;
 
 const compare = (a: unknown, b: unknown): number => {
   if ((typeof a === 'number' || Number.isNaN(Number(a))) && (typeof b === 'number' || !Number.isNaN(Number(b)))) {

--- a/src/functions/casing.ts
+++ b/src/functions/casing.ts
@@ -1,5 +1,12 @@
 import { Dictionary } from '@stoplight/types';
-import { ICasingOptions, IFunction } from '../types';
+import { IFunction, IRule, RuleFunction } from '../types';
+
+export interface ICasingOptions {
+  type: 'flat' | 'camel' | 'pascal' | 'kebab' | 'cobol' | 'snake' | 'macro';
+  disallowDigits?: boolean;
+}
+
+export type CasingRule = IRule<RuleFunction.CASING, ICasingOptions>;
 
 const CASES: Dictionary<RegExp, ICasingOptions['type']> = {
   flat: /^[a-z]+$/,

--- a/src/functions/enumeration.ts
+++ b/src/functions/enumeration.ts
@@ -1,4 +1,10 @@
-import { IEnumRuleOptions, IFunction, IFunctionResult } from '../types';
+import { IFunction, IFunctionResult, IRule, RuleFunction } from '../types';
+
+export interface IEnumRuleOptions {
+  values: Array<string | number>;
+}
+
+export type EnumRule = IRule<RuleFunction.ENUM, IEnumRuleOptions>;
 
 export const enumeration: IFunction<IEnumRuleOptions> = (targetVal, opts) => {
   const results: IFunctionResult[] = [];

--- a/src/functions/length.ts
+++ b/src/functions/length.ts
@@ -1,4 +1,11 @@
-import { IFunction, IFunctionResult, ILengthRuleOptions } from '../types';
+import { IFunction, IFunctionResult, IRule, RuleFunction } from '../types';
+
+export interface ILengthRuleOptions {
+  min?: number;
+  max?: number;
+}
+
+export type LengthRule = IRule<RuleFunction.LENGTH, ILengthRuleOptions>;
 
 export const length: IFunction<ILengthRuleOptions> = (targetVal, opts) => {
   const results: IFunctionResult[] = [];

--- a/src/functions/pattern.ts
+++ b/src/functions/pattern.ts
@@ -1,4 +1,14 @@
-import { IFunction, IFunctionResult, IRulePatternOptions } from '../types';
+import { IFunction, IFunctionResult, IRule, RuleFunction } from '../types';
+
+export interface IRulePatternOptions {
+  /** regex that target must match */
+  match?: string;
+
+  /** regex that target must not match */
+  notMatch?: string;
+}
+
+export type PatternRule = IRule<RuleFunction.PATTERN, IRulePatternOptions>;
 
 function test(value: string, regex: RegExp | string) {
   let re;

--- a/src/functions/schema-path.ts
+++ b/src/functions/schema-path.ts
@@ -7,10 +7,18 @@
  * The primary use case for this was validating OpenAPI examples
  * against their schema, but this could be used for other things.
  */
-import { IFunction, ISchemaPathOptions } from '../types';
+import { IFunction, IRule, RuleFunction } from '../types';
 import { schema } from './schema';
 
 const { JSONPath } = require('jsonpath-plus');
+
+export interface ISchemaPathOptions {
+  schemaPath: string;
+  // the `path.to.prop` to field, or special `@key` value to target keys for matched `given` object
+  field?: string;
+}
+
+export type SchemaPathRule = IRule<RuleFunction.SCHEMAPATH, ISchemaPathOptions>;
 
 export const schemaPath: IFunction<ISchemaPathOptions> = (targetVal, opts, paths, otherValues) => {
   if (!targetVal || typeof targetVal !== 'object') return [];

--- a/src/functions/schema.ts
+++ b/src/functions/schema.ts
@@ -7,9 +7,15 @@ import * as jsonSpecv6 from 'ajv/lib/refs/json-schema-draft-06.json';
 import * as jsonSpecv7 from 'ajv/lib/refs/json-schema-draft-07.json';
 import { IOutputError } from 'better-ajv-errors';
 import { escapeRegExp } from 'lodash';
-import { IFunction, IFunctionResult, ISchemaOptions, JSONSchema } from '../types';
+import { IFunction, IFunctionResult, IRule, JSONSchema, RuleFunction } from '../types';
 const oasFormatValidator = require('ajv-oai/lib/format-validator');
 const betterAjvErrors = require('better-ajv-errors/lib/modern');
+
+export interface ISchemaOptions {
+  schema: object;
+}
+
+export type SchemaRule = IRule<RuleFunction.SCHEMA, ISchemaOptions>;
 
 interface IAJVOutputError extends IOutputError {
   path?: string;

--- a/src/functions/truthy.ts
+++ b/src/functions/truthy.ts
@@ -1,4 +1,6 @@
-import { IFunction, IFunctionResult } from '../types';
+import { IFunction, IFunctionResult, IRule, RuleFunction } from '../types';
+
+export type TruthyRule = IRule<RuleFunction.TRUTHY>;
 
 export const truthy: IFunction = (targetVal): void | IFunctionResult[] => {
   if (!targetVal) {

--- a/src/functions/xor.ts
+++ b/src/functions/xor.ts
@@ -1,4 +1,11 @@
-import { IFunction, IFunctionResult, IXorRuleOptions } from '../types';
+import { IFunction, IFunctionResult, IRule, RuleFunction } from '../types';
+
+export interface IXorRuleOptions {
+  /** test to verify if one (but not all) of the provided keys are present in object */
+  properties: string[];
+}
+
+export type XorRule = IRule<RuleFunction.XOR, IXorRuleOptions>;
 
 export const xor: IFunction<IXorRuleOptions> = (targetVal, opts) => {
   const results: IFunctionResult[] = [];

--- a/src/types/rule.ts
+++ b/src/types/rule.ts
@@ -1,7 +1,24 @@
 import { DiagnosticSeverity } from '@stoplight/types';
-import { RuleFunction, RuleType } from './enums';
+import { AlphaRule } from '../functions/alphabetical';
+import { CasingRule } from '../functions/casing';
+import { LengthRule } from '../functions/length';
+import { PatternRule } from '../functions/pattern';
+import { SchemaRule } from '../functions/schema';
+import { SchemaPathRule } from '../functions/schema-path';
+import { TruthyRule } from '../functions/truthy';
+import { XorRule } from '../functions/xor';
+import { RuleType } from './enums';
 
-export type Rule = IRule | TruthyRule | XorRule | LengthRule | AlphaRule | PatternRule | CasingRule | SchemaRule;
+export type Rule =
+  | IRule
+  | TruthyRule
+  | XorRule
+  | LengthRule
+  | AlphaRule
+  | PatternRule
+  | CasingRule
+  | SchemaRule
+  | SchemaPathRule;
 
 export interface IRule<T = string, O = any> {
   type?: RuleType;
@@ -45,57 +62,5 @@ export interface IThen<T = string, O = any> {
   // Options passed to the function
   functionOptions?: O;
 }
-
-export type TruthyRule = IRule<RuleFunction.TRUTHY>;
-
-export interface IXorRuleOptions {
-  /** test to verify if one (but not all) of the provided keys are present in object */
-  properties: string[];
-}
-export type XorRule = IRule<RuleFunction.XOR, IXorRuleOptions>;
-
-export interface ILengthRuleOptions {
-  min?: number;
-  max?: number;
-}
-export type LengthRule = IRule<RuleFunction.LENGTH, ILengthRuleOptions>;
-
-export interface IEnumRuleOptions {
-  values: Array<string | number>;
-}
-export type EnumRule = IRule<RuleFunction.ENUM, IEnumRuleOptions>;
-
-export interface IAlphaRuleOptions {
-  /** if sorting array of objects, which key to use for comparison */
-  keyedBy?: string;
-}
-export type AlphaRule = IRule<RuleFunction.ALPHABETICAL, IAlphaRuleOptions>;
-
-export interface IRulePatternOptions {
-  /** regex that target must match */
-  match?: string;
-
-  /** regex that target must not match */
-  notMatch?: string;
-}
-export type PatternRule = IRule<RuleFunction.PATTERN, IRulePatternOptions>;
-
-export interface ICasingOptions {
-  type: 'flat' | 'camel' | 'pascal' | 'kebab' | 'cobol' | 'snake' | 'macro';
-  disallowDigits?: boolean;
-}
-export type CasingRule = IRule<RuleFunction.CASING, ICasingOptions>;
-
-export interface ISchemaOptions {
-  schema: object;
-}
-export type SchemaRule = IRule<RuleFunction.SCHEMA, ISchemaOptions>;
-
-export interface ISchemaPathOptions {
-  schemaPath: string;
-  // the `path.to.prop` to field, or special `@key` value to target keys for matched `given` object
-  field?: string;
-}
-export type SchemaPathRule = IRule<RuleFunction.SCHEMAPATH, ISchemaPathOptions>;
 
 export type HumanReadableDiagnosticSeverity = 'error' | 'warn' | 'info' | 'hint' | 'off';


### PR DESCRIPTION
Tries to tackle @philsturgeon 's comment @ https://github.com/stoplightio/spectral/pull/884/files/5375e91f368c107f59c09c47c65cd834ab011b35#r363666263

**Checklist**

- [ ] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

This PR moves some type declarations back into the files that should expose them.
