### PR TITLE
chore: drop support for Node 10.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,6 @@ workflows:
               os:
                 - linux
               node-version:
-                - "10.18"
                 - "12.9"
                 - "14.9"
       - test-browser

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "rulesets/*"
   ],
   "engines": {
-    "node": ">=10.18"
+    "node": ">=12"
   },
   "scripts": {
     "postinstall": "patch-package",


### PR DESCRIPTION
Node 10.x goes EOL in April 2021
Prism already requires >= 12

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [x] Yes
- [ ] No

