### PR TITLE
chore(deps): set monthly schedule

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -22,7 +22,7 @@ update_configs:
 
   - package_manager: "javascript"
     directory: "/"
-    update_schedule: "weekly" # we do not need to check for devDependencies updates on a daily basis
+    update_schedule: "monthly" # we do not need to check for devDependencies updates on a daily basis
     version_requirement_updates: increase_versions
 
     commit_message:


### PR DESCRIPTION

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No


**Additional context**

Weekly is still a bit too often IMHO - we still have a couple of devdep PRs to merge each Monday, and most of them could be easily updated at a later notice given they aren't production dependencies.
Unfortunately there is no bi-weekly choice, so we are left with monthly.