### PR TITLE
build(assets): $refs under functionOptions cannot be relative to the document

### DIFF
--- a/src/__tests__/generate-assets.jest.test.ts
+++ b/src/__tests__/generate-assets.jest.test.ts
@@ -1,4 +1,10 @@
 import { existsSync, readFileSync } from 'fs';
+import { Spectral } from '../spectral';
+import { setFunctionContext } from '../rulesets/evaluators';
+import { functions } from '../functions';
+import oasDocumentSchema from '../rulesets/oas/functions/oasDocumentSchema';
+import { KNOWN_FORMATS } from '../formats';
+import { DiagnosticSeverity } from '@stoplight/types/dist';
 
 describe('generate-assets', () => {
   let assets: Record<string, string>;
@@ -37,9 +43,83 @@ describe('generate-assets', () => {
     );
   });
 
-  it('Does not contain test files', () => {
+  it('does not contain test files', () => {
     Object.keys(assets).forEach(key => {
       expect(key).not.toMatch('__tests__');
     });
+  });
+
+  it('dereferences OAS schemas in the way they can be resolved by Ajv', async () => {
+    const key = `@stoplight/spectral/rulesets/oas/index.json`;
+    const ruleset = JSON.parse(assets[key]);
+    const spectral = new Spectral();
+
+    for (const [name, fn] of KNOWN_FORMATS) {
+      spectral.registerFormat(name, fn);
+    }
+
+    spectral.setFunctions({ oasDocumentSchema: setFunctionContext({ functions }, oasDocumentSchema) });
+    spectral.setRules({
+      'oas2-schema': {
+        ...ruleset.rules['oas2-schema'],
+      },
+      'oas3-schema': {
+        ...ruleset.rules['oas3-schema'],
+      },
+    });
+
+    expect(
+      await spectral.run({
+        openapi: '3.0.0',
+        info: {},
+        paths: {
+          '/': {
+            '500': true,
+          },
+        },
+      }),
+    ).toStrictEqual([
+      {
+        code: 'oas3-schema',
+        message: '`info` property should have required property `title`.',
+        path: ['info'],
+        range: expect.any(Object),
+        severity: DiagnosticSeverity.Error,
+      },
+      {
+        code: 'oas3-schema',
+        message: 'Property `500` is not expected to be here.',
+        path: ['paths', '/'],
+        range: expect.any(Object),
+        severity: DiagnosticSeverity.Error,
+      },
+    ]);
+
+    expect(
+      await spectral.run({
+        swagger: '2.0',
+        info: {},
+        paths: {
+          '/': {
+            '500': true,
+          },
+        },
+      }),
+    ).toStrictEqual([
+      {
+        code: 'oas2-schema',
+        message: '`info` property should have required property `title`.',
+        path: ['info'],
+        range: expect.any(Object),
+        severity: DiagnosticSeverity.Error,
+      },
+      {
+        code: 'oas2-schema',
+        message: 'Property `500` is not expected to be here.',
+        path: ['paths', '/'],
+        range: expect.any(Object),
+        severity: DiagnosticSeverity.Error,
+      },
+    ]);
   });
 });

--- a/src/functions/schema.ts
+++ b/src/functions/schema.ts
@@ -88,7 +88,13 @@ const validators = new (class extends WeakMap<JSONSchema, ValidateFunction> {
   public get({ schema: schemaObj, oasVersion, allErrors }: ISchemaOptions): ValidateFunction {
     const ajv = getAjv(oasVersion, allErrors);
     const schemaId = getSchemaId(schemaObj);
-    let validator = schemaId !== void 0 ? ajv.getSchema(schemaId) : void 0;
+    let validator;
+    try {
+      validator = schemaId !== void 0 ? ajv.getSchema(schemaId) : void 0;
+    } catch {
+      validator = void 0;
+    }
+
     if (validator !== void 0) {
       return validator;
     }


### PR DESCRIPTION
Fixes the issue with oas2/oas3-schema rules in Studio.

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No


**Additional context**

Why is it broken?
Some time ago we switched from dereferencing to bundling strategy when resolving $refs in rulesets during the Spectral offline assets generation.
This had one unintended side effect - as of that change all $refs are scoped relatively to the whole document.
This causes troubles, since in certain cases such has we pass a portion of the entire ruleset.
Having rewritten inline $refs inside of functionOptions is not really desired, because we always pass a given portion of the ruleset, therefore the $refs won't be resolvable, and eventually Ajv will refuse to validate the document.

```
  MissingRefError {
      message: "can't resolve reference #/rules/oas3-schema/then/functionOptions/schema/definitions/Info from id https://spec.openapis.org/oas/3.0/schema/2019-04-02#",
      missingRef: 'https://spec.openapis.org/oas/3.0/schema/2019-04-02#/rules/oas3-schema/then/functionOptions/schema/definitions/Info',
      missingSchema: 'https://spec.openapis.org/oas/3.0/schema/2019-04-02'
    }
```

The following PR makes sure we bundle only external $refs, while all inline $refs are kept untouched.