### PR TITLE
[WIP] feat(asyncapi): make asyncapi-payload-* rules support asyncapi schemaFormats 

### DIFF
--- a/docs/reference/asyncapi-rules.md
+++ b/docs/reference/asyncapi-rules.md
@@ -223,11 +223,36 @@ application/vnd.aai.asyncapi;version=2.0.0
 application/vnd.aai.asyncapi+json;version=2.0.0
 application/vnd.aai.asyncapi+yaml;version=2.0.0
 
-At this point, explicitly setting `schemaFormat` is not supported by Spectral, so if you use it this rule will emit an info message and skip validating the payload.
+At this point, explicitly setting `schemaFormat` to any other value is not supported by Spectral.
+Would that happen, this rule will emit an info message and skip validating the payload.
 
 Other formats such as OpenAPI Schema Object, JSON Schema Draft 07 and Avro will be added in various upcoming versions.
 
 **Recommended:** Yes
+
+**Good Examples**
+
+``` yaml
+message:
+  payload:
+    ...
+```
+
+``` yaml
+message:
+  schemaFormat: application/vnd.aai.asyncapi;version=2.0.0
+  payload:
+    ...
+```
+
+**Bad Example**
+
+``` yaml
+message:
+  schemaFormat: application/vnd.apache.avro;version=1.9.0
+  payload:
+    ...
+```
 
 ### asyncapi-payload
 

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
   "devDependencies": {
     "@commitlint/config-conventional": "^8.3.4",
     "@rollup/plugin-commonjs": "^11.1.0",
-    "@rollup/plugin-json": "^4.0.3",
     "@rollup/plugin-node-resolve": "^7.1.3",
     "@types/chalk": "^2.2.0",
     "@types/fetch-mock": "^7.3.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,7 +3,6 @@ import * as path from 'path';
 import * as fs from 'fs';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
-import json from '@rollup/plugin-json'
 import { terser } from 'rollup-plugin-terser';
 
 const BASE_PATH = process.cwd();
@@ -44,7 +43,6 @@ module.exports = functions.map(fn => ({
         'node_modules/@stoplight/types/dist/index.js': ['DiagnosticSeverity'],
       },
     }),
-    json(),
     terser(),
   ],
   output: {

--- a/src/rulesets/asyncapi/__tests__/asyncapi-payload-examples.ts
+++ b/src/rulesets/asyncapi/__tests__/asyncapi-payload-examples.ts
@@ -3,6 +3,7 @@ import { cloneDeep } from 'lodash';
 import { buildTestSpectralWithAsyncApiRule } from '../../../../setupTests';
 import { Spectral } from '../../../spectral';
 import { IRunRule } from '../../../types';
+import { supportedSchemaFormats } from '../functions/asyncApi2PayloadValidation';
 
 const ruleName = 'asyncapi-payload-examples';
 let s: Spectral;
@@ -54,8 +55,38 @@ describe(`Rule '${ruleName}'`, () => {
     },
   };
 
-  test('validates a correct object', async () => {
-    const results = await s.run(doc, { ignoreUnknownFormat: false });
+  test.each(supportedSchemaFormats)(
+    'validates a correct object (schemaFormat: "%s")',
+    async (schemaFormat: string | undefined) => {
+      const clone = cloneDeep(doc);
+
+      clone.components.messages.aMessage.schemaFormat = schemaFormat;
+      clone.components.messageTraits.aTrait.schemaFormat = schemaFormat;
+      clone.channels['users/{userId}/signedUp'].publish.message.schemaFormat = schemaFormat;
+      clone.channels['users/{userId}/signedUp'].subscribe.message.schemaFormat = schemaFormat;
+
+      const results = await s.run(clone, { ignoreUnknownFormat: false });
+
+      expect(results).toEqual([]);
+    },
+  );
+
+  test('silently ignore invalid examples values when the schemaFormat is unsupported', async () => {
+    const clone = cloneDeep(doc);
+
+    clone.components.messages.aMessage.schemaFormat = 'application/nope';
+    clone.components.messages.aMessage.payload.examples[1] = { seventeen: 17 };
+
+    clone.components.messageTraits.aTrait.schemaFormat = 'application/nope';
+    clone.components.messageTraits.aTrait.payload.examples[1] = { seventeen: 17 };
+
+    clone.channels['users/{userId}/signedUp'].publish.message.schemaFormat = 'application/nope';
+    clone.channels['users/{userId}/signedUp'].publish.message.payload.examples[1] = { seventeen: 17 };
+
+    clone.channels['users/{userId}/signedUp'].subscribe.message.schemaFormat = 'application/nope';
+    clone.channels['users/{userId}/signedUp'].subscribe.message.payload.examples[1] = { seventeen: 17 };
+
+    const results = await s.run(clone, { ignoreUnknownFormat: false });
 
     expect(results).toEqual([]);
   });

--- a/src/rulesets/asyncapi/__tests__/asyncapi-payload-unsupported-schemaFormat.ts
+++ b/src/rulesets/asyncapi/__tests__/asyncapi-payload-unsupported-schemaFormat.ts
@@ -3,6 +3,7 @@ import { cloneDeep } from 'lodash';
 import { buildTestSpectralWithAsyncApiRule } from '../../../../setupTests';
 import { Spectral } from '../../../spectral';
 import { IRunRule } from '../../../types';
+import { supportedSchemaFormats } from '../functions/asyncApi2PayloadValidation';
 
 const ruleName = 'asyncapi-payload-unsupported-schemaFormat';
 let s: Spectral;
@@ -35,11 +36,18 @@ describe(`Rule '${ruleName}'`, () => {
     },
   };
 
-  test('validates a correct object', async () => {
-    const results = await s.run(doc, { ignoreUnknownFormat: false });
+  test.each(supportedSchemaFormats)(
+    'validates a correct object (schemaFormat: "%s")',
+    async (schemaFormat: string | undefined) => {
+      const clone = cloneDeep(doc);
 
-    expect(results).toEqual([]);
-  });
+      clone.components.messages.aMessage.schemaFormat = schemaFormat;
+
+      const results = await s.run(clone, { ignoreUnknownFormat: false });
+
+      expect(results).toEqual([]);
+    },
+  );
 
   test('return result if components.messages.{message}.schemaFormat is set to a non supported value', async () => {
     const clone = cloneDeep(doc);
@@ -51,7 +59,8 @@ describe(`Rule '${ruleName}'`, () => {
     expect(results).toEqual([
       expect.objectContaining({
         code: ruleName,
-        message: 'Message schema validation is only supported with default unspecified `schemaFormat`.',
+        message:
+          'Message schema validation is only supported with default unspecified `schemaFormat`, or well known AsyncAPI2 mime types.',
         path: ['components', 'messages', 'aMessage', 'schemaFormat'],
         severity: rule.severity,
       }),
@@ -68,7 +77,8 @@ describe(`Rule '${ruleName}'`, () => {
     expect(results).toEqual([
       expect.objectContaining({
         code: ruleName,
-        message: 'Message schema validation is only supported with default unspecified `schemaFormat`.',
+        message:
+          'Message schema validation is only supported with default unspecified `schemaFormat`, or well known AsyncAPI2 mime types.',
         path: ['components', 'messageTraits', 'aTrait', 'schemaFormat'],
         severity: rule.severity,
       }),
@@ -87,7 +97,8 @@ describe(`Rule '${ruleName}'`, () => {
       expect(results).toEqual([
         expect.objectContaining({
           code: ruleName,
-          message: 'Message schema validation is only supported with default unspecified `schemaFormat`.',
+          message:
+            'Message schema validation is only supported with default unspecified `schemaFormat`, or well known AsyncAPI2 mime types.',
           path: ['channels', 'users/{userId}/signedUp', property, 'message', 'schemaFormat'],
           severity: rule.severity,
         }),

--- a/src/rulesets/asyncapi/functions/__tests__/asyncApi2PayloadValidation.test.ts
+++ b/src/rulesets/asyncapi/functions/__tests__/asyncApi2PayloadValidation.test.ts
@@ -13,19 +13,56 @@ function runPayloadValidation(targetVal: any) {
 }
 
 describe('asyncApi2PayloadValidation', () => {
-  test('Properly identify payload that do not fit the AsyncApi2 schema object definition', () => {
-    const payload = {
-      type: 'object',
-      deprecated: 14,
+  describe('AsyncApi2 schema', () => {
+    const validSchemaFormats = [
+      undefined,
+      'application/vnd.aai.asyncapi;version=2.0.0',
+      'application/vnd.aai.asyncapi+json;version=2.0.0',
+      'application/vnd.aai.asyncapi+yaml;version=2.0.0',
+    ];
+
+    test.each(validSchemaFormats)(
+      'Properly identify payload that do not fit the schema object definition',
+      (schemaFormat: string | undefined) => {
+        const message = {
+          schemaFormat,
+          payload: {
+            type: 'object',
+            deprecated: 14,
+          },
+        };
+
+        const results = runPayloadValidation(message);
+
+        expect(results).toEqual([
+          {
+            message: '{{property|gravis|append-property|optional-typeof|capitalize}}type should be boolean',
+            path: ['$', 'components', 'messages', 'aMessage', 'payload', 'deprecated'],
+          },
+        ]);
+      },
+    );
+
+    test.each(validSchemaFormats)('Returns no result when no payload', (schemaFormat: string | undefined) => {
+      const message = { schemaFormat };
+
+      const results = runPayloadValidation(message);
+
+      expect(results).toEqual([]);
+    });
+  });
+
+  test('Returns no result when schemaFormat bears an unsupported value', () => {
+    const message = {
+      schemaFormat: 'application/nope',
+      payload: {
+        type: 'object',
+        deprecated: 14,
+      },
     };
 
-    const results = runPayloadValidation(payload);
+    const results = runPayloadValidation(message);
 
-    expect(results).toEqual([
-      {
-        message: '{{property|gravis|append-property|optional-typeof|capitalize}}type should be boolean',
-        path: ['$', 'components', 'messages', 'aMessage', 'deprecated'],
-      },
-    ]);
+    expect(results).toEqual([]);
   });
 });

--- a/src/rulesets/asyncapi/functions/__tests__/asyncApi2PayloadValidation.test.ts
+++ b/src/rulesets/asyncapi/functions/__tests__/asyncApi2PayloadValidation.test.ts
@@ -1,11 +1,12 @@
 import { functions } from '../../../../functions';
+import * as asyncApi2Schema from '../../schemas/schema.asyncapi2.json';
 import { asyncApi2PayloadValidation } from '../asyncApi2PayloadValidation';
 
-function runPayloadValidation(targetVal: any, field: string) {
+function runPayloadValidation(targetVal: any) {
   return asyncApi2PayloadValidation.call(
     { functions },
     targetVal,
-    { field },
+    { asyncApi2Schema },
     { given: ['$', 'components', 'messages', 'aMessage'] },
     { given: null, original: null, documentInventory: {} as any },
   );
@@ -18,7 +19,7 @@ describe('asyncApi2PayloadValidation', () => {
       deprecated: 14,
     };
 
-    const results = runPayloadValidation(payload, '$');
+    const results = runPayloadValidation(payload);
 
     expect(results).toEqual([
       {

--- a/src/rulesets/asyncapi/functions/asyncApi2PayloadValidation.ts
+++ b/src/rulesets/asyncapi/functions/asyncApi2PayloadValidation.ts
@@ -15,6 +15,10 @@ export const supportedSchemaFormats = [
   'application/vnd.aai.asyncapi+yaml;version=2.0.0',
 ];
 
+export const isSchemaFormatSupported = (schemaFormat: string): boolean => {
+  return supportedSchemaFormats.includes(schemaFormat);
+};
+
 const buildAsyncApi2SchemaObjectValidator = (schemaFn: ISchemaFunction, asyncApi2Schema: any): ValidateFunction => {
   if (validator !== void 0) {
     return validator;
@@ -45,7 +49,7 @@ export const asyncApi2PayloadValidation: IFunction<IAsyncApi2PayloadValidationOp
   paths,
   otherValues,
 ) {
-  if (!supportedSchemaFormats.includes(targetVal.schemaFormat)) {
+  if (!isSchemaFormatSupported(targetVal.schemaFormat)) {
     // silently ignore unsupported schemaFormat values
     return [];
   }

--- a/src/rulesets/asyncapi/functions/asyncApi2PayloadValidation.ts
+++ b/src/rulesets/asyncapi/functions/asyncApi2PayloadValidation.ts
@@ -2,14 +2,13 @@ import { ValidateFunction } from 'ajv';
 
 import { ISchemaFunction } from '../../../functions/schema';
 import { IFunction, IFunctionContext } from '../../../types';
-import * as asyncApi2Schema from '../schemas/schema.asyncapi2.json';
 
 const fakeSchemaObjectId = 'asyncapi2#schemaObject';
 const asyncApi2SchemaObject = { $ref: fakeSchemaObjectId };
 
 let validator: ValidateFunction;
 
-const buildAsyncApi2SchemaObjectValidator = (schemaFn: ISchemaFunction): ValidateFunction => {
+const buildAsyncApi2SchemaObjectValidator = (schemaFn: ISchemaFunction, asyncApi2Schema: any): ValidateFunction => {
   if (validator !== void 0) {
     return validator;
   }
@@ -28,14 +27,18 @@ const buildAsyncApi2SchemaObjectValidator = (schemaFn: ISchemaFunction): Validat
   return validator;
 };
 
-export const asyncApi2PayloadValidation: IFunction = function(
+export interface IAsyncApi2PayloadValidationOptions {
+  asyncApi2Schema: object;
+}
+
+export const asyncApi2PayloadValidation: IFunction<IAsyncApi2PayloadValidationOptions> = function(
   this: IFunctionContext,
   targetVal,
-  _opts,
+  opts,
   paths,
   otherValues,
 ) {
-  const ajvValidationFn = buildAsyncApi2SchemaObjectValidator(this.functions.schema);
+  const ajvValidationFn = buildAsyncApi2SchemaObjectValidator(this.functions.schema, opts.asyncApi2Schema);
 
   const results = this.functions.schema(
     targetVal,

--- a/src/rulesets/asyncapi/functions/asyncApi2PayloadValidation.ts
+++ b/src/rulesets/asyncapi/functions/asyncApi2PayloadValidation.ts
@@ -1,12 +1,19 @@
 import { ValidateFunction } from 'ajv';
 
 import { ISchemaFunction } from '../../../functions/schema';
-import { IFunction, IFunctionContext } from '../../../types';
+import { IFunction, IFunctionContext, IFunctionPaths } from '../../../types';
 
 const fakeSchemaObjectId = 'asyncapi2#schemaObject';
 const asyncApi2SchemaObject = { $ref: fakeSchemaObjectId };
 
 let validator: ValidateFunction;
+
+export const supportedSchemaFormats = [
+  undefined,
+  'application/vnd.aai.asyncapi;version=2.0.0',
+  'application/vnd.aai.asyncapi+json;version=2.0.0',
+  'application/vnd.aai.asyncapi+yaml;version=2.0.0',
+];
 
 const buildAsyncApi2SchemaObjectValidator = (schemaFn: ISchemaFunction, asyncApi2Schema: any): ValidateFunction => {
   if (validator !== void 0) {
@@ -38,16 +45,30 @@ export const asyncApi2PayloadValidation: IFunction<IAsyncApi2PayloadValidationOp
   paths,
   otherValues,
 ) {
+  if (!supportedSchemaFormats.includes(targetVal.schemaFormat)) {
+    // silently ignore unsupported schemaFormat values
+    return [];
+  }
+
+  const payload = targetVal.payload;
+  if (payload === void 0) {
+    return [];
+  }
+
   const ajvValidationFn = buildAsyncApi2SchemaObjectValidator(this.functions.schema, opts.asyncApi2Schema);
 
+  const refinedPaths: IFunctionPaths = { target: [], given: paths.given };
+  Array.prototype.push.apply(refinedPaths.target, paths.target || paths.given);
+  refinedPaths.target!.push('payload');
+
   const results = this.functions.schema(
-    targetVal,
+    payload,
     {
       schema: asyncApi2SchemaObject,
       ajv: ajvValidationFn,
       allErrors: true,
     },
-    paths,
+    refinedPaths,
     otherValues,
   );
 

--- a/src/rulesets/asyncapi/functions/asyncApi2SchemaPath.ts
+++ b/src/rulesets/asyncapi/functions/asyncApi2SchemaPath.ts
@@ -1,0 +1,40 @@
+import { IFunction, IFunctionContext } from '../../../types';
+import { isSchemaFormatSupported } from './asyncApi2PayloadValidation';
+
+export interface IAsyncApi2SchemaPathOptions {
+  schemaPath: string;
+  // the `path.to.prop` to field, or special `@key` value to target keys for matched `given` object
+  field: string;
+}
+
+export const asyncApi2SchemaPath: IFunction<IAsyncApi2SchemaPathOptions> = function(
+  this: IFunctionContext,
+  targetVal,
+  opts,
+  paths,
+  otherValues,
+) {
+  if (!isSchemaFormatSupported(targetVal.schemaFormat)) {
+    // silently ignore unsupported schemaFormat values
+    return [];
+  }
+
+  const results = this.functions.schemaPath(
+    targetVal,
+    {
+      schemaPath: opts.schemaPath,
+      field: opts.field,
+      allErrors: true,
+    },
+    paths,
+    otherValues,
+  );
+
+  if (!Array.isArray(results)) {
+    return [];
+  }
+
+  return results;
+};
+
+export default asyncApi2SchemaPath;

--- a/src/rulesets/asyncapi/index.json
+++ b/src/rulesets/asyncapi/index.json
@@ -212,18 +212,24 @@
       }
     },
     "asyncapi-payload-unsupported-schemaFormat": {
-      "description": "Message schema validation is only supported with default unspecified `schemaFormat`.",
+      "description": "Message schema validation is only supported with default unspecified `schemaFormat`, or well known AsyncAPI2 mime types.",
       "severity": "info",
       "recommended": true,
       "type": "validation",
       "given": [
-        "$.components.messageTraits.*",
-        "$.components.messages.*",
-        "$.channels.*.[publish,subscribe].message"
+        "$.components.messageTraits.*.schemaFormat",
+        "$.components.messages.*.schemaFormat",
+        "$.channels.*.[publish,subscribe].message.schemaFormat"
       ],
       "then": {
-        "field": "schemaFormat",
-        "function": "undefined"
+        "function": "enumeration",
+        "functionOptions": {
+          "values": [
+            "application/vnd.aai.asyncapi;version=2.0.0",
+            "application/vnd.aai.asyncapi+json;version=2.0.0",
+            "application/vnd.aai.asyncapi+yaml;version=2.0.0"
+          ]
+        }
       }
     },
     "asyncapi-payload": {
@@ -233,9 +239,9 @@
       "recommended": true,
       "type": "validation",
       "given": [
-        "$.components.messageTraits[?(@.schemaFormat === void 0)].payload",
-        "$.components.messages[?(@.schemaFormat === void 0)].payload",
-        "$.channels.*.[publish,subscribe][?(@property === 'message' && @.schemaFormat === void 0)].payload"
+        "$.components.messageTraits.*.payload^",
+        "$.components.messages.*.payload^",
+        "$.channels.*.[publish,subscribe].message.payload^"
       ],
       "then": {
         "function": "asyncApi2PayloadValidation",

--- a/src/rulesets/asyncapi/index.json
+++ b/src/rulesets/asyncapi/index.json
@@ -238,7 +238,12 @@
         "$.channels.*.[publish,subscribe][?(@property === 'message' && @.schemaFormat === void 0)].payload"
       ],
       "then": {
-        "function": "asyncApi2PayloadValidation"
+        "function": "asyncApi2PayloadValidation",
+        "functionOptions": {
+          "asyncApi2Schema": {
+            "$ref": "./schemas/schema.asyncapi2.json"
+          }
+        }
       }
     },
     "asyncapi-schema-default": {

--- a/src/rulesets/asyncapi/index.json
+++ b/src/rulesets/asyncapi/index.json
@@ -198,15 +198,15 @@
       "recommended": true,
       "type": "validation",
       "given": [
-        "$.components.messageTraits[?(@.schemaFormat === void 0)].payload.examples^",
-        "$.components.messages[?(@.schemaFormat === void 0)].payload.examples^",
-        "$.channels.*.[publish,subscribe][?(@property === 'message' && @.schemaFormat === void 0)].payload.examples^"
+        "$.components.messageTraits.*.payload.examples^^",
+        "$.components.messages.*.payload.examples^^",
+        "$.channels.*.[publish,subscribe].message.payload.examples^^"
       ],
       "then": {
-        "function": "schemaPath",
+        "function": "asyncApi2SchemaPath",
         "functionOptions": {
-          "field": "$.examples.*",
-          "schemaPath": "$",
+          "field": "$.payload.examples.*",
+          "schemaPath": "$.payload",
           "allErrors": true
         }
       }

--- a/src/rulesets/asyncapi/index.json
+++ b/src/rulesets/asyncapi/index.json
@@ -3,7 +3,8 @@
     "asyncapi2"
   ],
   "functions" : [
-    "asyncApi2PayloadValidation"
+    "asyncApi2PayloadValidation",
+    "asyncApi2SchemaPath"
   ],
   "rules": {
     "asyncapi-channel-no-empty-parameter": {
@@ -178,16 +179,15 @@
       "recommended": true,
       "type": "validation",
       "given": [
-        "$.components.messageTraits[?(@.schemaFormat === void 0)].payload.default^",
-        "$.components.messages[?(@.schemaFormat === void 0)].payload.default^",
-        "$.channels.*.[publish,subscribe][?(@property === 'message' && @.schemaFormat === void 0)].payload.default^"
+        "$.components.messageTraits.*.payload.default^^",
+        "$.components.messages.*.payload.default^^",
+        "$.channels.*.[publish,subscribe].message.payload.default^^"
       ],
       "then": {
-        "function": "schemaPath",
+        "function": "asyncApi2SchemaPath",
         "functionOptions": {
-          "field": "default",
-          "schemaPath": "$",
-          "allErrors": true
+          "field": "$.payload.default",
+          "schemaPath": "$.payload"
         }
       }
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -463,13 +463,6 @@
     magic-string "^0.25.2"
     resolve "^1.11.0"
 
-"@rollup/plugin-json@^4.0.3":
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-json/-/plugin-json-4.0.3.tgz#747e2c2884c5a0fa00b66c9c0f3f1012cddca534"
-  integrity sha512-QMUT0HZNf4CX17LMdwaslzlYHUKTYGuuk34yYIgZrNdu+pMEfqMS55gck7HEeHBKXHM4cz5Dg1OVwythDdbbuQ==
-  dependencies:
-    "@rollup/pluginutils" "^3.0.8"
-
 "@rollup/plugin-node-resolve@^7.1.3":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz#80de384edfbd7bfc9101164910f86078151a3eca"


### PR DESCRIPTION
**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

Follow up work on #974 AsyncAPI PR.

- Fixes a technical debt I introduced
- Paves the way to make it easier to validate payloads against other schemas (Avro, OAS3, ...)