### PR TITLE
fix: normalize documentUri

### DIFF
--- a/src/document.ts
+++ b/src/document.ts
@@ -17,10 +17,13 @@ export interface IDocument<D = unknown> {
   data: D;
 }
 
-const normalizeSource = (source: Optional<string>): string | null => {
+export function normalizeSource(source: undefined): null;
+export function normalizeSource(source: string): string;
+export function normalizeSource(source: Optional<string>): string | null;
+export function normalizeSource(source: Optional<string>): string | null {
   if (source === void 0) return null;
-  return source && !startsWithProtocol(source) ? normalize(source) : source;
-};
+  return source.length > 0 && !startsWithProtocol(source) ? normalize(source) : source;
+}
 
 export class Document<D = unknown, R extends IParserResult = IParserResult<D>> implements IDocument<D> {
   protected readonly parserResult: R;

--- a/src/spectral.ts
+++ b/src/spectral.ts
@@ -1,6 +1,6 @@
 import { safeStringify } from '@stoplight/json';
 import { Resolver } from '@stoplight/json-ref-resolver';
-import { DiagnosticSeverity, Dictionary } from '@stoplight/types';
+import { DiagnosticSeverity, Dictionary, Optional } from '@stoplight/types';
 import { YamlParserResult } from '@stoplight/yaml';
 import { memoize, merge } from 'lodash';
 
@@ -62,7 +62,10 @@ export class Spectral {
     Object.assign(STATIC_ASSETS, assets);
   }
 
-  protected parseDocument(target: IParsedResult | IDocument | object | string): IDocument {
+  protected parseDocument(
+    target: IParsedResult | IDocument | object | string,
+    documentUri: Optional<string>,
+  ): IDocument {
     return target instanceof Document
       ? target
       : isParsedResult(target)
@@ -70,6 +73,7 @@ export class Spectral {
       : new Document<unknown, YamlParserResult<unknown>>(
           typeof target === 'string' ? target : safeStringify(target, undefined, 2),
           Parsers.Yaml,
+          documentUri,
         );
   }
 
@@ -77,7 +81,7 @@ export class Spectral {
     target: IParsedResult | IDocument | object | string,
     opts: IRunOpts = {},
   ): Promise<ISpectralFullResult> {
-    const document = this.parseDocument(target);
+    const document = this.parseDocument(target, opts.resolve?.documentUri);
 
     if (document.source === null && opts.resolve?.documentUri !== void 0) {
       (document as Omit<Document, 'source'> & { source: string }).source = opts.resolve?.documentUri;


### PR DESCRIPTION
3 tests seem to fail regularly on CI (Windows).
I thought they were flaky, yet it turns out we have a minor issue here.
Minor, cause it _may_ only happen when Spectral is used programmatically and a plain string is passed to `run` & $ref resolving takes place.

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No


