### PR TITLE
chore: generate more efficient assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "yargs": "15.3.1"
   },
   "devDependencies": {
+    "@apidevtools/json-schema-ref-parser": "^9.0.1",
     "@commitlint/config-conventional": "^8.3.4",
     "@rollup/plugin-commonjs": "^12.0.0",
     "@rollup/plugin-json": "^4.0.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -38,12 +38,7 @@ module.exports = functions.map(fn => ({
       include: ['dist/**/*.{ts,tsx}'],
     }),
     resolve(),
-    commonjs({
-      namedExports: {
-        'node_modules/lodash/lodash.js': ['isObject', 'trimStart', 'cloneDeep', 'get', 'set'],
-        'node_modules/@stoplight/types/dist/index.js': ['DiagnosticSeverity'],
-      },
-    }),
+    commonjs(),
     json(),
     terser(),
   ],

--- a/scripts/generate-assets.ts
+++ b/scripts/generate-assets.ts
@@ -8,12 +8,10 @@
  * If you execute the code above, ruleset will be loaded fully offline, without a need to make any request.
  */
 
-import { IUriParserResult } from '@stoplight/json-ref-resolver/types';
 import * as path from '@stoplight/path';
-import { parse } from '@stoplight/yaml';
 import * as fs from 'fs';
 import { promisify } from 'util';
-import { httpAndFileResolver } from '../dist/resolvers/http-and-file';
+import * as $RefParser from '@apidevtools/json-schema-ref-parser';
 
 const readFileAsync = promisify(fs.readFile);
 const writeFileAsync = promisify(fs.writeFile);
@@ -26,49 +24,40 @@ if (!fs.existsSync(baseDir)) {
   fs.mkdirSync(baseDir);
 }
 
-const assetsPath = path.join(baseDir, `assets.json`);
 const generatedAssets = {};
 
 (async () => {
   for (const kind of ['oas', 'asyncapi']) {
-    await processDirectory(generatedAssets, path.join(__dirname, `../rulesets/${kind}`));
-    await writeFileAsync(assetsPath, JSON.stringify(generatedAssets, null, 2));
+    const assets = await processDirectory(path.join(__dirname, `../rulesets/${kind}`));
+    Object.assign(generatedAssets, assets);
+    await writeFileAsync(path.join(baseDir, `assets.${kind}.json`), JSON.stringify(assets, null, 2));
   }
+
+  await writeFileAsync(path.join(baseDir, `assets.json`), JSON.stringify(generatedAssets, null, 2));
 })();
 
-async function processDirectory(assets: Record<string, string>, dir: string) {
+async function _processDirectory(assets: Record<string, string>, dir: string): Promise<void> {
   await Promise.all(
     (await readdirAsync(dir)).map(async (name: string) => {
       if (['schemas', '__tests__'].includes(name)) return;
       const target = path.join(dir, name);
       const stats = await statAsync(target);
       if (stats.isDirectory()) {
-        return processDirectory(assets, target);
+        return _processDirectory(assets, target);
       } else {
         let content = await readFileAsync(target, 'utf8');
         if (path.extname(name) === '.json') {
-          content = JSON.stringify(
-            (
-              await httpAndFileResolver.resolve(JSON.parse(content), {
-                dereferenceRemote: true,
-                dereferenceInline: false,
-                baseUri: target,
-                parseResolveResult(opts) {
-                  return new Promise<IUriParserResult>((resolve, reject) => {
-                    try {
-                      resolve({ result: parse(opts.result) });
-                    } catch (e) {
-                      reject(e);
-                    }
-                  });
-                },
-              })
-            ).result,
-          );
+          content = JSON.stringify(await $RefParser.bundle(target, JSON.parse(content), {}))
         }
 
         assets[path.join('@stoplight/spectral', path.relative(path.join(__dirname, '..'), target))] = content;
       }
     }),
   );
+}
+
+async function processDirectory(dir: string): Promise<Record<string, string>> {
+  const assets = {};
+  await _processDirectory(assets, dir);
+  return assets;
 }

--- a/src/rulesets/asyncapi/functions/asyncApi2PayloadValidation.ts
+++ b/src/rulesets/asyncapi/functions/asyncApi2PayloadValidation.ts
@@ -1,7 +1,7 @@
-import { ValidateFunction } from 'ajv';
+import type { ValidateFunction } from 'ajv';
 
-import { ISchemaFunction } from '../../../functions/schema';
-import { IFunction, IFunctionContext } from '../../../types';
+import type { ISchemaFunction } from '../../../functions/schema';
+import type { IFunction, IFunctionContext } from '../../../types';
 import * as asyncApi2Schema from '../schemas/schema.asyncapi2.json';
 
 const fakeSchemaObjectId = 'asyncapi2#schemaObject';

--- a/src/rulesets/oas/functions/oasOp2xxResponse.ts
+++ b/src/rulesets/oas/functions/oasOp2xxResponse.ts
@@ -1,4 +1,4 @@
-import { IFunction, IFunctionResult } from '../../../types';
+import type { IFunction, IFunctionResult } from '../../../types';
 
 export const oasOp2xxResponse: IFunction = targetVal => {
   if (!targetVal) {

--- a/src/rulesets/oas/functions/oasOpFormDataConsumeCheck.ts
+++ b/src/rulesets/oas/functions/oasOpFormDataConsumeCheck.ts
@@ -1,4 +1,4 @@
-import { IFunction, IFunctionResult } from '../../../types';
+import type { IFunction, IFunctionResult } from '../../../types';
 
 export const oasOpFormDataConsumeCheck: IFunction = targetVal => {
   const results: IFunctionResult[] = [];

--- a/src/rulesets/oas/functions/oasOpIdUnique.ts
+++ b/src/rulesets/oas/functions/oasOpIdUnique.ts
@@ -1,4 +1,4 @@
-import { IFunction, IFunctionResult } from '../../../types';
+import type { IFunction, IFunctionResult } from '../../../types';
 
 export const oasOpIdUnique: IFunction = (targetVal, _options, functionPaths) => {
   const results: IFunctionResult[] = [];

--- a/src/rulesets/oas/functions/oasOpParams.ts
+++ b/src/rulesets/oas/functions/oasOpParams.ts
@@ -1,4 +1,4 @@
-import { IFunction, IFunctionResult } from '../../../types';
+import type { IFunction, IFunctionResult } from '../../../types';
 
 export const oasOpParams: IFunction = (targetVal, _options, _paths, vals) => {
   const results: IFunctionResult[] = [];

--- a/src/rulesets/oas/functions/oasOpSecurityDefined.ts
+++ b/src/rulesets/oas/functions/oasOpSecurityDefined.ts
@@ -1,4 +1,4 @@
-import { JsonPath } from '@stoplight/types';
+import type { JsonPath } from '@stoplight/types';
 
 const _get = require('lodash/get');
 

--- a/src/rulesets/oas/functions/oasPathParam.ts
+++ b/src/rulesets/oas/functions/oasPathParam.ts
@@ -1,5 +1,5 @@
-import { Segment } from '@stoplight/types';
-import { IFunction, IFunctionResult } from '../../../types';
+import type { Segment } from '@stoplight/types';
+import type { IFunction, IFunctionResult } from '../../../types';
 
 const pathRegex = /(\{[a-zA-Z0-9_-]+\})+/g;
 

--- a/src/rulesets/oas/functions/oasTagDefined.ts
+++ b/src/rulesets/oas/functions/oasTagDefined.ts
@@ -1,7 +1,7 @@
 // This function will check an API doc to verify that any tag that appears on
 // an operation is also present in the global tags array.
 
-import { IFunction, IFunctionResult } from '../../../types';
+import type { IFunction, IFunctionResult } from '../../../types';
 
 export const oasTagDefined: IFunction = targetVal => {
   const results: IFunctionResult[] = [];

--- a/src/rulesets/oas/functions/refSiblings.ts
+++ b/src/rulesets/oas/functions/refSiblings.ts
@@ -1,5 +1,5 @@
-import { JsonPath } from '@stoplight/types/dist';
-import { IFunction, IFunctionResult } from '../../../types';
+import type { JsonPath } from '@stoplight/types';
+import type { IFunction, IFunctionResult } from '../../../types';
 
 function isObject(maybeObj: unknown): maybeObj is object {
   return typeof maybeObj === 'object' && maybeObj !== null;

--- a/src/rulesets/oas/functions/typedEnum.ts
+++ b/src/rulesets/oas/functions/typedEnum.ts
@@ -1,4 +1,4 @@
-import { IFunction, IFunctionContext } from '../../../types';
+import type { IFunction, IFunctionContext } from '../../../types';
 
 export const typedEnum: IFunction = function (this: IFunctionContext, targetVal, opts, paths, otherValues) {
   if (targetVal === null || typeof targetVal !== 'object') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,15 @@
 # yarn lockfile v1
 
 
+"@apidevtools/json-schema-ref-parser@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.1.tgz#c0ed0bd21a7397d2d7a83b69565268f2d78f2d7a"
+  integrity sha512-Qsdz0W0dyK84BuBh5KZATWXOtVDXIF2EeNRzpyWblPUeAmnIokwWcwrpAm5pTPMjuWoIQt9C67X3Af1OlL6oSw==
+  dependencies:
+    "@jsdevtools/ono" "^7.1.2"
+    call-me-maybe "^1.0.1"
+    js-yaml "^3.13.1"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
@@ -454,6 +463,11 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
+
+"@jsdevtools/ono@^7.1.2":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.2.tgz#373995bb40a6686589a7fcfec06b0e6e304ef6c6"
+  integrity sha512-qS/a24RA5FEoiJS9wiv6Pwg2c/kiUo3IVUQcfeM9JvsR6pM8Yx+yl/6xWYLckZCT5jpLNhslgjiA8p/XcGyMRQ==
 
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
@@ -1592,6 +1606,11 @@ cache-base@^1.0.1:
     to-object-path "^0.3.0"
     union-value "^1.0.0"
     unset-value "^1.0.0"
+
+call-me-maybe@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
+  integrity sha1-JtII6onje1y95gJQoV8DHBak1ms=
 
 callsite@1.0.0:
   version "1.0.0"


### PR DESCRIPTION

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No


**Additional Context**

Compression does its job when it comes to file size, yet it obviously doesn't solve the issue with unnecessary high memory consumption in Studio.

The gain in size comes from the $ref resolver change as well as using `import type` that makes sure we do not import any code.


**Before**:
```bash
ls -lh rulesets/assets
total 1,6M
-rw-rw-r-- 1 p0lip p0lip 1,6M maj 31 22:25 assets.json
```
**Before (gzipped)**:
```bash
 ls -lh rulesets/assets
total 44K
-rw-rw-r-- 1 p0lip p0lip 43K maj 31 22:25 assets.json.gz
```

**After**:
```bash
ls -lh rulesets/assets
total 324K
-rw-rw-r-- 1 p0lip p0lip  63K maj 31 22:13 assets.asyncapi.json
-rw-rw-r-- 1 p0lip p0lip 159K maj 31 22:13 assets.json
-rw-rw-r-- 1 p0lip p0lip  97K maj 31 22:13 assets.oas.json
```
**After (gzipped)**:
```bash
ls -lh rulesets/assets
total 48K
-rw-rw-r-- 1 p0lip p0lip 7,5K maj 31 22:27 assets.asyncapi.json.gz
-rw-rw-r-- 1 p0lip p0lip  21K maj 31 22:27 assets.json.gz
-rw-rw-r-- 1 p0lip p0lip  14K maj 31 22:27 assets.oas.json.gz
```


Tested in Studio & it works.