### PR TITLE
chore(doc): how to return multiple results from a function

### DIFF
--- a/docs/guides/custom-functions.md
+++ b/docs/guides/custom-functions.md
@@ -97,7 +97,7 @@ You can do it as follows:
 
 ```yaml
 functions:
-- - equals
+- equals
   # can be any valid JSONSchema7
   - properties:
       value:

--- a/docs/guides/custom-functions.md
+++ b/docs/guides/custom-functions.md
@@ -145,6 +145,78 @@ rules:
 
 Spectral would look for functions in a `my-functions` directory now.
 
+## Returning multiple results
+
+Many functions will return a single message, but its possible for a function to return multiple.
+
+For example, if a rule is created to make sure something is unique, it could either:
+
+- return a single error for the entire array which lists offending values in a comma separated list
+- return a single error for the array value which contains the first offending non-unique item
+- return multiple errors for each duplicate value located
+
+How exactly you chose to implement messages depends on the rule at hand and probably personal preference too.
+
+It's worth keeping in mind, Spectral will attempt to deduplicate messages when they bear the same `code` and target the same `path`.
+As such, when your custom function is susceptible to return more than one result, you have to specify a different `path`
+for each result. 
+
+Below a sample function that checks tags bear unique names.
+
+**my-ruleset.yaml**
+
+```yaml
+functions: [uniqueTagNames]
+rules:
+  unique-tag-names:
+    message: "Tags should have distinct names: {{error}}"
+    given: "$.tags"
+    then:
+      function: "uniqueTagNames"
+```
+
+**functions/uniqueTagNames.js**
+
+```js
+const NAME_PROPERTY = 'name';
+
+module.exports = (targetVal, _opts, paths) => {
+    if (!Array.isArray(targetVal)) {
+        return;
+    }
+
+    const seen = [];
+    const results = [];
+
+    const rootPath = paths.target !== void 0 ? paths.target : paths.given;
+
+    for (let i = 0; i < targetVal.length; i++) {
+        if (targetVal[i] === null || typeof targetVal[i] !== 'object') {
+           continue;
+        }
+
+        const tagName = targetVal[i][NAME_PROPERTY];
+
+        if (tagName === void 0) {
+            continue;
+        }
+
+        if (seen.includes(tagName)) {
+            results.push(
+                {
+                    message: `Duplicate tag name '${tagName}'`,
+                    path: [...rootPath, i, NAME_PROPERTY]
+                },
+            );
+        } else {
+            seen.push(tagName);
+        }
+    }
+
+    return results;
+};
+```
+
 ## Inheritance
 
 Core functions can be overridden with custom rulesets, so if you'd like to make your own truthy go ahead. Custom functions are only available in the ruleset which defines them, so loading a foo in one ruleset will not clobber a foo in another ruleset.

--- a/test-harness/scenarios/custom-function-can-return-multiple-results.scenario
+++ b/test-harness/scenarios/custom-function-can-return-multiple-results.scenario
@@ -1,0 +1,84 @@
+====test====
+Custom function can return multiple results
+====document====
+openapi: 3.0.2
+info:
+  title: Test Spec
+  version: 0.0.0
+
+tags:
+  - name: a-tag
+    description: A tag
+  - name: b-tag
+    description: Another tag
+  - name: a-tag
+    description: A tag. Huh?
+  - name: a-tag
+    description: A tag. Srsly!
+
+paths: {}
+====asset:fn.js====
+// Code sample from `custom-functions.md`
+
+const NAME_PROPERTY = 'name';
+
+module.exports = (targetVal, _opts, paths) => {
+  if (!Array.isArray(targetVal)) {
+    return;
+  }
+
+  const seen = [];
+  const results = [];
+
+  const rootPath = paths.target !== void 0 ? paths.target : paths.given;
+
+  for (let i = 0; i < targetVal.length; i++) {
+    if (targetVal[i] === null || typeof targetVal[i] !== 'object') {
+      continue;
+    }
+
+    const tagName = targetVal[i][NAME_PROPERTY];
+
+    if (tagName === void 0) {
+      continue;
+    }
+
+    if (seen.includes(tagName)) {
+      results.push(
+        {
+            message: `Duplicate tag name '${tagName}'`,
+            path: [...rootPath, i, NAME_PROPERTY]
+        },
+      );
+    } else {
+      seen.push(tagName);
+    }
+  }
+
+  return results;
+};
+====asset:ruleset====
+extends: [spectral:oas]
+
+functions: ["{asset:fn.js|filename|no-ext}"]
+functionsDir: "."
+
+rules:
+  unique-tag-names:
+    message: "Tags should have distinct names: {{error}}"
+    given: "$.tags"
+    then:
+      function: "{asset:fn.js|filename|no-ext}"
+====command====
+{bin} lint {document} --ruleset {asset:ruleset}
+====stdout====
+OpenAPI 3.x detected
+
+{document}
+  1:1   warning  oas3-api-servers  OpenAPI `servers` must be present and non-empty array.
+  2:6   warning  info-contact      Info object should contain `contact` object.
+  2:6   warning  info-description  OpenAPI object info `description` must be present and non-empty string.
+ 11:11  warning  unique-tag-names  Tags should have distinct names: Duplicate tag name 'a-tag'
+ 13:11  warning  unique-tag-names  Tags should have distinct names: Duplicate tag name 'a-tag'
+
+✖ 5 problems (0 errors, 5 warnings, 0 infos, 0 hints)


### PR DESCRIPTION
Fixes #1030 and #920 

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

This attempts at documenting how to properly return multiple results from custom functions while playing nicely with the deduplication of the fringerprinting mechanism.