### PR TITLE
chore: export functions to help Spectral integration

### DIFF
--- a/src/cli/commands/lint.ts
+++ b/src/cli/commands/lint.ts
@@ -178,7 +178,7 @@ const filterResultsBySeverity = (results: IRuleResult[], failSeverity: FailSever
   return results.filter(r => r.severity <= diagnosticSeverity);
 };
 
-const severeEnoughToFail = (results: IRuleResult[], failSeverity: FailSeverity): boolean => {
+export const severeEnoughToFail = (results: IRuleResult[], failSeverity: FailSeverity): boolean => {
   const diagnosticSeverity = getDiagnosticSeverity(failSeverity);
   return results.some(r => r.severity <= diagnosticSeverity);
 };

--- a/src/cli/services/linter/linter.ts
+++ b/src/cli/services/linter/linter.ts
@@ -31,6 +31,8 @@ const KNOWN_FORMATS: Array<[string, FormatLookup, string]> = [
   ['json-schema-2019-09', isJSONSchemaDraft2019_09, 'JSON Schema Draft 2019-09 detected'],
 ];
 
+export const BUILTIN_FORMATS: Array<[string, FormatLookup]> = KNOWN_FORMATS.map(kf => [kf[0], kf[1]]);
+
 export async function lint(documents: Array<number | string>, flags: ILintConfig) {
   const spectral = new Spectral({
     resolver: getResolver(flags.resolver),


### PR DESCRIPTION
Proposed changes:
- Both `vscode-spectral` and `spectral-action` need to register the supported format. Rather than forcing them to copy/paste the Spectral inner code, let's export an array of supported formats/format validators.
- Exporting the `severeEnoughToFail` would allow those same projects to easily surface a parameter similar to Spectral CLI own `fail-severity` without re-implementing the filtering algorithm.

**Checklist**

- [ ] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
