### PR TITLE
fix: duplicated-entry-in-enum complains about enum property in objects

### DIFF
--- a/src/rulesets/oas/__tests__/duplicated-entry-in-enum.ts
+++ b/src/rulesets/oas/__tests__/duplicated-entry-in-enum.ts
@@ -33,6 +33,31 @@ describe('duplicated-entry-in-enum', () => {
       expect(results).toEqual([]);
     });
 
+    test('does not report anything when enum is an object property', async () => {
+      const doc = {
+        openapi: '3.0.2',
+        components: {
+          schemas: {
+            schema: {
+              type: 'object',
+              properties: {
+                enum: {
+                  type: 'array',
+                  items: {
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const results = await s.run(doc);
+
+      expect(results).toEqual([]);
+    });
+
     test('identifies enum with duplicated entries', async () => {
       const doc = {
         swagger: '2.0',

--- a/src/rulesets/oas/index.json
+++ b/src/rulesets/oas/index.json
@@ -107,8 +107,17 @@
         "function": "schema",
         "functionOptions": {
           "schema": {
-            "type": "array",
-            "uniqueItems": true
+            "oneOf": [
+              {
+                "type": "array",
+                "uniqueItems": true
+              },
+              {
+                "not": {
+                  "type": "array"
+                }
+              }
+            ]
           }
         }
       }


### PR DESCRIPTION
Fixes #1571.

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated (not required?!)

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Additional context**

As it's very hard to come up with a correct given expression, it seems the easiest to simply allow everything that is not an array. This rule is to detect duplicate arrays, not check whether an enum is an array, so I think the workaround is fine.