### PR TITLE
chore(deps): bump jsonpath-plus from 5.0.3 to 5.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "fast-glob": "3.2.5",
     "json-schema-migrate": "2.0.0",
     "json-schema-traverse": "1.0.0",
-    "jsonpath-plus": "5.0.3",
+    "jsonpath-plus": "5.0.7",
     "lodash": "4.17.21",
     "nanoid": "2.1.11",
     "nimma": "0.0.0",

--- a/src/rulesets/oas/index.json
+++ b/src/rulesets/oas/index.json
@@ -340,7 +340,7 @@
       "message": "{{error}}",
       "recommended": true,
       "type": "validation",
-      "given": "$..[?(@.enum && @.type)]",
+      "given": "$..[?(@ && @.enum && @.type)]",
       "then": {
         "function": "typedEnum"
       }

--- a/src/runner/runner.ts
+++ b/src/runner/runner.ts
@@ -59,8 +59,6 @@ const runRule = (
           lintNode(
             context,
             {
-              // @ts-expect-error
-              // this is needed due to broken typings in jsonpath-plus (JSONPathClass.toPathArray is correct from typings point of view, but JSONPathClass is not exported, so it fails at runtime)
               path: JSONPath.toPathArray(result.path),
               value: result.value,
             },

--- a/src/runner/utils/getLintTargets.ts
+++ b/src/runner/utils/getLintTargets.ts
@@ -7,10 +7,6 @@ export interface ILintTarget {
   value: unknown;
 }
 
-const { toPathArray } = JSONPath as typeof JSONPath & {
-  toPathArray(path: string): string[];
-};
-
 export const getLintTargets = (targetValue: unknown, field: Optional<string>): ILintTarget[] => {
   const targets: ILintTarget[] = [];
 
@@ -29,7 +25,7 @@ export const getLintTargets = (targetValue: unknown, field: Optional<string>): I
         resultType: 'all',
         callback(result) {
           targets.push({
-            path: toPathArray(result.path).slice(1),
+            path: JSONPath.toPathArray(result.path).slice(1),
             value: result.value,
           });
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5652,10 +5652,10 @@ jsonparse@^1.2.0:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
-jsonpath-plus@5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-5.0.3.tgz#502f0fc953d0f92428b2c2357c0c6809a803ec36"
-  integrity sha512-RDvpzY21CmKTvEfxuGqQmPqRTuzNOim7L+/TcsdBM8jguI5ok38t0p2eKr9GAsVkazrTyylpMZV/hKSQCWqx9g==
+jsonpath-plus@5.0.7:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-5.0.7.tgz#95fb437ebb69c67595208711a69c95735cbff45b"
+  integrity sha512-7TS6wsiw1s2UMK/A6nA4n0aUJuirCVhJ87nWX5je5MPOl0z5VTr2qs7nMP8NZ2ed3rlt6kePTqddgVPE9F0i0w==
 
 jsonpointer@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Needed for stoplightio/platform-internal#6228 to reduce the diff of https://github.com/stoplightio/spectral/pull/1630

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

