### PR TITLE
build(installer): support for alpine linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
           else
             npm publish
           fi
-      - run: npx pkg . --targets linux,macos --out-path ./binaries
+      - run: npx pkg . --targets linux,macos,alpine --out-path ./binaries
       - persist_to_workspace:
           root: ./
           paths:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,6 +14,14 @@ if [ "$UNAME" = "Darwin" ] ; then
   FILENAME="spectral-macos"
 elif [ "$UNAME" = "Linux" ] ; then
   FILENAME="spectral-linux"
+  if [ -f /etc/os-release ]; then
+    # extract the value for KEY named "NAME"
+    DISTRO=$(sed -n -e 's/^NAME="\?\([^"]*\)"\?$/\1/p' /etc/os-release)
+    if [ "$DISTRO" = "Alpine Linux" ]; then
+      echo "Installing on Alpine Linux."
+      FILENAME="spectral"
+    fi
+  fi
 fi
 
 URL="https://github.com/stoplightio/spectral/releases/latest/download/${FILENAME}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,7 +19,7 @@ elif [ "$UNAME" = "Linux" ] ; then
     DISTRO=$(sed -n -e 's/^NAME="\?\([^"]*\)"\?$/\1/p' /etc/os-release)
     if [ "$DISTRO" = "Alpine Linux" ]; then
       echo "Installing on Alpine Linux."
-      FILENAME="spectral"
+      FILENAME="spectral-alpine"
     fi
   fi
 fi


### PR DESCRIPTION
Fixes #[1374](https://github.com/stoplightio/spectral/issues/1374).

**Checklist**

- [ ] Tests added / updated - N/A
- [ ] Docs added / updated - N/A

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Additional context**
Implemented the fix based on @DenialAdams suggestion
Tested on Alpine Linux container, need to install the following packages for spectral to work on alpine
```
apk add libstdc++
apk add libgcc
```