### PR TITLE
Check links only for the `docs` folder

### DIFF
--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-      with:
-        folder-path: "./docs/"
     - uses: gaurav-nelson/github-action-markdown-link-check@master
+      with:
+        folder-path: 'docs'


### PR DESCRIPTION
Fixes incorrectly configured `folder-path` variable for [gaurav-nelson/github-action-markdown-link-check](https://github.com/gaurav-nelson/github-action-markdown-link-check)

CC: https://github.com/gaurav-nelson/github-action-markdown-link-check/issues/24