### PR TITLE
build(docker-image): use absolute path in ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,4 @@ COPY package.json /usr/src/spectral/
 COPY --from=compiler /usr/src/spectral/dist /usr/src/spectral/dist
 COPY --from=dependencies /usr/src/spectral/node_modules/ /usr/src/spectral/node_modules/
 
-WORKDIR /usr/src/spectral/
-
-ENTRYPOINT [ "node", "dist/cli/index.js" ]
+ENTRYPOINT [ "node", "/usr/src/spectral/dist/cli/index.js" ]


### PR DESCRIPTION
- Makes sure that ENTRYPOINT uses absolute paths.

- Removes duplicate WORKDIR.

**Checklist**

- [ ] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

> If indicated yes above, please describe the breaking change(s).
>
> **Remove this quote before creating the PR.**

**Additional context**

Allows to run the Docker image as GitHub Action with different workdir.
