### PR TITLE
fix: set proper document source if legacy parsed result is given

### DIFF
--- a/src/document.ts
+++ b/src/document.ts
@@ -66,9 +66,9 @@ export class ParsedDocument<D = unknown, R extends IParsedResult = IParsedResult
   public readonly diagnostics: ReadonlyArray<IRuleResult>;
   public formats?: string[] | null;
 
-  constructor(protected readonly parserResult: R, source?: string) {
+  constructor(protected readonly parserResult: R) {
     // we need to normalize the path in case path with forward slashes is given
-    this.source = normalizeSource(source);
+    this.source = normalizeSource(parserResult.source);
     this.diagnostics = formatParserDiagnostics(this.parserResult.parsed.diagnostics, this.source);
   }
 

--- a/src/spectral.ts
+++ b/src/spectral.ts
@@ -72,7 +72,7 @@ export class Spectral {
             opts.resolve?.documentUri,
           );
 
-    if (document.source === void 0 && opts.resolve?.documentUri !== void 0) {
+    if (document.source === null && opts.resolve?.documentUri !== void 0) {
       (document as Omit<Document, 'source'> & { source: string }).source = opts.resolve?.documentUri;
     }
 


### PR DESCRIPTION
Needed by Studio :grin:
A tiny bug, shouldn't really affect anyone besides Studio.

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No


