### PR TITLE
chore(ruleset): drop useless oas rule tags

### DIFF
--- a/src/rulesets/__tests__/reader.jest.test.ts
+++ b/src/rulesets/__tests__/reader.jest.test.ts
@@ -277,7 +277,6 @@ describe('Rulesets reader', () => {
           type: 'validation',
           severity: DiagnosticSeverity.Error,
           given: '$',
-          tags: ['operation'],
         }),
       }),
     );
@@ -290,7 +289,6 @@ describe('Rulesets reader', () => {
       formats: expect.arrayContaining([expect.any(String)]),
       recommended: true,
       severity: DiagnosticSeverity.Warning,
-      tags: ['operation'],
       then: expect.any(Object),
       type: 'style',
     });
@@ -305,7 +303,6 @@ describe('Rulesets reader', () => {
         formats: expect.arrayContaining([expect.any(String)]),
         severity: -1,
         description: 'Operation `security` values must match a scheme defined in the `securityDefinitions` object.',
-        tags: ['operation'],
         then: expect.any(Object),
         type: 'validation',
       },

--- a/src/rulesets/oas/index.json
+++ b/src/rulesets/oas/index.json
@@ -21,10 +21,7 @@
       "then": {
         "field": "responses",
         "function": "oasOp2xxResponse"
-      },
-      "tags": [
-        "operation"
-      ]
+      }
     },
     "oas2-operation-formData-consume-check": {
       "description": "Operations with an `in: formData` parameter must include `application/x-www-form-urlencoded` or `multipart/form-data` in their `consumes` property.",
@@ -34,10 +31,7 @@
       "given": "$.paths.*[?( @property === 'get' || @property === 'put' || @property === 'post' || @property === 'delete' || @property === 'options' || @property === 'head' || @property === 'patch' || @property === 'trace' )]",
       "then": {
         "function": "oasOpFormDataConsumeCheck"
-      },
-      "tags": [
-        "operation"
-      ]
+      }
     },
     "operation-operationId-unique": {
       "description": "Every operation must have a unique `operationId`.",
@@ -47,10 +41,7 @@
       "given": "$",
       "then": {
         "function": "oasOpIdUnique"
-      },
-      "tags": [
-        "operation"
-      ]
+      }
     },
     "operation-parameters": {
       "description": "Operation parameters are unique and non-repeating.",
@@ -59,10 +50,7 @@
       "given": "$",
       "then": {
         "function": "oasOpParams"
-      },
-      "tags": [
-        "operation"
-      ]
+      }
     },
     "operation-tag-defined": {
       "description": "Operation tags should be defined in global tags.",
@@ -71,10 +59,7 @@
       "given": "$",
       "then": {
         "function": "oasTagDefined"
-      },
-      "tags": [
-        "operation"
-      ]
+      }
     },
     "path-params": {
       "description": "Path parameters should be defined and valid.",
@@ -85,10 +70,7 @@
       "given": "$",
       "then": {
         "function": "oasPathParam"
-      },
-      "tags": [
-        "given"
-      ]
+      }
     },
     "contact-properties": {
       "description": "Contact object should have `name`, `url` and `email`.",
@@ -108,9 +90,6 @@
           "field": "email",
           "function": "truthy"
         }
-      ],
-      "tags": [
-        "api"
       ]
     },
     "info-contact": {
@@ -121,10 +100,7 @@
       "then": {
         "field": "info.contact",
         "function": "truthy"
-      },
-      "tags": [
-        "api"
-      ]
+      }
     },
     "info-description": {
       "description": "OpenAPI object info `description` must be present and non-empty string.",
@@ -134,10 +110,7 @@
       "then": {
         "field": "info.description",
         "function": "truthy"
-      },
-      "tags": [
-        "api"
-      ]
+      }
     },
     "info-license": {
       "description": "OpenAPI object `info` should contain a `license` object.",
@@ -147,10 +120,7 @@
       "then": {
         "field": "info.license",
         "function": "truthy"
-      },
-      "tags": [
-        "api"
-      ]
+      }
     },
     "license-url": {
       "description": "License object should include `url`.",
@@ -160,10 +130,7 @@
       "then": {
         "field": "info.license.url",
         "function": "truthy"
-      },
-      "tags": [
-        "api"
-      ]
+      }
     },
     "no-eval-in-markdown": {
       "description": "Markdown descriptions should not contain `eval(`.",
@@ -220,10 +187,7 @@
         "functionOptions": {
           "keyedBy": "name"
         }
-      },
-      "tags": [
-        "api"
-      ]
+      }
     },
     "openapi-tags": {
       "description": "OpenAPI object should have non-empty `tags` array.",
@@ -239,10 +203,7 @@
             "minItems": 1
           }
         }
-      },
-      "tags": [
-        "api"
-      ]
+      }
     },
     "operation-default-response": {
       "description": "Operations must have a default response.",
@@ -252,10 +213,7 @@
       "then": {
         "field": "default",
         "function": "truthy"
-      },
-      "tags": [
-        "operation"
-      ]
+      }
     },
     "operation-description": {
       "description": "Operation `description` must be present and non-empty string.",
@@ -265,10 +223,7 @@
       "then": {
         "field": "description",
         "function": "truthy"
-      },
-      "tags": [
-        "operation"
-      ]
+      }
     },
     "operation-operationId": {
       "description": "Operation should have an `operationId`.",
@@ -278,10 +233,7 @@
       "then": {
         "field": "operationId",
         "function": "truthy"
-      },
-      "tags": [
-        "operation"
-      ]
+      }
     },
     "operation-operationId-valid-in-url": {
       "description": "operationId may only use characters that are valid when used in a URL.",
@@ -294,10 +246,7 @@
         "functionOptions": {
           "match": "^[A-Za-z0-9-._~:/?#\\[\\]@!\\$&'()*+,;=]*$"
         }
-      },
-      "tags": [
-        "operation"
-      ]
+      }
     },
     "operation-singular-tag": {
       "description": "Operation may only have one tag.",
@@ -310,10 +259,7 @@
         "functionOptions": {
           "max": 1
         }
-      },
-      "tags": [
-        "operation"
-      ]
+      }
     },
     "operation-tags": {
       "description": "Operation should have non-empty `tags` array.",
@@ -323,10 +269,7 @@
       "then": {
         "field": "tags",
         "function": "truthy"
-      },
-      "tags": [
-        "operation"
-      ]
+      }
     },
     "path-declarations-must-exist": {
       "description": "Path parameter declarations cannot be empty, ex.`/given/{}` is invalid.",
@@ -339,10 +282,7 @@
         "functionOptions": {
           "notMatch": "{}"
         }
-      },
-      "tags": [
-        "given"
-      ]
+      }
     },
     "path-keys-no-trailing-slash": {
       "description": "paths should not end with a slash.",
@@ -355,10 +295,7 @@
         "functionOptions": {
           "notMatch": ".+\\/$"
         }
-      },
-      "tags": [
-        "given"
-      ]
+      }
     },
     "path-not-include-query": {
       "description": "given keys should not include a query string.",
@@ -371,10 +308,7 @@
         "functionOptions": {
           "notMatch": "\\?"
         }
-      },
-      "tags": [
-        "given"
-      ]
+      }
     },
     "tag-description": {
       "description": "Tag object should have a `description`.",
@@ -384,10 +318,7 @@
       "then": {
         "field": "description",
         "function": "truthy"
-      },
-      "tags": [
-        "api"
-      ]
+      }
     },
     "no-$ref-siblings": {
       "description": "Property cannot be placed among $ref",
@@ -420,10 +351,7 @@
       "then": {
         "field": "host",
         "function": "truthy"
-      },
-      "tags": [
-        "api"
-      ]
+      }
     },
     "oas2-api-schemes": {
       "description": "OpenAPI host `schemes` must be present and non-empty array.",
@@ -443,10 +371,7 @@
             "type": "array"
           }
         }
-      },
-      "tags": [
-        "api"
-      ]
+      }
     },
     "oas2-host-not-example": {
       "description": "Host URL should not point at example.com.",
@@ -460,10 +385,7 @@
         "functionOptions": {
           "notMatch": "example\\.com"
         }
-      },
-      "tags": [
-        "api"
-      ]
+      }
     },
     "oas2-host-trailing-slash": {
       "description": "Server URL should not have a trailing slash.",
@@ -477,10 +399,7 @@
         "functionOptions": {
           "notMatch": "/$"
         }
-      },
-      "tags": [
-        "api"
-      ]
+      }
     },
     "oas2-parameter-description": {
       "description": "Parameter objects should have a `description`.",
@@ -491,10 +410,7 @@
       "then": {
         "field": "description",
         "function": "truthy"
-      },
-      "tags": [
-        "parameters"
-      ]
+      }
     },
     "oas2-operation-security-defined": {
       "description": "Operation `security` values must match a scheme defined in the `securityDefinitions` object.",
@@ -509,10 +425,7 @@
             "securityDefinitions"
           ]
         }
-      },
-      "tags": [
-        "operation"
-      ]
+      }
     },
     "oas2-valid-parameter-example": {
       "description": "Examples must be valid against their defined schema.",
@@ -558,10 +471,7 @@
       "then": {
         "field": "anyOf",
         "function": "undefined"
-      },
-      "tags": [
-        "schema"
-      ]
+      }
     },
     "oas2-oneOf": {
       "description": "OpenAPI v3 keyword `oneOf` detected in OpenAPI v2 document.",
@@ -573,10 +483,7 @@
       "then": {
         "field": "oneOf",
         "function": "undefined"
-      },
-      "tags": [
-        "schema"
-      ]
+      }
     },
     "oas2-schema": {
       "description": "Validate structure of OpenAPI v2 specification.",
@@ -594,10 +501,7 @@
             "$ref": "./schemas/schema.oas2.json"
           }
         }
-      },
-      "tags": [
-        "schema"
-      ]
+      }
     },
     "oas2-unused-definition": {
       "description": "Potentially unused definition has been detected.",
@@ -631,10 +535,7 @@
             "type": "array"
           }
         }
-      },
-      "tags": [
-        "api"
-      ]
+      }
     },
     "oas3-example-value-or-externalValue": {
       "description": "Example should have either a `value` or `externalValue` field.",
@@ -674,10 +575,7 @@
             "securitySchemes"
           ]
         }
-      },
-      "tags": [
-        "operation"
-      ]
+      }
     },
     "oas3-parameter-description": {
       "description": "Parameter objects should have a `description`.",
@@ -688,10 +586,7 @@
       "then": {
         "field": "description",
         "function": "truthy"
-      },
-      "tags": [
-        "parameters"
-      ]
+      }
     },
     "oas3-server-not-example.com": {
       "description": "Server URL should not point at example.com.",
@@ -853,10 +748,7 @@
             "$ref": "./schemas/schema.oas3.json"
           }
         }
-      },
-      "tags": [
-        "schema"
-      ]
+      }
     },
     "oas3-unused-components-schema": {
       "description": "Potentially unused components schema has been detected.",

--- a/src/types/rule.ts
+++ b/src/types/rule.ts
@@ -34,9 +34,6 @@ export interface IRule<T = string, O = any> {
   // The severity of results this rule generates
   severity?: DiagnosticSeverity | HumanReadableDiagnosticSeverity;
 
-  // Tags attached to the rule, which can be used for organizational purposes
-  tags?: string[];
-
   // some rules are more important than others, recommended rules will be enabled by default
   // true by default
   recommended?: boolean;


### PR DESCRIPTION
**Checklist**

- [ ] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

Following a discussion in #974 about tags in rulesets, it's been realized that they're no longer used and may even be a bit confusing would someone want to get some inspiration from the oas ruleset in order to write his/her own.

Let's provide those tags a very well deserved freedom in the Great Recycle Land of Bits.