### PR TITLE
Fixed typo. functionsDir instead of functionDir

### DIFF
--- a/docs/guides/7-sharing-rulesets.md
+++ b/docs/guides/7-sharing-rulesets.md
@@ -138,4 +138,4 @@ extends:
   - ./style-guide/spectral.json
 ```
 
-If you need custom functions this will work, as `functionDir` can point to a directory inside `style-guide/` and all the JavaScript files can live in there too.
+If you need custom functions this will work, as `functionsDir` can point to a directory inside `style-guide/` and all the JavaScript files can live in there too.


### PR DESCRIPTION
**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

**Additional context**

It's just a typo in the doc