### PR TITLE
feat: add option to pass a list of additional paths for resolving

### DIFF
--- a/docs/guides/2-cli.md
+++ b/docs/guides/2-cli.md
@@ -29,6 +29,7 @@ Other options include:
   --output, -o                 output to a file instead of stdout                                      [string]
   --resolver                   path to custom json-ref-resolver instance                               [string]
   --ruleset, -r                path/URL to a ruleset file                                              [string]
+  --paths, -p                  path from which custom functions `require` statements may be resolved   [string]
   --fail-severity, -F          results of this level or above will trigger a failure exit code
                                          [string] [choices: "error", "warn", "info", "hint"] [default: "error"]
   --display-only-failures, -D  only output results equal to or greater than --fail-severity

--- a/src/__tests__/spectral.test.ts
+++ b/src/__tests__/spectral.test.ts
@@ -67,6 +67,33 @@ describe('spectral', () => {
         }, {}),
       );
     });
+
+    test.each([
+      ['spectral:oas', oasRulesetRules],
+      ['spectral:asyncapi', asyncApiRulesetRules],
+    ])('should support loading "%s" built-in ruleset with additional paths', async (rulesetName, rules) => {
+      const s = new Spectral();
+      await s.loadRuleset(rulesetName, undefined, ['/path/one', '/path/two']);
+
+      expect(s.rules).toEqual(
+        expect.objectContaining(
+          Object.entries(rules).reduce<RunRuleCollection>((oasRules, [name, rule]) => {
+            oasRules[name] = expect.objectContaining({
+              name,
+              given: expect.anything(),
+              formats: expect.arrayContaining([expect.any(String)]),
+              enabled: expect.any(Boolean),
+              severity: expect.any(Number),
+              then: expect.any(Array),
+              message: rule.message ?? null,
+              description: rule.description ?? null,
+            });
+
+            return oasRules;
+          }, {}),
+        ),
+      );
+    });
   });
 
   describe('setRules & mergeRules', () => {

--- a/src/cli/commands/__tests__/lint.test.ts
+++ b/src/cli/commands/__tests__/lint.test.ts
@@ -145,6 +145,31 @@ describe('lint', () => {
     );
   });
 
+  it('calls lint with document and paths', async () => {
+    const doc = './__fixtures__/empty-oas2-document.json';
+    const path = '/absolute/path/example';
+    await run(`lint -p ${path} ${doc}`);
+    expect(lint).toBeCalledWith(
+      [doc],
+      expect.objectContaining({
+        paths: [path],
+      }),
+    );
+  });
+
+  it('calls lint with document and multiple paths', async () => {
+    const doc = './__fixtures__/empty-oas2-document.json';
+    const path1 = '/first/path';
+    const path2 = '/second/path';
+    await run(`lint --p ${path1} -p ${path2} ${doc}`);
+    expect(lint).toBeCalledWith(
+      [doc],
+      expect.objectContaining({
+        paths: [path1, path2],
+      }),
+    );
+  });
+
   it.each(['json', 'stylish'])('calls formatOutput with %s format', async format => {
     await run(`lint -f ${format} ./__fixtures__/empty-oas2-document.json`);
     await new Promise(resolve => void process.nextTick(resolve));

--- a/src/cli/commands/lint.ts
+++ b/src/cli/commands/lint.ts
@@ -81,6 +81,12 @@ const lintCommand: CommandModule = {
           type: 'string',
           coerce: toArray,
         },
+        paths: {
+          alias: 'p',
+          description: 'additional paths for resolving',
+          type: 'string',
+          coerce: toArray,
+        },
         'fail-severity': {
           alias: 'F',
           description: 'results of this level or above will trigger a failure exit code',
@@ -122,6 +128,7 @@ const lintCommand: CommandModule = {
       failSeverity,
       displayOnlyFailures,
       ruleset,
+      paths,
       format,
       output,
       encoding,
@@ -141,6 +148,7 @@ const lintCommand: CommandModule = {
       ignoreUnknownFormat,
       failOnUnmatchedGlobs,
       ruleset,
+      paths,
       ...pick<Partial<ILintConfig>, keyof ILintConfig>(config, ['verbose', 'quiet', 'resolver']),
     })
       .then(results => {

--- a/src/cli/services/linter/linter.ts
+++ b/src/cli/services/linter/linter.ts
@@ -20,7 +20,7 @@ export async function lint(documents: Array<number | string>, flags: ILintConfig
     agent: DEFAULT_REQUEST_OPTIONS.agent as Agent,
   });
 
-  spectral.setRuleset(ruleset);
+  spectral.setRuleset(ruleset, flags.paths);
 
   for (const [format, lookup, prettyName] of KNOWN_FORMATS) {
     spectral.registerFormat(format, document => {

--- a/src/ruleset/utils/__tests__/evaluators.jest.test.ts
+++ b/src/ruleset/utils/__tests__/evaluators.jest.test.ts
@@ -4,14 +4,15 @@ import { evaluateExport } from '../evaluators';
 describe('Code evaluators', () => {
   describe('Export evaluator', () => {
     it('supports require', () => {
-      expect(evaluateExport(`module.exports = require('./foo')`, path.join(__dirname, '__fixtures__/a.js'))()).toEqual(
-        'hello!',
-      );
+      expect(
+        evaluateExport(`module.exports = require('./foo')`, path.join(__dirname, '__fixtures__/a.js'), null)(),
+      ).toEqual('hello!');
 
       expect(
         evaluateExport(
           `module.exports = () => require('path').join('/', 'hello!')`,
           path.join(__dirname, '__fixtures__/a.js'),
+          [],
         )(),
       ).toEqual(require('path').join('/', 'hello!'));
 
@@ -19,8 +20,17 @@ describe('Code evaluators', () => {
         evaluateExport(
           `module.exports = () => require('@stoplight/path').join('/', 'hello!')`,
           path.join(__dirname, '__fixtures__/a.js'),
+          ['should/work/with/another/path', 'and/another'],
         )(),
       ).toEqual(path.join('/', 'hello!'));
+    });
+
+    it('supports requiring when must require be resolved from additional path', () => {
+      expect(
+        evaluateExport(`module.exports = require('foo')`, '@stoplight/spectral/rulesets/oas3/functions/example.js', [
+          path.join(__dirname, '__fixtures__'),
+        ])(),
+      ).toEqual('hello!');
     });
 
     it('supports require.resolve', () => {
@@ -29,13 +39,16 @@ describe('Code evaluators', () => {
           evaluateExport(
             `module.exports = () => require.resolve('./foo', { paths: ['${path.join(__dirname, '__fixtures__')}'] } )`,
             null,
+            null,
           )(),
         ),
       ).toEqual(path.join(__dirname, '__fixtures__/foo.js'));
     });
 
     it.each(['cache', 'extensions'])('exposes %s', member => {
-      expect(evaluateExport(`module.exports = () => require['${member}']`, null)()).toStrictEqual(require[member]);
+      expect(evaluateExport(`module.exports = () => require['${member}']`, null, null)()).toStrictEqual(
+        require[member],
+      );
     });
   });
 });

--- a/src/ruleset/utils/__tests__/evaluators.test.ts
+++ b/src/ruleset/utils/__tests__/evaluators.test.ts
@@ -3,68 +3,68 @@ import { evaluateExport, setFunctionContext } from '../evaluators';
 describe('Code evaluators', () => {
   describe('Export evaluator', () => {
     it('detects CJS default export', () => {
-      const exported = evaluateExport(`module.exports = function a(x, y) {}`, null);
+      const exported = evaluateExport(`module.exports = function a(x, y) {}`, null, null);
       expect(exported).toBeInstanceOf(Function);
       expect(exported).toHaveProperty('name', 'a');
       expect(exported).toHaveProperty('length', 2);
     });
 
     it('detects CJS-ES compatible default export', () => {
-      const exported = evaluateExport(`exports.default = function b(x, y) {}`, null);
+      const exported = evaluateExport(`exports.default = function b(x, y) {}`, null, null);
       expect(exported).toBeInstanceOf(Function);
       expect(exported).toHaveProperty('name', 'b');
       expect(exported).toHaveProperty('length', 2);
     });
 
     it('detects CJS-ES compatible default export variant #2', () => {
-      const exported = evaluateExport(`module.exports.default = function c(x, y, z) {}`, null);
+      const exported = evaluateExport(`module.exports.default = function c(x, y, z) {}`, null, null);
       expect(exported).toBeInstanceOf(Function);
       expect(exported).toHaveProperty('name', 'c');
       expect(exported).toHaveProperty('length', 3);
     });
 
     it('detects AMD export', () => {
-      const exported = evaluateExport(`define(['exports'], () => function d(x){} )`, null);
+      const exported = evaluateExport(`define(['exports'], () => function d(x){} )`, null, null);
       expect(exported).toBeInstanceOf(Function);
       expect(exported).toHaveProperty('name', 'd');
       expect(exported).toHaveProperty('length', 1);
     });
 
     it('detects anonymous AMD export', () => {
-      const exported = evaluateExport(`define(() => function d(x){} )`, null);
+      const exported = evaluateExport(`define(() => function d(x){} )`, null, null);
       expect(exported).toBeInstanceOf(Function);
       expect(exported).toHaveProperty('name', 'd');
       expect(exported).toHaveProperty('length', 1);
     });
 
     it('detects context-based export', () => {
-      const exported = evaluateExport(`this.returnExports = function e() {}`, null);
+      const exported = evaluateExport(`this.returnExports = function e() {}`, null, null);
       expect(exported).toBeInstanceOf(Function);
       expect(exported).toHaveProperty('name', 'e');
       expect(exported).toHaveProperty('length', 0);
     });
 
     it('detects context-based export', () => {
-      const exported = evaluateExport(`this.returnExports = function e() {}`, null);
+      const exported = evaluateExport(`this.returnExports = function e() {}`, null, null);
       expect(exported).toBeInstanceOf(Function);
       expect(exported).toHaveProperty('name', 'e');
       expect(exported).toHaveProperty('length', 0);
     });
 
     it('throws error if no default export can be found', () => {
-      expect(() => evaluateExport(`exports.a = function b(x, y) {}`, null)).toThrow();
+      expect(() => evaluateExport(`exports.a = function b(x, y) {}`, null, null)).toThrow();
     });
 
     it('throws error default export is not a function', () => {
-      expect(() => evaluateExport(`module.exports = 2`, null)).toThrow();
-      expect(() => evaluateExport(`this.returnExports = {}`, null)).toThrow();
+      expect(() => evaluateExport(`module.exports = 2`, null, null)).toThrow();
+      expect(() => evaluateExport(`this.returnExports = {}`, null, null)).toThrow();
     });
 
     describe('inject', () => {
       it('can expose any arbitrary value', () => {
         const fetch = jest.fn();
         const url = 'https://foo.bar';
-        const fn = evaluateExport(`module.exports = () => fetch(url, { headers })`, null, {
+        const fn = evaluateExport(`module.exports = () => fetch(url, { headers })`, null, null, {
           fetch,
           url,
           headers: {

--- a/src/spectral.ts
+++ b/src/spectral.ts
@@ -214,11 +214,11 @@ export class Spectral {
     Object.assign(this.exceptions, target);
   }
 
-  public async loadRuleset(uris: string[] | string, options?: IRulesetReadOptions): Promise<void> {
-    this.setRuleset(await readRuleset(Array.isArray(uris) ? uris : [uris], { agent: this.agent, ...options }));
+  public async loadRuleset(uris: string[] | string, options?: IRulesetReadOptions, paths?: string[]): Promise<void> {
+    this.setRuleset(await readRuleset(Array.isArray(uris) ? uris : [uris], { agent: this.agent, ...options }), paths);
   }
 
-  public setRuleset(ruleset: IRuleset): void {
+  public setRuleset(ruleset: IRuleset, paths: string[] | null = null): void {
     this.runtime.revoke();
 
     this.setRules(ruleset.rules);
@@ -241,6 +241,7 @@ export class Spectral {
             code,
             name,
             source,
+            paths,
             schema,
             inject: {
               fetch: request,

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -18,6 +18,7 @@ export interface ILintConfig {
   output?: string;
   resolver?: string;
   ruleset?: string[];
+  paths?: string[];
   ignoreUnknownFormat: boolean;
   failOnUnmatchedGlobs: boolean;
   verbose?: boolean;


### PR DESCRIPTION
**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Additional context**

Purpose:
- Allow additional paths from which Spectral may resolve `require`s in custom functions.

Changes:
- Add a `-p` option in Spectral, so users may provide the paths through the CLI.
- Add a `paths` parameter to `loadRuleset` to add this feature to the javascript API.
- Pass paths to `evaluators.proxyRequire` to use for resolving `require`s.

Tests:
- Additional paths helps resolve file locations  when otherwise not enough information
- `-p` works and data is passed to `lint`

Additional Considerations:
- May extend so the additional paths are used to resolve files in the http-and-file-resolver.

