### PR TITLE
chore: [CVE-2021-23337] Upgrade lodash to 4.17.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "expression-eval": "4.0.0",
     "fast-glob": "3.2.5",
     "jsonpath-plus": "5.0.3",
-    "lodash": "4.17.20",
+    "lodash": "4.17.21",
     "nanoid": "2.1.11",
     "nimma": "0.0.0",
     "node-fetch": "2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5774,12 +5774,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@4.17.20:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
-
-lodash@4.x, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
+lodash@4.17.21, lodash@4.x, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
**Checklist**

- [ ] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Screenshots**

![Screen Shot 2021-04-26 at 4 31 10 PM](https://user-images.githubusercontent.com/12589078/116148796-5cb84580-a6af-11eb-9bff-443196f57e46.png)

![Screen Shot 2021-04-26 at 4 33 26 PM](https://user-images.githubusercontent.com/12589078/116148804-5f1a9f80-a6af-11eb-947a-90df896425dc.png)


**Additional context**

[CVE-2021-23337](https://nvd.nist.gov/vuln/detail/CVE-2021-23337). Vulnerability in Lodash < 4.17.21, "Improper Neutralization of Special Elements used in a Command ('Command Injection')"

[Whitesource](https://www.whitesourcesoftware.com/open-source-security-lp/?utm_origin=ad&utm_from=Adwords&utm_pcampaign=fs.brand.us-ca.search&utm_gen=Searched%20Term:whitesource%20software&gclid=Cj0KCQjwyZmEBhCpARIsALIzmnLBjaw1i_YhWXADoeT0SCuxT2s8u0mvTeATJv3qGMGizg_1_KrtNOIaAhnPEALw_wcB) security tool is alerting this package as high risk due to this.
