### PR TITLE
fix(oas): unevaluated x- extensions

### DIFF
--- a/src/rulesets/oas/schemas/3.1.json
+++ b/src/rulesets/oas/schemas/3.1.json
@@ -1169,7 +1169,9 @@
     },
     "specification-extensions": {
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+          "type": ["number", "string", "null", "boolean", "array", "object"]
+        }
       }
     },
     "examples": {

--- a/test-harness/scenarios/oas3.1/petstore.scenario
+++ b/test-harness/scenarios/oas3.1/petstore.scenario
@@ -20,6 +20,7 @@ paths:
         schema:
           type: integer
     get:
+      x-internal: true
       summary: Get User Info by User ID
       responses:
         '200':


### PR DESCRIPTION
Fixes https://github.com/stoplightio/spectral/issues/1636

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

Temporary workaround until https://github.com/ajv-validator/ajv/issues/1625 is fixed.
This PR makes it so the property gets evaluated ("type" keyword), but since every type is allowed, the behavior is almost identical to a booleanish true schema.
