### PR TITLE
fix(deps): lock @stoplight/{json,yaml}

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,12 +59,12 @@
     "test": "jest --silent"
   },
   "dependencies": {
-    "@stoplight/json": "^3.6.0",
+    "@stoplight/json": "3.6.0",
     "@stoplight/json-ref-readers": "^1.1.1",
     "@stoplight/json-ref-resolver": "^3.0.6",
     "@stoplight/path": "^1.3.0",
     "@stoplight/types": "^11.2.0",
-    "@stoplight/yaml": "^3.7.0",
+    "@stoplight/yaml": "3.7.0",
     "abort-controller": "^3.0.0",
     "ajv": "^6.10",
     "ajv-oai": "^1.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -533,7 +533,7 @@
     tslib "^1.10.0"
     urijs "~1.19.1"
 
-"@stoplight/json@^3.1.2", "@stoplight/json@^3.6.0":
+"@stoplight/json@3.6.0", "@stoplight/json@^3.1.2":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@stoplight/json/-/json-3.6.0.tgz#51ab4c677ec5aadcffd5c6ed67b6dbf51a5f93ba"
   integrity sha512-6hJN735r+aPzHP28HnBj30uC+RGyf/ZWEtAMlrXI4DntzocWvhgDqxLuLgOlmXkMd/4OAlD7fJQ/cI2RXNuWvQ==
@@ -561,7 +561,7 @@
   resolved "https://registry.yarnpkg.com/@stoplight/yaml-ast-parser/-/yaml-ast-parser-0.0.44.tgz#ed3c962564283e9983f7895a6effc3994286df5e"
   integrity sha512-PdY8p2Ufgtorf4d2DbKMfknILMa8KwuyyMMR/2lgK1mLaU8F5PKWYc+h9hIzC+ar0bh7m9h2rINo32m7ADfVyA==
 
-"@stoplight/yaml@^3.7.0":
+"@stoplight/yaml@3.7.0":
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/@stoplight/yaml/-/yaml-3.7.0.tgz#76cb3a0b7f9344eb7c7f2eefde175bc9b391040c"
   integrity sha512-lYs577C0tqs3WHtused0hclE+YHVshgeZT8i6kkqSIt1GUP3Hbe4AwZDEvFgZ9+9pa0JGlmKMrm0PJfvfKFxkw==


### PR DESCRIPTION
Fixes https://github.com/stoplightio/spectral/issues/1097

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No


**Additional context**

Develop is all good, as we haven't upgraded the dependencies yet (see the lockfile), but when Spectral is installed globally, it'll install any `@stoplight/{json/yaml}` packages that match at least `3.6.0` and `3.7.0` versions respectively, therefore a newer version of a particular dependency might be installed. This is the reason why it stopped working, as I've recently updated json and yaml packages to use `@stoplight/ordered-object-literal`.
Locking the dependencies should help in a shorter perspective. In a longer perspective, we need to stop using json-ref-resolver that is indirectly causing the issue here due to the usage of immer.
I'll release beta shortly after this PR is merged to see whether the issues are gone.

This is the line that causes the issue https://github.com/stoplightio/ordered-object-literal/blob/master/src/index.mjs#L14