### PR TITLE
fix: ensure all rules are recommended by default

### DIFF
--- a/src/__tests__/__fixtures__/recommended-ruleset.json
+++ b/src/__tests__/__fixtures__/recommended-ruleset.json
@@ -1,0 +1,33 @@
+{
+  "rules": {
+    "explicitly-recommended": {
+      "message": "Should expose a `likeable` property",
+      "given": "$",
+      "type": "style",
+      "recommended": true,
+      "then": {
+        "field": "likeable",
+        "function": "truthy"
+      }
+    },
+    "implicitly-recommended": {
+      "message": "Should expose a `likeable` property",
+      "given": "$",
+      "type": "style",
+      "then": {
+        "field": "likeable",
+        "function": "truthy"
+      }
+    },
+    "explicitly-not-recommended": {
+      "message": "Should expose a `likeable` property",
+      "given": "$",
+      "type": "style",
+      "recommended": false,
+      "then": {
+        "field": "likeable",
+        "function": "truthy"
+      }
+    }
+  }
+}

--- a/src/__tests__/linter.jest.test.ts
+++ b/src/__tests__/linter.jest.test.ts
@@ -15,6 +15,7 @@ import { IRuleset, RulesetExceptionCollection } from '../types/ruleset';
 const customFunctionOASRuleset = path.join(__dirname, './__fixtures__/custom-functions-oas-ruleset.json');
 const customOASRuleset = path.join(__dirname, './__fixtures__/custom-oas-ruleset.json');
 const customDirectoryFunctionsRuleset = path.join(__dirname, './__fixtures__/custom-directory-function-ruleset.json');
+const recommendedRulesetPath = path.join(__dirname, './__fixtures__/recommended-ruleset.json');
 
 describe('Linter', () => {
   let spectral: Spectral;
@@ -575,5 +576,32 @@ console.log(this.cache.get('test') || this.cache.set('test', []).get('test'));
         ]);
       });
     });
+  });
+
+  test('should only run recommended rules, whether implicitly or explictly', async () => {
+    const target = {
+      openapi: '3.0.2',
+    };
+
+    await spectral.loadRuleset(recommendedRulesetPath);
+
+    expect(Object.keys(spectral.rules)).toHaveLength(3);
+
+    expect(Object.entries(spectral.rules).map(([name, rule]) => [name, rule.recommended])).toEqual([
+      ['explicitly-recommended', true],
+      ['implicitly-recommended', true],
+      ['explicitly-not-recommended', false],
+    ]);
+
+    const res = await spectral.run(target);
+
+    expect(res).toEqual([
+      expect.objectContaining({
+        code: 'explicitly-recommended',
+      }),
+      expect.objectContaining({
+        code: 'implicitly-recommended',
+      }),
+    ]);
   });
 });

--- a/src/__tests__/spectral.jest.test.ts
+++ b/src/__tests__/spectral.jest.test.ts
@@ -32,6 +32,7 @@ describe('Spectral', () => {
               name,
               ...rule,
               formats: expect.arrayContaining([expect.any(String)]),
+              recommended: expect.any(Boolean),
               severity: expect.any(Number),
               then: expect.any(Object),
             };
@@ -86,6 +87,7 @@ describe('Spectral', () => {
         'info-matches-stoplight': {
           ...ruleset.rules['info-matches-stoplight'],
           name: 'info-matches-stoplight',
+          recommended: true,
           severity: DiagnosticSeverity.Warning,
         },
       });

--- a/src/__tests__/spectral.karma.test.ts
+++ b/src/__tests__/spectral.karma.test.ts
@@ -45,6 +45,7 @@ describe('Spectral', () => {
         'info-matches-stoplight': {
           ...ruleset.rules['info-matches-stoplight'],
           name: 'info-matches-stoplight',
+          recommended: true,
           severity: DiagnosticSeverity.Warning,
         },
       });

--- a/src/__tests__/spectral.test.ts
+++ b/src/__tests__/spectral.test.ts
@@ -27,6 +27,7 @@ describe('spectral', () => {
               name,
               ...rule,
               formats: expect.arrayContaining([expect.any(String)]),
+              recommended: expect.any(Boolean),
               severity: expect.any(Number),
               then: expect.any(Object),
             };
@@ -47,6 +48,7 @@ describe('spectral', () => {
             name,
             ...rule,
             formats: expect.arrayContaining([expect.any(String)]),
+            recommended: expect.any(Boolean),
             severity: expect.any(Number),
             then: expect.any(Object),
           };

--- a/src/rulesets/__tests__/reader.jest.test.ts
+++ b/src/rulesets/__tests__/reader.jest.test.ts
@@ -56,6 +56,7 @@ describe('Rulesets reader', () => {
             given: '$.info',
             message: 'should be OK',
             severity: DiagnosticSeverity.Warning,
+            recommended: true,
             then: expect.any(Object),
           },
           'valid-rule-recommended': {
@@ -78,6 +79,7 @@ describe('Rulesets reader', () => {
             given: '$.info',
             message: 'should be OK',
             severity: DiagnosticSeverity.Warning,
+            recommended: true,
             then: expect.any(Object),
           },
           'valid-rule-recommended': {
@@ -91,6 +93,7 @@ describe('Rulesets reader', () => {
             given: '$.info',
             message: 'should be OK',
             severity: DiagnosticSeverity.Warning,
+            recommended: true,
             then: expect.any(Object),
           },
         },
@@ -114,6 +117,7 @@ describe('Rulesets reader', () => {
       'foo-rule': {
         given: '$.info',
         message: 'should be OK',
+        recommended: true,
         severity: DiagnosticSeverity.Warning,
         then: {
           function: expect.stringMatching(/^random-id-\d$/),
@@ -142,6 +146,7 @@ describe('Rulesets reader', () => {
             ...rule,
             formats: expect.arrayContaining([expect.any(String)]),
             ...((rule as IRule).severity === void 0 && { severity: DiagnosticSeverity.Warning }),
+            ...((rule as IRule).recommended === void 0 && { recommended: true }),
             then: expect.any(Object),
           };
 
@@ -151,6 +156,7 @@ describe('Rulesets reader', () => {
         'valid-rule': {
           given: '$.info',
           message: 'should be OK',
+          recommended: true,
           severity: DiagnosticSeverity.Warning,
           then: expect.any(Object),
         },
@@ -168,6 +174,7 @@ describe('Rulesets reader', () => {
               formats: expect.arrayContaining([expect.any(String)]),
               ...((rule as IRule).severity === undefined && { severity: DiagnosticSeverity.Warning }),
               ...((rule as IRule).recommended === false && { severity: -1 }),
+              ...((rule as IRule).recommended === void 0 && { recommended: true }),
               then: expect.any(Object),
             };
 
@@ -177,6 +184,7 @@ describe('Rulesets reader', () => {
           'valid-rule': {
             given: '$.info',
             message: 'should be OK',
+            recommended: true,
             severity: DiagnosticSeverity.Warning,
             then: expect.any(Object),
           },
@@ -207,6 +215,7 @@ describe('Rulesets reader', () => {
               formats: expect.arrayContaining([expect.any(String)]),
               ...((rule as IRule).severity === void 0 && { severity: DiagnosticSeverity.Warning }),
               ...((rule as IRule).recommended === false && { severity: -1 }),
+              ...((rule as IRule).recommended === void 0 && { recommended: true }),
               then: expect.any(Object),
             };
 
@@ -398,6 +407,7 @@ describe('Rulesets reader', () => {
           given: '$.info',
           message: 'Title must contain Stoplight',
           severity: DiagnosticSeverity.Warning,
+          recommended: true,
           then: {
             field: 'title',
             function: 'pattern',
@@ -449,6 +459,7 @@ describe('Rulesets reader', () => {
         'title-matches-stoplight': {
           given: '$.info',
           message: 'Title must contain Stoplight',
+          recommended: true,
           severity: DiagnosticSeverity.Warning,
           then: {
             field: 'title',
@@ -502,6 +513,7 @@ describe('Rulesets reader', () => {
           given: '$.info',
           message: 'Title must contain Stoplight',
           severity: -1,
+          recommended: true,
           then: {
             field: 'title',
             function: 'pattern',
@@ -522,6 +534,7 @@ describe('Rulesets reader', () => {
           PascalCase: {
             given: '$',
             message: 'bar',
+            recommended: true,
             severity: DiagnosticSeverity.Warning,
             then: {
               function: 'truthy',
@@ -539,6 +552,7 @@ describe('Rulesets reader', () => {
           snake_case: {
             given: '$',
             message: 'foo',
+            recommended: true,
             severity: DiagnosticSeverity.Warning,
             then: {
               function: 'truthy',
@@ -580,6 +594,7 @@ describe('Rulesets reader', () => {
         'valid-foo-value': {
           given: '$',
           severity: DiagnosticSeverity.Warning,
+          recommended: true,
           then: {
             field: 'foo',
             function: 'random-id-0',
@@ -638,6 +653,7 @@ describe('Rulesets reader', () => {
         'valid-foo-value': {
           given: '$',
           severity: DiagnosticSeverity.Warning,
+          recommended: true,
           then: {
             field: 'foo',
             function: 'random-id-0',
@@ -779,6 +795,7 @@ describe('Rulesets reader', () => {
         'bar-rule': {
           given: '$.bar',
           message: 'Bar is truthy',
+          recommended: true,
           severity: DiagnosticSeverity.Warning,
           then: {
             function: 'truthy',
@@ -787,6 +804,7 @@ describe('Rulesets reader', () => {
         'foo-rule': {
           given: '$.foo',
           message: 'Foo is falsy',
+          recommended: true,
           severity: DiagnosticSeverity.Warning,
           then: {
             function: 'falsy',

--- a/src/rulesets/mergers/__tests__/rules.test.ts
+++ b/src/rulesets/mergers/__tests__/rules.test.ts
@@ -1,4 +1,4 @@
-import { DiagnosticSeverity } from '@stoplight/types';
+import { DiagnosticSeverity, Dictionary } from '@stoplight/types';
 import { IRule } from '../../../types';
 import { FileRuleCollection } from '../../../types/ruleset';
 import { mergeRules } from '../rules';
@@ -190,7 +190,7 @@ describe('Ruleset rules merging', () => {
   });
 
   it('picks up recommended rules', () => {
-    const rules = {};
+    const rules: Dictionary<IRule, string> = {};
 
     const test3 = JSON.parse(JSON.stringify(baseRule));
     delete test3.recommended;
@@ -207,6 +207,10 @@ describe('Ruleset rules merging', () => {
       },
       'recommended',
     );
+
+    expect(rules.test.recommended).toBe(true);
+    expect(rules.test2.recommended).toBe(false);
+    expect(rules.test3.recommended).toBe(true);
 
     expect(rules).toHaveProperty('test.severity', DiagnosticSeverity.Warning);
     expect(rules).toHaveProperty('test2.severity', -1);

--- a/src/rulesets/mergers/rules.ts
+++ b/src/rulesets/mergers/rules.ts
@@ -117,6 +117,10 @@ function processRule(rules: FileRuleCollection, name: string, rule: FileRule | F
 }
 
 function normalizeRule(rule: Rule, severity: DiagnosticSeverity | HumanReadableDiagnosticSeverity | undefined) {
+  if (rule.recommended === void 0) {
+    rule.recommended = true;
+  }
+
   if (rule.severity === void 0) {
     rule.severity = severity === void 0 ? (rule.recommended !== false ? DEFAULT_SEVERITY_LEVEL : -1) : severity;
   } else {


### PR DESCRIPTION
As of Spectral 5, all rules are recommended by default now. However, no normalization is applied to the `recommended` property (as it's done for `severity`, for instance). This PR fixes this.

Also slightly enhance the code coverage to ensure the `recommended` setting of a rule eventually leads to the rule being run or not.

**Checklist**

- [x] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
