### PR TITLE
fix(schema): handle non-string enum values

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "test": "jest --silent"
   },
   "dependencies": {
-    "@stoplight/better-ajv-errors": "0.0.0",
+    "@stoplight/better-ajv-errors": "0.0.3",
     "@stoplight/json": "3.9.0",
     "@stoplight/json-ref-readers": "1.2.1",
     "@stoplight/json-ref-resolver": "3.1.0",

--- a/src/functions/__tests__/schema.test.ts
+++ b/src/functions/__tests__/schema.test.ts
@@ -269,7 +269,7 @@ describe('schema', () => {
       it('reports pretty enum errors for a string', () => {
         expect(runSchema('baz', testSchema)).toEqual([
           {
-            message: `String should be equal to one of the allowed values: foo, bar. Did you mean bar?`,
+            message: 'String should be equal to one of the allowed values: `foo`, `bar`. Did you mean `bar`?',
             path: [],
           },
         ]);
@@ -310,6 +310,31 @@ describe('schema', () => {
         ]);
       });
     });
+
+    describe('and an enum contains a null', () => {
+      const testSchema: JSONSchema6 = {
+        $schema: `http://json-schema.org/draft-06/schema#`,
+        enum: [1, null],
+      };
+
+      it('reports pretty enum errors for a string', () => {
+        expect(runSchema('baz', testSchema)).toEqual([
+          {
+            message: `String should be equal to one of the allowed values: 1, null`,
+            path: [],
+          },
+        ]);
+      });
+
+      it('reports pretty enum errors for a number', () => {
+        expect(runSchema(2, testSchema)).toEqual([
+          {
+            message: `Number should be equal to one of the allowed values: 1, null`,
+            path: [],
+          },
+        ]);
+      });
+    });
   });
 
   test('reports slightly less pretty enum errors for primitive values that are not similar to any values in enum', () => {
@@ -321,7 +346,7 @@ describe('schema', () => {
 
     expect(runSchema('three', testSchema)).toEqual([
       {
-        message: `String should be equal to one of the allowed values: foo, bar`,
+        message: 'String should be equal to one of the allowed values: `foo`, `bar`',
         path: [],
       },
     ]);

--- a/src/rulesets/asyncapi/__tests__/asyncapi-headers-schema-type-object.ts
+++ b/src/rulesets/asyncapi/__tests__/asyncapi-headers-schema-type-object.ts
@@ -63,7 +63,7 @@ describe(`Rule '${ruleName}'`, () => {
       expect.objectContaining({
         code: ruleName,
         message:
-          'Headers schema type should be `object` (`type` property should be equal to one of the allowed values: object. Did you mean object?).',
+          'Headers schema type should be `object` (`type` property should be equal to one of the allowed values: `object`. Did you mean `object`?).',
         path: ['components', 'messages', 'aMessage', 'headers', 'type'],
         severity: rule.severity,
       }),
@@ -98,7 +98,7 @@ describe(`Rule '${ruleName}'`, () => {
       expect.objectContaining({
         code: ruleName,
         message:
-          'Headers schema type should be `object` (`type` property should be equal to one of the allowed values: object. Did you mean object?).',
+          'Headers schema type should be `object` (`type` property should be equal to one of the allowed values: `object`. Did you mean `object`?).',
         path: ['components', 'messageTraits', 'aTrait', 'headers', 'type'],
         severity: rule.severity,
       }),
@@ -155,7 +155,7 @@ describe(`Rule '${ruleName}'`, () => {
         expect.objectContaining({
           code: ruleName,
           message:
-            'Headers schema type should be `object` (`type` property should be equal to one of the allowed values: object. Did you mean object?).',
+            'Headers schema type should be `object` (`type` property should be equal to one of the allowed values: `object`. Did you mean `object`?).',
           path: ['channels', 'users/{userId}/signedUp', property, 'message', 'headers', 'type'],
           severity: rule.severity,
         }),

--- a/test-harness/scenarios/examples.oas2.scenario
+++ b/test-harness/scenarios/examples.oas2.scenario
@@ -268,7 +268,7 @@ OpenAPI 2.0 (Swagger) detected
   95:26    error  oas2-valid-schema-example  `example` property should match format `date-time`
   99:26    error  oas2-valid-schema-example  `example` property should match format `url`
  106:11  warning  operation-tag-defined      Operation tags should be defined in global tags.
- 120:22    error  oas2-valid-schema-example  `x-example` property should be equal to one of the allowed values: foo, bar
+ 120:22    error  oas2-valid-schema-example  `x-example` property should be equal to one of the allowed values: `foo`, `bar`
  177:30    error  oas2-valid-media-example   `application/json` property should have required property `name`
  194:30    error  oas2-valid-media-example   `application/json` property should have required property `user`
 

--- a/test-harness/scenarios/examples.oas3.scenario
+++ b/test-harness/scenarios/examples.oas3.scenario
@@ -356,8 +356,8 @@ OpenAPI 3.x detected
  138:30  error  oas3-valid-schema-example  `example` property type should be boolean
  142:30  error  oas3-valid-schema-example  `example` property should match format `date-time`
  146:30  error  oas3-valid-schema-example  `example` property should match format `url`
- 169:20  error  oas3-valid-media-example   `example` property should be equal to one of the allowed values: foo, bar
- 185:22  error  oas3-valid-schema-example  `example` property should be equal to one of the allowed values: foo, bar
+ 169:20  error  oas3-valid-media-example   `example` property should be equal to one of the allowed values: `foo`, `bar`
+ 185:22  error  oas3-valid-schema-example  `example` property should be equal to one of the allowed values: `foo`, `bar`
  197:22  error  oas3-valid-media-example   `value` property type should be string
  199:21  error  oas3-valid-media-example   `value` property type should be string
  262:25  error  oas3-valid-media-example   `value` property should have required property `id`

--- a/test-harness/scenarios/external-schemas-ruleset.scenario
+++ b/test-harness/scenarios/external-schemas-ruleset.scenario
@@ -11,7 +11,7 @@ info:
 OpenAPI 3.x detected
 
 {document}
- 3:10  error  info-title        `title` property should be equal to one of the allowed values: Stoplight, Stoplight.io, StoplightIO. Did you mean Stoplight?
- 4:16  error  info-description  `description` property should be equal to one of the allowed values: foo, foo-bar, bar-foo
+ 3:10  error  info-title        `title` property should be equal to one of the allowed values: `Stoplight`, `Stoplight.io`, `StoplightIO`. Did you mean `Stoplight`?
+ 4:16  error  info-description  `description` property should be equal to one of the allowed values: `foo`, `foo-bar`, `bar-foo`
 
 ✖ 2 problems (2 errors, 0 warnings, 0 infos, 0 hints)

--- a/yarn.lock
+++ b/yarn.lock
@@ -593,10 +593,10 @@
   dependencies:
     type-detect "4.0.8"
 
-"@stoplight/better-ajv-errors@0.0.0":
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/better-ajv-errors/-/better-ajv-errors-0.0.0.tgz#18bf69c2380a00b72e4bd5fb7247c5adf615795a"
-  integrity sha512-jA1i4J5HmCXMmZdZigdeEHpisFCGVg5QfK++ouxP58pxshATJ5G40U9uGec2vYnuR2MQnzWHAXYf0f8jvJhBwg==
+"@stoplight/better-ajv-errors@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@stoplight/better-ajv-errors/-/better-ajv-errors-0.0.3.tgz#8d47a511aca89e0027cf748785910fbb25d7c54f"
+  integrity sha512-q3PoPiYZdzfJjQ+q6ifuLVFx3dBKRxW1OBGxnLAoDlamYb+GJUNiaSLB32L6OB4fi6h/TsY21lZB7y7aYFM7tQ==
   dependencies:
     jsonpointer "^4.0.1"
     leven "^3.1.0"


### PR DESCRIPTION
Spotted while working on https://github.com/stoplightio/spectral/issues/1353
Right now, if enum contains a null and the value does not match, an exception is thrown.
Also opened a PR to the upstream package https://github.com/atlassian/better-ajv-errors/pull/82


**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No


