### PR TITLE
chore: improve OAS functions

### DIFF
--- a/src/rulesets/oas/functions/__tests__/oasOpIdUnique.test.ts
+++ b/src/rulesets/oas/functions/__tests__/oasOpIdUnique.test.ts
@@ -56,22 +56,6 @@ describe('oasOpIdUnique', () => {
       {
         code: 'operation-operationId-unique',
         message: 'Every operation must have a unique `operationId`.',
-        path: ['paths', '/path1', 'get', 'operationId'],
-        range: {
-          end: {
-            character: 28,
-            line: 4,
-          },
-          start: {
-            character: 23,
-            line: 4,
-          },
-        },
-        severity: DiagnosticSeverity.Error,
-      },
-      {
-        code: 'operation-operationId-unique',
-        message: 'Every operation must have a unique `operationId`.',
         path: ['paths', '/path2', 'get', 'operationId'],
         range: {
           end: {
@@ -103,22 +87,6 @@ describe('oasOpIdUnique', () => {
     });
 
     expect(results).toEqual([
-      {
-        code: 'operation-operationId-unique',
-        message: 'Every operation must have a unique `operationId`.',
-        path: ['paths', '/path1', 'get', 'operationId'],
-        range: {
-          end: {
-            character: 28,
-            line: 4,
-          },
-          start: {
-            character: 23,
-            line: 4,
-          },
-        },
-        severity: DiagnosticSeverity.Error,
-      },
       {
         code: 'operation-operationId-unique',
         message: 'Every operation must have a unique `operationId`.',

--- a/src/rulesets/oas/functions/oasExample.ts
+++ b/src/rulesets/oas/functions/oasExample.ts
@@ -1,10 +1,6 @@
-import type { IFunction, IFunctionContext, IFunctionResult } from '../../../types';
-import type { Dictionary } from '@stoplight/types';
+import type { IFunction, IFunctionContext, IFunctionResult, JSONSchema } from '../../../types';
 import type { ISchemaOptions } from '../../../functions/schema';
-
-function isObject(value: unknown): value is Dictionary<any> {
-  return value !== null && typeof value === 'object';
-}
+import { isObject } from './utils/isObject';
 
 interface IOasExampleOptions {
   oasVersion: 2 | 3;
@@ -69,7 +65,7 @@ export const oasExample: IFunction<IOasExampleOptions> = function (
   }
 
   const schemaOpts: ISchemaOptions = {
-    schema: opts.schemaField === '$' ? targetVal : targetVal[opts.schemaField],
+    schema: opts.schemaField === '$' ? targetVal : (targetVal[opts.schemaField] as JSONSchema),
     oasVersion: opts.oasVersion,
   };
 
@@ -104,7 +100,7 @@ export const oasExample: IFunction<IOasExampleOptions> = function (
 
         const result = this.functions.schema.call(
           this,
-          keyed ? exampleValue.value : exampleValue,
+          keyed && isObject(exampleValue) ? exampleValue.value : exampleValue,
           schemaOpts,
           {
             given: paths.given,

--- a/src/rulesets/oas/functions/oasOpFormDataConsumeCheck.ts
+++ b/src/rulesets/oas/functions/oasOpFormDataConsumeCheck.ts
@@ -1,20 +1,24 @@
-import type { IFunction, IFunctionResult } from '../../../types';
+import type { IFunction } from '../../../types';
+
+const validConsumeValue = /(application\/x-www-form-urlencoded|multipart\/form-data)/;
 
 export const oasOpFormDataConsumeCheck: IFunction = targetVal => {
-  const results: IFunctionResult[] = [];
+  const parameters: unknown = targetVal.parameters;
+  const consumes: unknown = targetVal.consumes;
 
-  const parameters = targetVal.parameters;
-  const consumes = targetVal.consumes || [];
-
-  if (parameters?.find((p: any) => p.in === 'formData')) {
-    if (!consumes.join(',').match(/(application\/x-www-form-urlencoded|multipart\/form-data)/)) {
-      results.push({
-        message: 'consumes must include urlencoded, multipart, or formdata media type when using formData parameter',
-      });
-    }
+  if (!Array.isArray(parameters) || !Array.isArray(consumes)) {
+    return;
   }
 
-  return results;
+  if (parameters.some(p => p?.in === 'formData') && !validConsumeValue.test(consumes?.join(','))) {
+    return [
+      {
+        message: 'Consumes must include urlencoded, multipart, or form-data media type when using formData parameter.',
+      },
+    ];
+  }
+
+  return;
 };
 
 export default oasOpFormDataConsumeCheck;

--- a/src/rulesets/oas/functions/oasOpIdUnique.ts
+++ b/src/rulesets/oas/functions/oasOpIdUnique.ts
@@ -1,37 +1,25 @@
 import type { IFunction, IFunctionResult } from '../../../types';
+import { getAllOperations } from './utils/getAllOperations';
 
-export const oasOpIdUnique: IFunction = (targetVal, _options, functionPaths) => {
+export const oasOpIdUnique: IFunction = targetVal => {
   const results: IFunctionResult[] = [];
 
-  const { paths = {} } = targetVal;
+  const { paths } = targetVal;
 
-  const ids: any[] = [];
+  const seenIds: unknown[] = [];
 
-  for (const path in paths) {
-    if (Object.keys(paths[path]).length > 0) {
-      for (const operation in paths[path]) {
-        if (operation !== 'parameters') {
-          const { operationId } = paths[path][operation];
+  for (const { path, operation } of getAllOperations(paths)) {
+    const { operationId } = paths[path][operation];
 
-          if (operationId) {
-            ids.push({
-              path: ['paths', path, operation, 'operationId'],
-              operationId,
-            });
-          }
-        }
-      }
-    }
-  }
-
-  ids.forEach(operationId => {
-    if (ids.filter(id => id.operationId === operationId.operationId).length > 1) {
+    if (seenIds.includes(operationId)) {
       results.push({
-        message: 'operationId must be unique',
-        path: operationId.path || functionPaths.given,
+        message: 'operationId must be unique.',
+        path: ['paths', path, operation, 'operationId'],
       });
     }
-  });
+
+    seenIds.push(operationId);
+  }
 
   return results;
 };

--- a/src/rulesets/oas/functions/oasOpIdUnique.ts
+++ b/src/rulesets/oas/functions/oasOpIdUnique.ts
@@ -9,6 +9,10 @@ export const oasOpIdUnique: IFunction = targetVal => {
   const seenIds: unknown[] = [];
 
   for (const { path, operation } of getAllOperations(paths)) {
+    if (!('operationId' in paths[path][operation])) {
+      continue;
+    }
+
     const { operationId } = paths[path][operation];
 
     if (seenIds.includes(operationId)) {
@@ -16,9 +20,9 @@ export const oasOpIdUnique: IFunction = targetVal => {
         message: 'operationId must be unique.',
         path: ['paths', path, operation, 'operationId'],
       });
+    } else {
+      seenIds.push(operationId);
     }
-
-    seenIds.push(operationId);
   }
 
   return results;

--- a/src/rulesets/oas/functions/oasOpSuccessResponse.ts
+++ b/src/rulesets/oas/functions/oasOpSuccessResponse.ts
@@ -1,18 +1,22 @@
-import type { IFunction, IFunctionResult } from '../../../types';
+import type { IFunction } from '../../../types';
+import { isObject } from './utils/isObject';
 
 export const oasOpSuccessResponse: IFunction = targetVal => {
-  if (!targetVal) {
+  if (!isObject(targetVal)) {
     return;
   }
 
-  const results: IFunctionResult[] = [];
-  const responses = Object.keys(targetVal);
-  if (responses.filter(response => Number(response) >= 200 && Number(response) < 400).length === 0) {
-    results.push({
-      message: 'operations must define at least one 2xx or 3xx response',
-    });
+  for (const response of Object.keys(targetVal)) {
+    if (Number(response) >= 200 && Number(response) < 400) {
+      return;
+    }
   }
-  return results;
+
+  return [
+    {
+      message: 'operations must define at least one 2xx or 3xx response',
+    },
+  ];
 };
 
 export default oasOpSuccessResponse;

--- a/src/rulesets/oas/functions/utils/getAllOperations.ts
+++ b/src/rulesets/oas/functions/utils/getAllOperations.ts
@@ -1,0 +1,33 @@
+import { isObject } from './isObject';
+
+const validOperationKeys = ['get', 'head', 'post', 'put', 'patch', 'delete', 'options', 'trace'];
+
+export function* getAllOperations(paths: unknown): IterableIterator<{ path: string; operation: string }> {
+  if (!isObject(paths)) {
+    return;
+  }
+
+  const item = {
+    path: '',
+    operation: '',
+  };
+
+  for (const path of Object.keys(paths)) {
+    const operations = paths[path];
+    if (!isObject(operations)) {
+      continue;
+    }
+
+    item.path = path;
+
+    for (const operation of Object.keys(operations)) {
+      if (!isObject(operations[operation]) || !validOperationKeys.includes(operation)) {
+        continue;
+      }
+
+      item.operation = operation;
+
+      yield item;
+    }
+  }
+}

--- a/src/rulesets/oas/functions/utils/isObject.ts
+++ b/src/rulesets/oas/functions/utils/isObject.ts
@@ -1,0 +1,5 @@
+import type { Dictionary } from '@stoplight/types';
+
+export function isObject(value: unknown): value is Dictionary<unknown> {
+  return value !== null && typeof value === 'object';
+}

--- a/test-harness/scenarios/severity/fail-on-error.oas3.scenario
+++ b/test-harness/scenarios/severity/fail-on-error.oas3.scenario
@@ -30,11 +30,10 @@ OpenAPI 3.x detected
   2:6   warning  info-description              OpenAPI object info `description` must be present and non-empty string.  info
   7:9   warning  operation-description         Operation `description` must be present and non-empty string.            paths./test.get
   7:9   warning  operation-tags                Operation should have non-empty `tags` array.                            paths./test.get
-  8:20    error  operation-operationId-unique  Every operation must have a unique `operationId`.                        paths./test.get.operationId
   10:9    error  parser                        Mapping key must be a string scalar rather than number                   paths./test.get.responses[200]
  12:10  warning  operation-description         Operation `description` must be present and non-empty string.            paths./test.post
  12:10  warning  operation-tags                Operation should have non-empty `tags` array.                            paths./test.post
  13:20    error  operation-operationId-unique  Every operation must have a unique `operationId`.                        paths./test.post.operationId
   15:9    error  parser                        Mapping key must be a string scalar rather than number                   paths./test.post.responses[200]
 
-✖ 11 problems (4 errors, 7 warnings, 0 infos, 0 hints)
+✖ 10 problems (3 errors, 7 warnings, 0 infos, 0 hints)


### PR DESCRIPTION
Fixes 
```bash
spectral lint a.yaml
OpenAPI 3.x detected
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at Object.oasOpIdUnique (eval at <anonymous> (/snapshot/spectral/dist/rulesets/evaluators.js:89:80), <anonymous>:1:352)
    at Object.lintNode (/snapshot/spectral/dist/runner/lintNode.js:30:33)
    at runRule (/snapshot/spectral/dist/runner/runner.js:27:24)
    at Runner.run (/snapshot/spectral/dist/runner/runner.js:98:17)
    at Spectral.runWithResolved (/snapshot/spectral/dist/spectral.js:101:22)
    at async Spectral.run (/snapshot/spectral/dist/spectral.js:113:17)
    at async Object.lint (/snapshot/spectral/dist/cli/services/linter/linter.js:50:26)
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at Object.oasTagDefined (eval at <anonymous> (/snapshot/spectral/dist/rulesets/evaluators.js:89:80), <anonymous>:1:440)
    at Object.lintNode (/snapshot/spectral/dist/runner/lintNode.js:30:33)
    at runRule (/snapshot/spectral/dist/runner/runner.js:27:24)
    at Runner.run (/snapshot/spectral/dist/runner/runner.js:98:17)
    at Spectral.runWithResolved (/snapshot/spectral/dist/spectral.js:101:22)
    at async Spectral.run (/snapshot/spectral/dist/spectral.js:113:17)
    at async Object.lint (/snapshot/spectral/dist/cli/services/linter/linter.js:50:26)
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at Object.oasOpSecurityDefined (eval at <anonymous> (/snapshot/spectral/dist/rulesets/evaluators.js:89:80), <anonymous>:1:6084)
    at Object.lintNode (/snapshot/spectral/dist/runner/lintNode.js:30:33)
    at runRule (/snapshot/spectral/dist/runner/runner.js:27:24)
    at Runner.run (/snapshot/spectral/dist/runner/runner.js:98:17)
    at Spectral.runWithResolved (/snapshot/spectral/dist/spectral.js:101:22)
    at async Spectral.run (/snapshot/spectral/dist/spectral.js:113:17)
    at async Object.lint (/snapshot/spectral/dist/cli/services/linter/linter.js:50:26)

/foo/path/a.yaml
 1:1  warning  info-contact      Info object should contain `contact` object.
 1:1  warning  info-description  OpenAPI object info `description` must be present and non-empty string.
 1:1  warning  oas3-api-servers  OpenAPI `servers` must be present and non-empty array.
 1:1    error  oas3-schema       Object should have required property `info`.
 1:1  warning  openapi-tags      OpenAPI object should have non-empty `tags` array.
 3:8    error  oas3-schema       `~1foo` property type should be object.

✖ 6 problems (2 errors, 4 warnings, 0 infos, 0 hints)
```
that was yield for the following document (nullish path)
```
openapi: 3.0.0
paths:
  /foo:
```

Other than that, I also assured that most of our OAS functions actually validate valid operations.
This wasn't the case for some of them.
Last but not least, `oasOpIdUnique` reports errors only for 2nd and all subsequent duplicate keys.
The first one is not considered an error.


**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No


