### PR TITLE
feat(replacer): allow code to be evaluated

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "blueimp-md5": "2.13.0",
     "chalk": "4.0.0",
     "eol": "0.9.1",
+    "expression-eval": "3.1.2",
     "fast-glob": "3.1.0",
     "jsonpath-plus": "4.0.0",
     "lodash": "4.17.19",

--- a/src/__tests__/linter.jest.test.ts
+++ b/src/__tests__/linter.jest.test.ts
@@ -502,7 +502,7 @@ console.log(this.cache.get('test') || this.cache.set('test', []).get('test'));
           severity: DiagnosticSeverity.Error,
           recommended: true,
           description: 'Should be falsy',
-          message: 'Value {{value|to-string}} should be falsy',
+          message: 'Value #{{printValue()}} should be falsy',
           given: '$..empty',
           then: {
             function: 'falsy',

--- a/src/__tests__/linter.jest.test.ts
+++ b/src/__tests__/linter.jest.test.ts
@@ -502,7 +502,7 @@ console.log(this.cache.get('test') || this.cache.set('test', []).get('test'));
           severity: DiagnosticSeverity.Error,
           recommended: true,
           description: 'Should be falsy',
-          message: 'Value #{{printValue()}} should be falsy',
+          message: 'Value #{{print("value")}} should be falsy',
           given: '$..empty',
           then: {
             function: 'falsy',

--- a/src/__tests__/linter.test.ts
+++ b/src/__tests__/linter.test.ts
@@ -981,7 +981,7 @@ responses:: !!foo
           severity: DiagnosticSeverity.Error,
           recommended: true,
           description: 'A parameter in the header should be written in kebab-case',
-          message: '{{value|to-string}} is not kebab-cased: {{error}}',
+          message: '#{{printValue()}} is not kebab-cased: {{error}}',
           given: "$..parameters[?(@.in === 'header')]",
           then: {
             field: 'name',
@@ -1032,7 +1032,7 @@ responses:: !!foo
           severity: DiagnosticSeverity.Error,
           recommended: true,
           description: 'Should be falsy',
-          message: 'Value {{value|to-string}} should be falsy',
+          message: 'Value #{{printValue()}} should be falsy',
           given: '$..empty',
           then: {
             function: 'falsy',

--- a/src/__tests__/linter.test.ts
+++ b/src/__tests__/linter.test.ts
@@ -981,7 +981,7 @@ responses:: !!foo
           severity: DiagnosticSeverity.Error,
           recommended: true,
           description: 'A parameter in the header should be written in kebab-case',
-          message: '#{{printValue()}} is not kebab-cased: {{error}}',
+          message: '#{{print("value")}} is not kebab-cased: {{error}}',
           given: "$..parameters[?(@.in === 'header')]",
           then: {
             field: 'name',
@@ -1032,7 +1032,7 @@ responses:: !!foo
           severity: DiagnosticSeverity.Error,
           recommended: true,
           description: 'Should be falsy',
-          message: 'Value #{{printValue()}} should be falsy',
+          message: 'Value #{{print("value")}} should be falsy',
           given: '$..empty',
           then: {
             function: 'falsy',

--- a/src/functions/__tests__/defined.test.ts
+++ b/src/functions/__tests__/defined.test.ts
@@ -23,7 +23,7 @@ describe('defined', () => {
   test('should return an error message if target value is undefined', () => {
     expect(runDefined(void 0)).toEqual([
       {
-        message: '{{property|gravis|append-property}}should be defined',
+        message: '#{{printProperty()}}should be defined',
       },
     ]);
   });

--- a/src/functions/__tests__/defined.test.ts
+++ b/src/functions/__tests__/defined.test.ts
@@ -23,7 +23,7 @@ describe('defined', () => {
   test('should return an error message if target value is undefined', () => {
     expect(runDefined(void 0)).toEqual([
       {
-        message: '#{{printProperty()}}should be defined',
+        message: '#{{print("property")}}should be defined',
       },
     ]);
   });

--- a/src/functions/__tests__/falsy.test.ts
+++ b/src/functions/__tests__/falsy.test.ts
@@ -27,7 +27,7 @@ describe('falsy', () => {
   test('returns error message if target value is not falsy', () => {
     expect(runFalsy(true)).toEqual([
       {
-        message: '#{{printProperty()}}is not falsy',
+        message: '#{{print("property")}}is not falsy',
       },
     ]);
   });

--- a/src/functions/__tests__/falsy.test.ts
+++ b/src/functions/__tests__/falsy.test.ts
@@ -27,7 +27,7 @@ describe('falsy', () => {
   test('returns error message if target value is not falsy', () => {
     expect(runFalsy(true)).toEqual([
       {
-        message: '{{property|gravis|append-property}}is not falsy',
+        message: '#{{printProperty()}}is not falsy',
       },
     ]);
   });

--- a/src/functions/__tests__/schemaPath.test.ts
+++ b/src/functions/__tests__/schemaPath.test.ts
@@ -177,7 +177,7 @@ describe('schema-path', () => {
       };
       expect(runSchemaPath(target, invalidFieldToCheck, path)).toEqual([
         {
-          message: '{{property|gravis|append-property}}does not exist',
+          message: '#{{printProperty()}}does not exist',
           path: ['nonsense'],
         },
       ]);

--- a/src/functions/__tests__/schemaPath.test.ts
+++ b/src/functions/__tests__/schemaPath.test.ts
@@ -177,7 +177,7 @@ describe('schema-path', () => {
       };
       expect(runSchemaPath(target, invalidFieldToCheck, path)).toEqual([
         {
-          message: '#{{printProperty()}}does not exist',
+          message: '#{{print("property")}}does not exist',
           path: ['nonsense'],
         },
       ]);

--- a/src/functions/__tests__/truthy.test.ts
+++ b/src/functions/__tests__/truthy.test.ts
@@ -23,7 +23,7 @@ describe('truthy', () => {
   test('should return an error message if target value is falsy', () => {
     expect(runTruthy(false)).toEqual([
       {
-        message: '{{property|gravis|append-property}}is not truthy',
+        message: '#{{printProperty()}}is not truthy',
       },
     ]);
   });
@@ -31,7 +31,7 @@ describe('truthy', () => {
   test('should return an error message if target value is null', () => {
     expect(runTruthy(null)).toEqual([
       {
-        message: '{{property|gravis|append-property}}is not truthy',
+        message: '#{{printProperty()}}is not truthy',
       },
     ]);
   });

--- a/src/functions/__tests__/truthy.test.ts
+++ b/src/functions/__tests__/truthy.test.ts
@@ -23,7 +23,7 @@ describe('truthy', () => {
   test('should return an error message if target value is falsy', () => {
     expect(runTruthy(false)).toEqual([
       {
-        message: '#{{printProperty()}}is not truthy',
+        message: '#{{print("property")}}is not truthy',
       },
     ]);
   });
@@ -31,7 +31,7 @@ describe('truthy', () => {
   test('should return an error message if target value is null', () => {
     expect(runTruthy(null)).toEqual([
       {
-        message: '#{{printProperty()}}is not truthy',
+        message: '#{{print("property")}}is not truthy',
       },
     ]);
   });

--- a/src/functions/defined.ts
+++ b/src/functions/defined.ts
@@ -4,7 +4,7 @@ export const defined: IFunction = (targetVal): void | IFunctionResult[] => {
   if (typeof targetVal === 'undefined') {
     return [
       {
-        message: '#{{printProperty()}}should be defined',
+        message: '#{{print("property")}}should be defined',
       },
     ];
   }

--- a/src/functions/defined.ts
+++ b/src/functions/defined.ts
@@ -4,7 +4,7 @@ export const defined: IFunction = (targetVal): void | IFunctionResult[] => {
   if (typeof targetVal === 'undefined') {
     return [
       {
-        message: '{{property|gravis|append-property}}should be defined',
+        message: '#{{printProperty()}}should be defined',
       },
     ];
   }

--- a/src/functions/falsy.ts
+++ b/src/functions/falsy.ts
@@ -4,7 +4,7 @@ export const falsy: IFunction = (targetVal): void | IFunctionResult[] => {
   if (targetVal) {
     return [
       {
-        message: '#{{printProperty()}}is not falsy',
+        message: '#{{print("property")}}is not falsy',
       },
     ];
   }

--- a/src/functions/falsy.ts
+++ b/src/functions/falsy.ts
@@ -4,7 +4,7 @@ export const falsy: IFunction = (targetVal): void | IFunctionResult[] => {
   if (targetVal) {
     return [
       {
-        message: '{{property|gravis|append-property}}is not falsy',
+        message: '#{{printProperty()}}is not falsy',
       },
     ];
   }

--- a/src/functions/schema.ts
+++ b/src/functions/schema.ts
@@ -117,7 +117,7 @@ export const schema: ISchemaFunction = (targetVal, opts, paths, { rule }) => {
     return [
       {
         path,
-        message: `{{property|gravis|append-property}}does not exist`,
+        message: `#{{printProperty()}}does not exist`,
       },
     ];
   }

--- a/src/functions/schema.ts
+++ b/src/functions/schema.ts
@@ -117,7 +117,7 @@ export const schema: ISchemaFunction = (targetVal, opts, paths, { rule }) => {
     return [
       {
         path,
-        message: `#{{printProperty()}}does not exist`,
+        message: `#{{print("property")}}does not exist`,
       },
     ];
   }

--- a/src/functions/truthy.ts
+++ b/src/functions/truthy.ts
@@ -4,7 +4,7 @@ export const truthy: IFunction = (targetVal): void | IFunctionResult[] => {
   if (!targetVal) {
     return [
       {
-        message: '{{property|gravis|append-property}}is not truthy',
+        message: '#{{printProperty()}}is not truthy',
       },
     ];
   }

--- a/src/functions/truthy.ts
+++ b/src/functions/truthy.ts
@@ -4,7 +4,7 @@ export const truthy: IFunction = (targetVal): void | IFunctionResult[] => {
   if (!targetVal) {
     return [
       {
-        message: '#{{printProperty()}}is not truthy',
+        message: '#{{print("property")}}is not truthy',
       },
     ];
   }

--- a/src/functions/undefined.ts
+++ b/src/functions/undefined.ts
@@ -5,7 +5,7 @@ export const undefined: IFunction = (targetVal): void | IFunctionResult[] => {
   if (typeof targetVal !== 'undefined') {
     return [
       {
-        message: '{{property|gravis|append-property}}should be undefined',
+        message: '#{{printProperty()}}should be undefined',
       },
     ];
   }

--- a/src/functions/undefined.ts
+++ b/src/functions/undefined.ts
@@ -5,7 +5,7 @@ export const undefined: IFunction = (targetVal): void | IFunctionResult[] => {
   if (typeof targetVal !== 'undefined') {
     return [
       {
-        message: '#{{printProperty()}}should be undefined',
+        message: '#{{print("property")}}should be undefined',
       },
     ];
   }

--- a/src/rulesets/__tests__/message.test.ts
+++ b/src/rulesets/__tests__/message.test.ts
@@ -14,6 +14,21 @@ describe('message util', () => {
     ).toEqual('oops... "description" is missing;error: expected property to be truthy');
   });
 
+  test('evaluates code', () => {
+    const template = 'Property "#{{value.param}}" is missing. Path: #{{path.toUpperCase()}}';
+    expect(
+      message(template, {
+        property: 'description',
+        error: 'expected property to be truthy',
+        path: 'test',
+        description: null,
+        value: {
+          param: 'test',
+        },
+      }),
+    ).toEqual('Property "test" is missing. Path: TEST');
+  });
+
   test.each([0, false, null, undefined])('interpolates %s value correctly', value => {
     const template = 'Value must not equal {{value}}';
     expect(

--- a/src/rulesets/message.ts
+++ b/src/rulesets/message.ts
@@ -14,20 +14,29 @@ export type MessageInterpolator = (str: string, values: IMessageVars) => string;
 
 const MessageReplacer = new Replacer<IMessageVars>(2);
 
-MessageReplacer.addFunction('printProperty', ({ property }) => {
-  if (property !== void 0) {
-    return `\`${property}\` property `;
+MessageReplacer.addFunction('print', function (type) {
+  if (typeof type !== 'string') return '';
+  const { property, value } = this;
+  switch (type) {
+    case 'property':
+      if (property !== void 0) {
+        return `\`${property}\` property `;
+      }
+
+      return '';
+    case 'value':
+      if (isObject(value)) {
+        return Array.isArray(value) ? 'Array[]' : 'Object{}';
+      }
+
+      return JSON.stringify(value);
+    default:
+      if (type in this && this[type] !== null) {
+        return String(this[type]);
+      }
+
+      return '';
   }
-
-  return '';
-});
-
-MessageReplacer.addFunction('printValue', ({ value }) => {
-  if (isObject(value)) {
-    return Array.isArray(value) ? 'Array[]' : 'Object{}';
-  }
-
-  return JSON.stringify(value);
 });
 
 export const message: MessageInterpolator = MessageReplacer.print.bind(MessageReplacer);

--- a/src/rulesets/message.ts
+++ b/src/rulesets/message.ts
@@ -1,5 +1,5 @@
 import { Segment } from '@stoplight/types';
-import { capitalize, isObject } from 'lodash';
+import { isObject } from 'lodash';
 import { Replacer } from '../utils/replacer';
 
 export interface IMessageVars {
@@ -14,17 +14,15 @@ export type MessageInterpolator = (str: string, values: IMessageVars) => string;
 
 const MessageReplacer = new Replacer<IMessageVars>(2);
 
-MessageReplacer.addTransformer('double-quotes', (id, value) => (value ? `"${value}"` : ''));
-MessageReplacer.addTransformer('single-quotes', (id, value) => (value ? `'${value}'` : ''));
-MessageReplacer.addTransformer('gravis', (id, value) => (value ? `\`${value}\`` : ''));
-MessageReplacer.addTransformer('capitalize', (id, value) => capitalize(String(value)));
+MessageReplacer.addFunction('printProperty', ({ property }) => {
+  if (property !== void 0) {
+    return `\`${property}\` property `;
+  }
 
-MessageReplacer.addTransformer('append-property', (id, value) => (value ? `${value} property ` : ''));
-MessageReplacer.addTransformer('optional-typeof', (id, value, values) =>
-  value ? String(value) : `${typeof values.value} `,
-);
+  return '';
+});
 
-MessageReplacer.addTransformer('to-string', (id, value) => {
+MessageReplacer.addFunction('printValue', ({ value }) => {
   if (isObject(value)) {
     return Array.isArray(value) ? 'Array[]' : 'Object{}';
   }

--- a/src/rulesets/reader.ts
+++ b/src/rulesets/reader.ts
@@ -1,6 +1,6 @@
 import { Cache } from '@stoplight/json-ref-resolver';
 import { ICache } from '@stoplight/json-ref-resolver/types';
-import { extname, join } from '@stoplight/path';
+import { extname, join, toFSPath } from '@stoplight/path';
 import { Optional } from '@stoplight/types';
 import { readFile, readParsable } from '../fs/reader';
 import { createHttpAndFileResolver, IHttpAndFileResolverOptions } from '../resolvers/http-and-file';
@@ -79,7 +79,7 @@ const createRulesetProcessor = (
         dereferenceInline: false,
         uriCache,
         async parseResolveResult(opts) {
-          opts.result = parseContent(opts.result, opts.targetAuthority.pathname());
+          opts.result = parseContent(opts.result, toFSPath(opts.targetAuthority.pathname()));
           return opts;
         },
       },

--- a/src/rulesets/reader.ts
+++ b/src/rulesets/reader.ts
@@ -1,6 +1,6 @@
 import { Cache } from '@stoplight/json-ref-resolver';
 import { ICache } from '@stoplight/json-ref-resolver/types';
-import { extname, join, toFSPath } from '@stoplight/path';
+import { extname, join } from '@stoplight/path';
 import { Optional } from '@stoplight/types';
 import { readFile, readParsable } from '../fs/reader';
 import { createHttpAndFileResolver, IHttpAndFileResolverOptions } from '../resolvers/http-and-file';
@@ -79,7 +79,7 @@ const createRulesetProcessor = (
         dereferenceInline: false,
         uriCache,
         async parseResolveResult(opts) {
-          opts.result = parseContent(opts.result, toFSPath(opts.targetAuthority.pathname()));
+          opts.result = parseContent(opts.result, opts.targetAuthority.pathname());
           return opts;
         },
       },

--- a/src/utils/__tests__/replacer.test.ts
+++ b/src/utils/__tests__/replacer.test.ts
@@ -2,6 +2,10 @@ import { Dictionary } from '@stoplight/types';
 import { Replacer } from '../replacer';
 
 describe('Replacer', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('interpolates correctly', () => {
     const replacer = new Replacer<Dictionary<unknown>>(2);
     const template = 'oops... "{{property}}" is missing;error: {{error}}';
@@ -81,7 +85,11 @@ describe('Replacer', () => {
     ).toEqual('foo.bar./a');
   });
 
-  it('handles exceptions thrown during evaluation', () => {
+  it('handles and prints out exceptions thrown during evaluation', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {
+      // no-op
+    });
+
     const replacer = new Replacer<Dictionary<unknown>>(2);
     const template = 'value is: #{{value.name}}';
 
@@ -90,5 +98,6 @@ describe('Replacer', () => {
         value: null,
       }),
     ).toEqual('value is: ');
+    expect(warnSpy).toBeCalledWith(new TypeError("Cannot read property 'name' of null"));
   });
 });

--- a/src/utils/__tests__/replacer.test.ts
+++ b/src/utils/__tests__/replacer.test.ts
@@ -67,7 +67,10 @@ describe('Replacer', () => {
 
   it('supports custom functions', () => {
     const replacer = new Replacer<Dictionary<unknown>>(2);
-    replacer.addFunction('printPath', ({ path }) => (Array.isArray(path) ? path.join('.') : String(path)));
+    replacer.addFunction('printPath', function () {
+      const { path } = this;
+      return Array.isArray(path) ? path.join('.') : String(path);
+    });
 
     const template = '#{{printPath()}}';
 

--- a/src/utils/__tests__/replacer.test.ts
+++ b/src/utils/__tests__/replacer.test.ts
@@ -53,11 +53,23 @@ describe('Replacer', () => {
     ).toEqual('missing :(');
   });
 
-  it('supports transformers', () => {
+  it('evaluates expressions', () => {
     const replacer = new Replacer<Dictionary<unknown>>(2);
-    replacer.addTransformer('dot', (id, value) => (Array.isArray(value) ? value.join('.') : String(value)));
 
-    const template = '{{path|dot}}';
+    const template = "#{{path[1] + '-' + path[2].toUpperCase()}}";
+
+    expect(
+      replacer.print(template, {
+        path: ['foo', 'bar', '/a'],
+      }),
+    ).toEqual('bar-/A');
+  });
+
+  it('supports custom functions', () => {
+    const replacer = new Replacer<Dictionary<unknown>>(2);
+    replacer.addFunction('printPath', ({ path }) => (Array.isArray(path) ? path.join('.') : String(path)));
+
+    const template = '#{{printPath()}}';
 
     expect(
       replacer.print(template, {

--- a/src/utils/__tests__/replacer.test.ts
+++ b/src/utils/__tests__/replacer.test.ts
@@ -80,4 +80,15 @@ describe('Replacer', () => {
       }),
     ).toEqual('foo.bar./a');
   });
+
+  it('handles exceptions thrown during evaluation', () => {
+    const replacer = new Replacer<Dictionary<unknown>>(2);
+    const template = 'value is: #{{value.name}}';
+
+    expect(
+      replacer.print(template, {
+        value: null,
+      }),
+    ).toEqual('value is: ');
+  });
 });

--- a/src/utils/replacer.ts
+++ b/src/utils/replacer.ts
@@ -1,4 +1,5 @@
 import { Dictionary } from '@stoplight/types';
+import { eval, parse } from 'expression-eval';
 
 export type Transformer<V = unknown, VV = object> = (identifier: string, value: V, values: VV) => string;
 
@@ -7,17 +8,23 @@ export class Replacer<V extends object> {
   protected readonly transformers: Dictionary<Transformer<V[keyof V], V>>;
 
   constructor(count: number) {
-    this.regex = new RegExp(`${'{'.repeat(count)}([^}\n]+)${'}'.repeat(count)}`, 'g');
+    this.regex = new RegExp(`#?${'{'.repeat(count)}([^}\n]+)${'}'.repeat(count)}`, 'g');
 
     this.transformers = {};
   }
 
-  public addTransformer(name: string, filter: Transformer<V[keyof V], V>) {
+  public addTransformer(name: string, filter: Transformer<V[keyof V], V>): void {
     this.transformers[name] = filter;
   }
 
-  public print(input: string, values: V) {
-    return input.replace(this.regex, (substr, expr) => {
+  public print(input: string, values: V): string {
+    return input.replace(this.regex, (substr, expr, index) => {
+      const shouldEvaluate = input[index] === '#';
+
+      if (shouldEvaluate) {
+        return String(eval(parse(expr), values));
+      }
+
       const [identifier, ...transformers] = expr.split('|');
 
       if (!(identifier in values)) {

--- a/src/utils/replacer.ts
+++ b/src/utils/replacer.ts
@@ -32,7 +32,8 @@ export class Replacer<V extends object> {
               ...values,
             }),
           );
-        } catch {
+        } catch (ex) {
+          console.warn(ex);
           return '';
         }
       }

--- a/src/utils/replacer.ts
+++ b/src/utils/replacer.ts
@@ -22,15 +22,19 @@ export class Replacer<V extends object> {
       const shouldEvaluate = input[index] === '#';
 
       if (shouldEvaluate) {
-        return String(
-          eval(parse(identifier), {
-            ...Object.entries(this.functions).reduce((fns, [name, fn]) => {
-              fns[name] = fn.bind(values);
-              return fns;
-            }, {}),
-            ...values,
-          }),
-        );
+        try {
+          return String(
+            eval(parse(identifier), {
+              ...Object.entries(this.functions).reduce((fns, [name, fn]) => {
+                fns[name] = fn.bind(values);
+                return fns;
+              }, {}),
+              ...values,
+            }),
+          );
+        } catch {
+          return '';
+        }
       }
 
       if (!(identifier in values)) {

--- a/src/utils/replacer.ts
+++ b/src/utils/replacer.ts
@@ -1,7 +1,7 @@
 import { Dictionary } from '@stoplight/types';
 import { eval, parse } from 'expression-eval';
 
-export type Transformer<V = object> = (values: V) => string;
+export type Transformer<V = object> = (this: V, ...args: unknown[]) => string;
 
 export class Replacer<V extends object> {
   protected readonly regex: RegExp;
@@ -25,7 +25,7 @@ export class Replacer<V extends object> {
         return String(
           eval(parse(identifier), {
             ...Object.entries(this.functions).reduce((fns, [name, fn]) => {
-              fns[name] = fn.bind(null, values);
+              fns[name] = fn.bind(values);
               return fns;
             }, {}),
             ...values,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2766,6 +2766,13 @@ export-files@^2.0.1:
   dependencies:
     lazy-cache "^1.0.3"
 
+expression-eval@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/expression-eval/-/expression-eval-3.1.2.tgz#45ddf0b8fdb8bf0633d02f4061d6f25516eddb30"
+  integrity sha512-c8ZN8fuAz0TRYKoGsrIq5kLNHtm81KAqWSBORHIY0DpJmZZrwK/r2zFDOhFIAJDV47gJ6irV7dWf1TOFpKvULQ==
+  dependencies:
+    jsep "^0.3.0"
+
 extend-shallow@^2.0.0, extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
@@ -4511,10 +4518,10 @@ jsdom@^15.2.1:
     ws "^7.0.0"
     xml-name-validator "^3.0.0"
 
-jsep@^0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/jsep/-/jsep-0.3.4.tgz#55ebd4400c5c5861cb1ff949a7a4cd97fcaacaa0"
-  integrity sha512-ovGD9wE+wvudIIYxZGrRcZCxNyZ3Cl1N7Bzyp7/j4d/tA0BaUwcVM9bu0oZaSrefMiNwv6TwZ9X15gvZosteCQ==
+jsep@^0.3.0, jsep@^0.3.4:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/jsep/-/jsep-0.3.5.tgz#3fd79ebd92f6f434e4857d5272aaeef7d948264d"
+  integrity sha512-AoRLBDc6JNnKjNcmonituEABS5bcfqDhQAWWXNTFrqu6nVXBpBAGfcoTGZMFlIrh9FjmE1CQyX9CTNwZrXMMDA==
 
 jsesc@^2.5.1:
   version "2.5.2"


### PR DESCRIPTION
This would close https://github.com/stoplightio/spectral/issues/1339

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No


**Additional context**

I'm not quite sure whether we'll want to have this in in the end.
While, I like the new syntax here, we already have these sort-of pipe operators, which are somewhat redundant as of this change. I'd rather avoid any fragmentation here, and go with a single syntax, but this would be a breaking change.

expression-eval is used, as it's slightly safer than running plain eval, as the set of operations available is strictly limited.

EDIT:
I decided to get rid of the "pipe syntax" and use functions everywhere where necessary, as this gives us more flexibility.
Luckily, we didn't document that syntax, therefore it's not a breaking change in the end.
