### PR TITLE
perf(pattern): improve general perf

### DIFF
--- a/src/functions/__tests__/pattern.test.ts
+++ b/src/functions/__tests__/pattern.test.ts
@@ -1,7 +1,10 @@
 import { pattern } from '../pattern';
 
 function runPattern(targetVal: any, options?: any) {
-  return pattern(
+  return pattern.call(
+    {
+      cache: new Map(),
+    },
     targetVal,
     options,
     {
@@ -15,37 +18,17 @@ function runPattern(targetVal: any, options?: any) {
 }
 
 describe('pattern', () => {
-  describe('given a true regex', () => {
-    test('should return empty array when given value matches the given match regex', () => {
-      expect(runPattern('abc', { match: /[abc]+/ })).toEqual([]);
-    });
-
-    test('should return a message when given value does not match the given notMatch regex', () => {
-      expect(runPattern('def', { match: /[abc]+/ })).toEqual([{ message: "must match the pattern '/[abc]+/'" }]);
-    });
-
-    test('should return empty array when given value does not match the given notMatch regex', () => {
-      expect(runPattern('dEf', { notMatch: /[abc]+/i })).toEqual([]);
-    });
-
-    test('should return a message when given value does match the given notMatch regex', () => {
-      expect(runPattern('aBc', { notMatch: /[abc]+/i })).toEqual([
-        { message: "must not match the pattern '/[abc]+/i'" },
-      ]);
-    });
-  });
-
   describe('given a string regex', () => {
     test('should return empty array when given value matches the given match string regex without slashes', () => {
-      expect(runPattern('abc', { match: '[abc]+' })).toEqual([]);
+      expect(runPattern('abc', { match: '[abc]+' })).toBeUndefined();
     });
 
     test('should return empty array when given value matches the given match string regex with slashes', () => {
-      expect(runPattern('abc', { match: '/[abc]+/' })).toEqual([]);
+      expect(runPattern('abc', { match: '/[abc]+/' })).toBeUndefined();
     });
 
     test('should return empty array when given value matches the given match string regex with slashes and modifier', () => {
-      expect(runPattern('aBc', { match: '/[abc]+/im' })).toEqual([]);
+      expect(runPattern('aBc', { match: '/[abc]+/im' })).toBeUndefined();
     });
 
     test('should throw an exception when given string regex contains invalid flags', () => {
@@ -55,13 +38,13 @@ describe('pattern', () => {
     });
 
     test('should return empty array when given value does not match the given notMatch string regex with slashes and modifier', () => {
-      expect(runPattern('def', { notMatch: '/[abc]+/i' })).toEqual([]);
+      expect(runPattern('def', { notMatch: '/[abc]+/i' })).toBeUndefined();
     });
   });
 
   describe('given match and notMatch regexes', () => {
     test('should return empty array when given value match the given match and does not match the given notMatch regexes', () => {
-      expect(runPattern('def', { match: /[def]+/, notMatch: /[abc]+/ })).toEqual([]);
+      expect(runPattern('def', { match: /[def]+/, notMatch: /[abc]+/ })).toBeUndefined();
     });
   });
 });

--- a/src/functions/pattern.ts
+++ b/src/functions/pattern.ts
@@ -1,4 +1,5 @@
-import { IFunction, IFunctionResult } from '../types';
+import type { IFunction, IFunctionContext, IFunctionResult } from '../types';
+import type { Optional } from '@stoplight/types';
 
 export interface IRulePatternOptions {
   /** regex that target must match */
@@ -8,46 +9,65 @@ export interface IRulePatternOptions {
   notMatch?: string;
 }
 
-function test(value: string, regex: RegExp | string) {
-  let re;
-  if (typeof regex === 'string') {
-    // regex in a string like {"match": "/[a-b]+/im"} or {"match": "[a-b]+"} in a json ruleset
-    // the available flags are "gimsuy" as described here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
-    const splitRegex = /^\/(.+)\/([a-z]*)$/.exec(regex);
-    if (splitRegex) {
-      // with slashes like /[a-b]+/ and possibly with flags like /[a-b]+/im
-      re = new RegExp(splitRegex[1], splitRegex[2]);
-    } else {
-      // without slashes like [a-b]+
-      re = new RegExp(regex);
-    }
-  } else {
-    // true regex
-    re = new RegExp(regex);
+// regex in a string like {"match": "/[a-b]+/im"} or {"match": "[a-b]+"} in a json ruleset
+// the available flags are "gimsuy" as described here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
+const REGEXP_PATTERN = /^\/(.+)\/([a-z]*)$/;
+
+function getFromCache(cache: Map<string, RegExp>, pattern: string): RegExp {
+  const existingPattern = cache.get(pattern);
+  if (existingPattern !== void 0) {
+    return existingPattern;
   }
-  return re.test(value);
+
+  const newPattern = createRegex(pattern);
+  cache.set(pattern, newPattern);
+  return newPattern;
 }
 
-export const pattern: IFunction<IRulePatternOptions> = (targetVal, opts) => {
+function createRegex(pattern: string): RegExp {
+  const splitRegex = REGEXP_PATTERN.exec(pattern);
+  if (splitRegex !== null) {
+    // with slashes like /[a-b]+/ and possibly with flags like /[a-b]+/im
+    return new RegExp(splitRegex[1], splitRegex[2]);
+  } else {
+    // without slashes like [a-b]+
+    return new RegExp(pattern);
+  }
+}
+
+export const pattern: IFunction<IRulePatternOptions> = function (this: IFunctionContext, targetVal, opts) {
   if (typeof targetVal !== 'string') return;
 
-  const results: IFunctionResult[] = [];
+  let results: Optional<IFunctionResult[]>;
 
   const { match, notMatch } = opts;
+  const cache = this.cache as Map<string, RegExp>;
 
-  if (match) {
-    if (test(targetVal, match) !== true) {
-      results.push({
-        message: `must match the pattern '${match}'`,
-      });
+  if (match !== void 0) {
+    const pattern = getFromCache(cache, match);
+
+    if (!pattern.test(targetVal)) {
+      results = [
+        {
+          message: `must match the pattern '${match}'`,
+        },
+      ];
     }
   }
 
-  if (notMatch) {
-    if (test(targetVal, notMatch) === true) {
-      results.push({
+  if (notMatch !== void 0) {
+    const pattern = getFromCache(cache, notMatch);
+
+    if (pattern.test(targetVal)) {
+      const result = {
         message: `must not match the pattern '${notMatch}'`,
-      });
+      };
+
+      if (results === void 0) {
+        results = [result];
+      } else {
+        results.push(result);
+      }
     }
   }
 

--- a/src/rulesets/__tests__/evaluators.test.ts
+++ b/src/rulesets/__tests__/evaluators.test.ts
@@ -96,5 +96,18 @@ describe('Code evaluators', () => {
       const fn2 = setFunctionContext(context, jest.fn().mockReturnThis());
       expect(fn()).not.toBe(fn2());
     });
+
+    it('copies enumerable properties', () => {
+      const context = { a: true };
+      const prop = Object.freeze({});
+      const fn = function () {
+        return;
+      };
+
+      fn.foo = prop;
+
+      const boundFn = setFunctionContext(context, fn);
+      expect(boundFn.foo).toBe(prop);
+    });
   });
 });

--- a/src/rulesets/evaluators.ts
+++ b/src/rulesets/evaluators.ts
@@ -165,8 +165,12 @@ export const compileExportedFunction = ({ code, name, source, schema, inject }: 
 };
 
 export function setFunctionContext(context: unknown, fn: Function) {
-  return Function.prototype.bind.call(
+  const boundFn = Function.prototype.bind.call(
     fn,
     Object.freeze(Object.defineProperties({}, Object.getOwnPropertyDescriptors(context))),
   );
+
+  Object.assign(boundFn, fn);
+
+  return boundFn;
 }


### PR DESCRIPTION
Leverages the cache mechanism we added back in 5.4 so that each regular expression does not to be compiled each time.
Moreover, we avoid an allocation of an array if not required.
It's not like the perf gain is huge, but it's like 2-4% on average, which is still something.

Oh, and I expose cache to built-in (core) functions, because they didn't have access to it beforehand.

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

