### PR TITLE
chore(harness): reduce tests failures on Windows

### DIFF
--- a/test-harness/helpers.ts
+++ b/test-harness/helpers.ts
@@ -112,3 +112,7 @@ export const applyReplacements = (str: string, values: Dictionary<string>) => {
 
   return str;
 };
+
+export const normalizeLineEndings = (str: string): string => {
+  return str.replace(/\r?\n/g, '\n');
+};

--- a/test-harness/helpers.ts
+++ b/test-harness/helpers.ts
@@ -99,18 +99,15 @@ export function tmpFile(opts?: tmp.TmpNameOptions): Promise<tmp.FileResult> {
 const BRACES = /{([^}]+)}/g;
 
 export const applyReplacements = (str: string, values: Dictionary<string>) => {
-  BRACES.lastIndex = 0;
-  let result: RegExpExecArray | null;
+  const replacer = (match: string, identifier: string): string => {
+    if (!(identifier in values)) {
+      return match;
+    }
 
-  // tslint:disable-next-line:no-conditional-assignment
-  while ((result = BRACES.exec(str))) {
-    if (!(result[1] in values)) continue;
-    const newValue = String(values[result[1]] || '');
-    str = `${str.slice(0, result.index)}${newValue}${str.slice(BRACES.lastIndex)}`;
-    BRACES.lastIndex = result.index + newValue.length;
-  }
+    return values[identifier];
+  };
 
-  return str;
+  return str.replace(BRACES, replacer);
 };
 
 export const normalizeLineEndings = (str: string): string => {

--- a/test-harness/index.ts
+++ b/test-harness/index.ts
@@ -30,11 +30,10 @@ describe('cli acceptance tests', () => {
           const tmpFileHandle = await tmpFile();
           tmpFileHandles.set(asset, tmpFileHandle);
 
-          replacements[asset] = tmpFileHandle.name;
-          replacements[`${asset}|no-ext`] = tmpFileHandle.name.replace(
-            new RegExp(`${path.extname(tmpFileHandle.name)}$`),
-            '',
-          );
+          const normalizedName = normalize(tmpFileHandle.name);
+
+          replacements[asset] = normalizedName;
+          replacements[`${asset}|no-ext`] = normalizedName.replace(new RegExp(`${path.extname(normalizedName)}$`), '');
 
           await writeFileAsync(tmpFileHandle.name, contents, { encoding: 'utf8' }); // todo: apply replacements to contents
         }),

--- a/test-harness/index.ts
+++ b/test-harness/index.ts
@@ -5,7 +5,7 @@ import * as fg from 'fast-glob';
 import * as fs from 'fs';
 import * as tmp from 'tmp';
 import { promisify } from 'util';
-import { applyReplacements, parseScenarioFile, tmpFile } from './helpers';
+import { applyReplacements, normalizeLineEndings, parseScenarioFile, tmpFile } from './helpers';
 import { spawnNode } from './spawn';
 const writeFileAsync = promisify(fs.writeFile);
 
@@ -57,13 +57,13 @@ describe('cli acceptance tests', () => {
       const expectedStderr = scenario.stderr === void 0 ? void 0 : applyReplacements(scenario.stderr, replacements);
 
       if (expectedStderr !== void 0) {
-        expect(stderr).toEqual(expectedStderr);
+        expect(stderr).toEqual(normalizeLineEndings(expectedStderr));
       } else if (stderr) {
         throw new Error(stderr);
       }
 
       if (expectedStdout !== void 0) {
-        expect(stdout).toEqual(expectedStdout);
+        expect(stdout).toEqual(normalizeLineEndings(expectedStdout));
       }
 
       if (scenario.status !== void 0) {

--- a/test-harness/spawn.ts
+++ b/test-harness/spawn.ts
@@ -2,6 +2,7 @@ import { join } from '@stoplight/path';
 import { Optional } from '@stoplight/types';
 import * as child_process from 'child_process';
 import { Transform } from 'stream';
+import { normalizeLineEndings } from './helpers';
 
 const cwd = join(__dirname, 'scenarios');
 
@@ -64,8 +65,8 @@ export const spawnNode: SpawnFn = async (script, env) => {
   });
 
   return {
-    stderr: stderrText.replace(/\r?\n/g, '\n'),
-    stdout: stdoutText.replace(/\r?\n/g, '\n'),
+    stderr: normalizeLineEndings(stderrText),
+    stdout: normalizeLineEndings(stdoutText),
     status,
   };
 };


### PR DESCRIPTION
**Let's start to shine some love on Harness in Windows land.**

---

Partially address #919 

**Checklist**

- [ ] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

While working on #939, I eventually bit the bullet and worked a bit to scratch my own itch.

This improves a bit the running of harness tests on Windows platform.

Harness tests still fail on Win, but this greatly reduce the noise in the failures.