### PR TITLE
chore(docker): build docker image in Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,14 +153,11 @@ jobs:
             echo "GIT_SHA=${GIT_SHA}";
             # Login to DockerHub
             echo $DOCKER_PASSWORD | docker login -u $DOCKER_USER --password-stdin
-            echo "CIRCLE_TAG=${CIRCLE_TAG}";
             DOCKER_BRANCH="${CIRCLE_BRANCH//\//-}";
             echo "DOCKER_BRANCH=${DOCKER_BRANCH}";
             if [[ -n "$DOCKER_BRANCH" ]]; then
               docker tag stoplight/spectral:${GIT_SHA} stoplight/spectral:${DOCKER_BRANCH};
             fi
-            echo "Setting a fake value for CIRCLE_TAG";
-            CIRCLE_TAG="0.0.0";
             if [[ -n "$CIRCLE_TAG" ]]; then
               FULL_VERSION="${CIRCLE_TAG/v/}";
               MINOR_VERSION="${FULL_VERSION/%.+([0-9])/}";
@@ -172,7 +169,7 @@ jobs:
               docker tag stoplight/spectral:${GIT_SHA} stoplight/spectral:${MINOR_VERSION};
               docker tag stoplight/spectral:${GIT_SHA} stoplight/spectral:${MAJOR_VERSION};
             fi
-            echo "Created tags:";
+            echo "Docker tags:";
             docker images stoplight/spectral --format="{{ .Tag }}";
             docker push stoplight/spectral:${GIT_SHA};
             if [[ -n "$DOCKER_BRANCH" ]]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
           paths:
             - binaries
 
-  build-docker:
+  release-docker:
     docker:
       - image: circleci/node:14
     steps:
@@ -231,12 +231,6 @@ workflows:
       - test-windows
       - test-browser
       - lint
-      - build-docker:
-         filters:
-            branches:
-              only:
-                - develop
-                - chore/can-we-build-docker-in-circle
 
   release:
     jobs:
@@ -252,7 +246,7 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
-      - build-docker:
+      - release-docker:
          filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,7 +234,9 @@ workflows:
       - build-docker:
          filters:
             branches:
-              only: /chore\/can-we-build-docker-in-circle/
+              only:
+                - develop
+                - chore/can-we-build-docker-in-circle
 
   release:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,43 @@ jobs:
           command: npm --no-git-tag-version --no-commit-hooks -f version from-git
       - run:
           name: docker build
-          command: docker build .
+          command: docker build . --tag stoplight/spectral:${CIRCLE_SHA1};
+      - run:
+          name: docker push
+          command: |
+            echo "CIRCLE_SHA1=${CIRCLE_SHA1}";
+            # Login to DockerHub
+            echo $DOCKER_PASSWORD | docker login -u $DOCKER_USER --password-stdin
+            echo "CIRCLE_TAG=${CIRCLE_TAG}";
+            DOCKER_BRANCH="${CIRCLE_BRANCH//\//-}";
+            echo "DOCKER_BRANCH=${DOCKER_BRANCH}";
+            if [[ -n "$DOCKER_BRANCH" ]]; then
+              docker tag stoplight/spectral:${CIRCLE_SHA1} stoplight/spectral:${DOCKER_BRANCH};
+            fi
+            echo "Setting a fake value for CIRCLE_TAG";
+            CIRCLE_TAG="0.0.0";
+            if [[ -n "$CIRCLE_TAG" ]]; then
+              FULL_VERSION="${CIRCLE_TAG/v/}";
+              MINOR_VERSION="${FULL_VERSION/%.+([0-9])/}";
+              MAJOR_VERSION="${MINOR_VERSION/%.+([0-9])/}";
+              echo "FULL_VERSION=$FULL_VERSION";
+              echo "MINOR_VERSION=$MINOR_VERSION";
+              echo "MAJOR_VERSION=$MAJOR_VERSION";
+              docker tag stoplight/spectral:${CIRCLE_SHA1} stoplight/spectral:${FULL_VERSION};
+              docker tag stoplight/spectral:${CIRCLE_SHA1} stoplight/spectral:${MINOR_VERSION};
+              docker tag stoplight/spectral:${CIRCLE_SHA1} stoplight/spectral:${MAJOR_VERSION};
+            fi
+            echo "Created tags:";
+            docker images stoplight/spectral --format="{{ .Tag }}";
+            docker push stoplight/spectral:${CIRCLE_SHA1};
+            if [[ -n "$DOCKER_BRANCH" ]]; then
+              docker push stoplight/spectral:${DOCKER_BRANCH};
+            fi
+            if [[ -n "$CIRCLE_TAG" ]]; then
+              docker push stoplight/spectral:${FULL_VERSION} \
+                          stoplight/spectral:${MINOR_VERSION} \
+                          stoplight/spectral:${MAJOR_VERSION};
+            fi
 
   release:
     docker:
@@ -190,7 +226,10 @@ workflows:
       - test-windows
       - test-browser
       - lint
-      - build-docker
+      - build-docker:
+         filters:
+            branches:
+              only: /chore\/can-we-build-docker-in-circle/
 
   release:
     jobs:
@@ -201,6 +240,12 @@ workflows:
             tags:
               only: /^v.*/
       - build-windows-binary:
+         filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+      - build-docker:
          filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,7 @@ jobs:
       - run:
           name: docker push
           command: |
+            shopt -s extglob
             echo "CIRCLE_SHA1=${CIRCLE_SHA1}";
             # Login to DockerHub
             echo $DOCKER_PASSWORD | docker login -u $DOCKER_USER --password-stdin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,6 +128,18 @@ jobs:
           paths:
             - binaries
 
+  build-docker:
+    docker:
+      - image: circleci/node:14
+    steps:
+      - checkout
+      - run:
+          name: set version in package.json
+          command: npm --no-git-tag-version --no-commit-hooks -f version from-git
+      - run:
+          name: docker build
+          command: docker build .
+
   release:
     docker:
       - image: circleci/node:14
@@ -175,6 +187,7 @@ workflows:
       - test-windows
       - test-browser
       - lint
+      - build-docker
 
   release:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,6 +154,9 @@ jobs:
             # Login to DockerHub
             echo $DOCKER_PASSWORD | docker login -u $DOCKER_USER --password-stdin
             DOCKER_BRANCH="${CIRCLE_BRANCH//\//-}";
+            if [[ "$DOCKER_BRANCH" == "master" ]]; then
+              DOCKER_BRANCH="latest";
+            fi
             echo "DOCKER_BRANCH=${DOCKER_BRANCH}";
             if [[ -n "$DOCKER_BRANCH" ]]; then
               docker tag stoplight/spectral:${GIT_SHA} stoplight/spectral:${DOCKER_BRANCH};

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,9 @@ jobs:
       - image: circleci/node:14
     steps:
       - checkout
+      - setup_remote_docker:
+          version: 20.10.2
+          docker_layer_caching: true
       - run:
           name: set version in package.json
           command: npm --no-git-tag-version --no-commit-hooks -f version from-git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,19 +141,23 @@ jobs:
           command: npm --no-git-tag-version --no-commit-hooks -f version from-git
       - run:
           name: docker build
-          command: docker build . --tag stoplight/spectral:${CIRCLE_SHA1};
+          command: |
+            GIT_SHA=${CIRCLE_SHA1:0:7}
+            echo "GIT_SHA=${GIT_SHA}";
+            docker build . --tag stoplight/spectral:${GIT_SHA};
       - run:
           name: docker push
           command: |
             shopt -s extglob
-            echo "CIRCLE_SHA1=${CIRCLE_SHA1}";
+            GIT_SHA=${CIRCLE_SHA1:0:7}
+            echo "GIT_SHA=${GIT_SHA}";
             # Login to DockerHub
             echo $DOCKER_PASSWORD | docker login -u $DOCKER_USER --password-stdin
             echo "CIRCLE_TAG=${CIRCLE_TAG}";
             DOCKER_BRANCH="${CIRCLE_BRANCH//\//-}";
             echo "DOCKER_BRANCH=${DOCKER_BRANCH}";
             if [[ -n "$DOCKER_BRANCH" ]]; then
-              docker tag stoplight/spectral:${CIRCLE_SHA1} stoplight/spectral:${DOCKER_BRANCH};
+              docker tag stoplight/spectral:${GIT_SHA} stoplight/spectral:${DOCKER_BRANCH};
             fi
             echo "Setting a fake value for CIRCLE_TAG";
             CIRCLE_TAG="0.0.0";
@@ -164,13 +168,13 @@ jobs:
               echo "FULL_VERSION=$FULL_VERSION";
               echo "MINOR_VERSION=$MINOR_VERSION";
               echo "MAJOR_VERSION=$MAJOR_VERSION";
-              docker tag stoplight/spectral:${CIRCLE_SHA1} stoplight/spectral:${FULL_VERSION};
-              docker tag stoplight/spectral:${CIRCLE_SHA1} stoplight/spectral:${MINOR_VERSION};
-              docker tag stoplight/spectral:${CIRCLE_SHA1} stoplight/spectral:${MAJOR_VERSION};
+              docker tag stoplight/spectral:${GIT_SHA} stoplight/spectral:${FULL_VERSION};
+              docker tag stoplight/spectral:${GIT_SHA} stoplight/spectral:${MINOR_VERSION};
+              docker tag stoplight/spectral:${GIT_SHA} stoplight/spectral:${MAJOR_VERSION};
             fi
             echo "Created tags:";
             docker images stoplight/spectral --format="{{ .Tag }}";
-            docker push stoplight/spectral:${CIRCLE_SHA1};
+            docker push stoplight/spectral:${GIT_SHA};
             if [[ -n "$DOCKER_BRANCH" ]]; then
               docker push stoplight/spectral:${DOCKER_BRANCH};
             fi


### PR DESCRIPTION
Moves the docker image builds from Docker Hubs CI back to Circle CI, because apparently this:

![image](https://user-images.githubusercontent.com/587740/118041169-78bf1680-b340-11eb-8694-89b825609970.png)

is an [ancient issue they don't care enough to fix](https://github.com/docker/hub-feedback/issues/1777#issuecomment-835426290). I've tried everything I can think of (turning off build caches, making a new branch with a different name) and no, Docker Hub is just incapable of running "git clone" on an empty directory, as incredibly logical as that behavior would seem for generating reliable, immutable builds. And no they don't let you override the git clone step in their hooks and stuff.

This is an impediment from us releasing v6 Docker images, because presumably to release v6 we'll merge `develop` into the `master` branch. At which point DockerHub will give up and say "nope, I'm broken on master branch sorry too bad".

This is basically a reversal of https://github.com/stoplightio/spectral/pull/343 although I kept Vincenzo's dockerfile improvements.

**Does this PR introduce a breaking change?**

No

