### PR TITLE
fix(ruleset): Allow single trailing slash for oas3 server url

### DIFF
--- a/src/rulesets/oas/__tests__/oas3-server-trailing-slash.ts
+++ b/src/rulesets/oas/__tests__/oas3-server-trailing-slash.ts
@@ -25,6 +25,19 @@ describe('oas3-server-trailing-slash', () => {
     expect(results.length).toEqual(0);
   });
 
+  test('validate a correct object with default value', async () => {
+    const results = await s.run({
+      openapi: '3.0.0',
+      paths: {},
+      servers: [
+        {
+          url: '/',
+        },
+      ],
+    });
+    expect(results.length).toEqual(0);
+  });
+
   test('return errors if server url ends with a slash', async () => {
     const results = await s.run({
       openapi: '3.0.0',

--- a/src/rulesets/oas/index.json
+++ b/src/rulesets/oas/index.json
@@ -569,7 +569,7 @@
       "then": {
         "function": "pattern",
         "functionOptions": {
-          "notMatch": "/$"
+          "notMatch": ".+/$"
         }
       }
     },

--- a/src/rulesets/oas/index.json
+++ b/src/rulesets/oas/index.json
@@ -569,7 +569,7 @@
       "then": {
         "function": "pattern",
         "functionOptions": {
-          "notMatch": ".+/$"
+          "notMatch": "./$"
         }
       }
     },


### PR DESCRIPTION
This PR makes a small modification to the `oas3-server-trailing-slash` rule to allow the url value to be a single slash.

According to the description of the `servers` field of an OpenAPI object in [the OpenAPI specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#oasDocument):

> the default value would be a Server Object with a url value of `/`

Since the default value for the `url` is a single slash (`/`), this should be considered a valid value and not generate a warning message.

**Checklist**

- [X] Tests added / updated
- [ ] Docs added / updated (NA)

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No
