### PR TITLE
feat: format lookup by source

### DIFF
--- a/docs/guides/3-javascript.md
+++ b/docs/guides/3-javascript.md
@@ -195,7 +195,7 @@ spectral
 Alternatively you may lookup for certain format by optional `source`, which could be passed in `run` options.
 
 ```js
-const { Spectral } = require('@stoplight/spectral');
+const { Document, Spectral } = require('@stoplight/spectral');
 
 const spectral = new Spectral();
 
@@ -216,15 +216,7 @@ spectral.setRuleset({
 });
 
 spectral
-  .run(
-    {
-      'foo-bar': true,
-      x: false
-    },
-    {
-      source: '/foo/bar',
-    }
-  )
+  .run(new Document(`foo-bar: true\nx: false`, Parsers.Yaml, '/foo/bar'))
   .then(result => {
     expect(result).toEqual([
       expect.objectContaining({

--- a/docs/guides/3-javascript.md
+++ b/docs/guides/3-javascript.md
@@ -192,6 +192,48 @@ spectral
   });
 ```
 
+Alternatively you may lookup for certain format by optional `source`, which could be passed in `run` options.
+
+```js
+const { Spectral } = require('@stoplight/spectral');
+
+const spectral = new Spectral();
+
+spectral.registerFormat('foo-bar', (_, source) => source === '/foo/bar');
+
+spectral.setRuleset({
+  functions: {},
+  rules: {
+    rule1: {
+      given: '$.x',
+      formats: ['foo-bar'],
+      severity: 'error',
+      then: {
+        function: 'truthy',
+      },
+    },
+  },
+});
+
+spectral
+  .run(
+    {
+      'foo-bar': true,
+      x: false
+    },
+    {
+      source: '/foo/bar',
+    }
+  )
+  .then(result => {
+    expect(result).toEqual([
+      expect.objectContaining({
+       code: 'rule1',
+     }),
+   ]);
+  });
+```
+
 ### Using a Proxy
 
 Spectral supports HTTP(S) proxies when fetching remote schemas and rulesets.

--- a/src/__tests__/linter.test.ts
+++ b/src/__tests__/linter.test.ts
@@ -573,6 +573,45 @@ describe('linter', () => {
     expect(result).toEqual([]);
   });
 
+  test('should accept format lookup by source', async () => {
+    spectral.registerFormat('foo-bar', (_, source) => source === '/foo/bar');
+
+    spectral.setRules({
+      rule1: {
+        given: '$.x',
+        formats: ['foo-bar'],
+        severity: 'error',
+        then: {
+          function: 'truthy',
+        },
+      },
+      rule2: {
+        given: '$.y',
+        formats: [],
+        severity: 'warn',
+        then: {
+          function: 'truthy',
+        },
+      },
+    });
+
+    const result = await spectral.run(
+      {
+        x: false,
+        y: '',
+      },
+      {
+        source: '/foo/bar',
+      },
+    );
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        code: 'rule1',
+      }),
+    ]);
+  });
+
   test('should include parser diagnostics', async () => {
     const responses = `
 responses:: !!foo

--- a/src/__tests__/linter.test.ts
+++ b/src/__tests__/linter.test.ts
@@ -595,15 +595,7 @@ describe('linter', () => {
       },
     });
 
-    const result = await spectral.run(
-      {
-        x: false,
-        y: '',
-      },
-      {
-        source: '/foo/bar',
-      },
-    );
+    const result = await spectral.run(new Document(`x: false\ny: ''`, Parsers.Yaml, '/foo/bar'));
 
     expect(result).toEqual([
       expect.objectContaining({

--- a/src/spectral.ts
+++ b/src/spectral.ts
@@ -111,7 +111,9 @@ export class Spectral {
 
     if (document.formats === void 0) {
       const registeredFormats = Object.keys(this.formats);
-      const foundFormats = registeredFormats.filter(format => this.formats[format](inventory.resolved, opts.source));
+      const foundFormats = registeredFormats.filter(format =>
+        this.formats[format](inventory.resolved, document.source ?? void 0),
+      );
       if (foundFormats.length === 0 && opts.ignoreUnknownFormat !== true) {
         document.formats = null;
         if (registeredFormats.length > 0) {

--- a/src/spectral.ts
+++ b/src/spectral.ts
@@ -111,7 +111,7 @@ export class Spectral {
 
     if (document.formats === void 0) {
       const registeredFormats = Object.keys(this.formats);
-      const foundFormats = registeredFormats.filter(format => this.formats[format](inventory.resolved));
+      const foundFormats = registeredFormats.filter(format => this.formats[format](inventory.resolved, opts.source));
       if (foundFormats.length === 0 && opts.ignoreUnknownFormat !== true) {
         document.formats = null;
         if (registeredFormats.length > 0) {

--- a/src/types/spectral.ts
+++ b/src/types/spectral.ts
@@ -31,6 +31,7 @@ export interface IRunOpts {
   resolve?: {
     documentUri?: string;
   };
+  source?: string;
 }
 
 export interface IRuleResult extends IDiagnostic {
@@ -53,7 +54,7 @@ export interface IResolver {
   resolve(source: unknown, opts?: IResolveOpts): Promise<ResolveResult>;
 }
 
-export type FormatLookup = (document: unknown) => boolean;
+export type FormatLookup = (document: unknown, source?: string) => boolean;
 export type RegisteredFormats = Dictionary<FormatLookup, string>;
 
 export type JSONSchema = JSONSchema4 | JSONSchema6 | JSONSchema7;

--- a/src/types/spectral.ts
+++ b/src/types/spectral.ts
@@ -53,6 +53,7 @@ export interface IResolver {
   resolve(source: unknown, opts?: IResolveOpts): Promise<ResolveResult>;
 }
 
+// todo(@p0lip): make it string | null when working on 6.0
 export type FormatLookup = (document: unknown, source?: string) => boolean;
 export type RegisteredFormats = Dictionary<FormatLookup, string>;
 

--- a/src/types/spectral.ts
+++ b/src/types/spectral.ts
@@ -31,7 +31,6 @@ export interface IRunOpts {
   resolve?: {
     documentUri?: string;
   };
-  source?: string;
 }
 
 export interface IRuleResult extends IDiagnostic {


### PR DESCRIPTION
Adds support for looking up formats by source (filename, uri) additionally to document content.

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

