### PR TITLE
 fix: use correct documentation urls 

### DIFF
--- a/src/rulesets/__tests__/reader.jest.test.ts
+++ b/src/rulesets/__tests__/reader.jest.test.ts
@@ -145,7 +145,7 @@ describe('Rulesets reader', () => {
           oasRules[name] = {
             ...rule,
             formats: expect.arrayContaining([expect.any(String)]),
-            documentationUrl: 'https://stoplight.io/p/docs/gh/stoplightio/spectral/docs/reference/openapi-rules.md',
+            documentationUrl: `https://meta.stoplight.io/docs/spectral/docs/reference/openapi-rules.md#${name}`,
             ...(rule.severity === void 0 && { severity: DiagnosticSeverity.Warning }),
             ...(rule.recommended === void 0 && { recommended: true }),
             then: expect.any(Object),
@@ -173,7 +173,7 @@ describe('Rulesets reader', () => {
             rules[name] = {
               ...rule,
               formats: expect.arrayContaining([expect.any(String)]),
-              documentationUrl: 'https://stoplight.io/p/docs/gh/stoplightio/spectral/docs/reference/openapi-rules.md',
+              documentationUrl: `https://meta.stoplight.io/docs/spectral/docs/reference/openapi-rules.md#${name}`,
               ...(rule.severity === undefined && { severity: DiagnosticSeverity.Warning }),
               ...(rule.recommended === false && { severity: -1 }),
               ...(rule.recommended === void 0 && { recommended: true }),
@@ -215,7 +215,7 @@ describe('Rulesets reader', () => {
             const formattedRule: IRule = {
               ...rule,
               formats: expect.arrayContaining([expect.any(String)]),
-              documentationUrl: 'https://stoplight.io/p/docs/gh/stoplightio/spectral/docs/reference/openapi-rules.md',
+              documentationUrl: `https://meta.stoplight.io/docs/spectral/docs/reference/openapi-rules.md#${name}`,
               ...(rule.severity === void 0 && { severity: DiagnosticSeverity.Warning }),
               ...(rule.recommended === false && { severity: -1 }),
               ...(rule.recommended === void 0 && { recommended: true }),
@@ -301,7 +301,7 @@ describe('Rulesets reader', () => {
       'rules.operation-success-response',
       {
         description: 'should be overridden',
-        documentationUrl: 'https://stoplight.io/p/docs/gh/stoplightio/spectral/docs/reference/openapi-rules.md',
+        documentationUrl: `https://meta.stoplight.io/docs/spectral/docs/reference/openapi-rules.md#operation-success-response`,
         given: '$.info',
         formats: expect.arrayContaining([expect.any(String)]),
         recommended: true,
@@ -312,7 +312,7 @@ describe('Rulesets reader', () => {
     );
   });
 
-  it('should persist disabled properties of extended rulesets', () => {
+  it('should persist disabled properties of extended rulesets', async () => {
     return expect(readRuleset(extendsOasWithOverrideRuleset)).resolves.toHaveProperty(
       'rules.oas2-operation-security-defined',
       {
@@ -321,7 +321,8 @@ describe('Rulesets reader', () => {
         formats: expect.arrayContaining([expect.any(String)]),
         severity: -1,
         description: 'Operation `security` values must match a scheme defined in the `securityDefinitions` object.',
-        documentationUrl: 'https://stoplight.io/p/docs/gh/stoplightio/spectral/docs/reference/openapi-rules.md',
+        documentationUrl:
+          'https://meta.stoplight.io/docs/spectral/docs/reference/openapi-rules.md#oas2-operation-security-defined',
         then: expect.any(Object),
         type: 'validation',
       },
@@ -944,7 +945,8 @@ describe('Rulesets reader', () => {
 
     expect(ruleset.rules).toStrictEqual({
       'foo-rule': {
-        documentationUrl: 'https://stoplight.io/p/docs/gh/stoplightio/spectral/docs/reference/openapi-rules.md',
+        documentationUrl:
+          'https://stoplight.io/p/docs/gh/stoplightio/spectral/docs/reference/openapi-rules.md#foo-rule',
         given: '',
         recommended: true,
         severity: DiagnosticSeverity.Warning,

--- a/src/rulesets/asyncapi/index.json
+++ b/src/rulesets/asyncapi/index.json
@@ -1,5 +1,5 @@
 {
-  "documentationUrl": "https://stoplight.io/p/docs/gh/stoplightio/spectral/docs/reference/asyncapi-rules.md",
+  "documentationUrl": "https://meta.stoplight.io/docs/spectral/docs/reference/asyncapi-rules.md",
   "formats": ["asyncapi2"],
   "functions": ["asyncApi2PayloadValidation"],
   "rules": {

--- a/src/rulesets/oas/index.json
+++ b/src/rulesets/oas/index.json
@@ -1,5 +1,5 @@
 {
-  "documentationUrl": "https://stoplight.io/p/docs/gh/stoplightio/spectral/docs/reference/openapi-rules.md",
+  "documentationUrl": "https://meta.stoplight.io/docs/spectral/docs/reference/openapi-rules.md",
   "formats": ["oas2", "oas3"],
   "functions": [
     "oasDocumentSchema",

--- a/src/rulesets/reader.ts
+++ b/src/rulesets/reader.ts
@@ -123,9 +123,9 @@ const createRulesetProcessor = (
       mergeRules(rules, ruleset.rules, severity === void 0 ? 'recommended' : severity);
 
       if (ruleset.documentationUrl !== void 0) {
-        for (const rule of Object.values(ruleset.rules)) {
+        for (const [name, rule] of Object.entries(ruleset.rules)) {
           if (isValidRule(rule) && rule.documentationUrl === void 0) {
-            rule.documentationUrl = ruleset.documentationUrl;
+            rule.documentationUrl = `${ruleset.documentationUrl}#${name}`;
           }
         }
       }


### PR DESCRIPTION
Needs #1358 

The documentation url we have is no longer correct.
We've already switched to workspaces.
There is also one minor tweak - hash is added automatically, so that consumers do not need to do it on their own.

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

