### PR TITLE
chore: only check docs/ markdown links

### DIFF
--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -12,5 +12,5 @@ jobs:
     steps:
     - uses: actions/checkout@master
       with:
-        fetch-depth: 1
-    - uses: planetscale/github-action-markdown-link-check@master
+        folder-path: "./docs/"
+    - uses: gaurav-nelson/github-action-markdown-link-check@master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdown-link-check-disable -->
+
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -162,3 +164,5 @@ CLI: missing tslib [#524](https://github.com/stoplightio/spectral/issues/524)
 
 - Configuration files were briefly available in 3.x but removed in v4.0
 - CLI `--max-results` flag is removed
+
+<!-- markdown-link-check-enable-->


### PR DESCRIPTION
develop is failing due to this github action trawling through every issue/PR link in the CHANGELOG and hitting 429 rate limiting. It's slow and usually results in a failure, so let's just hit docs/ and see if that speeds things up.