### PR TITLE
docs: asyncapi spec url returns 404

### DIFF
--- a/docs/getting-started/5-asyncapi.md
+++ b/docs/getting-started/5-asyncapi.md
@@ -1,5 +1,5 @@
 # AsyncAPI Support
 
-Spectral is a generic linter, but a lot of effort has been put in to making sure [AsyncAPI v2](https://www.asyncapi.com/docs/specifications/2.0.0/) is well supported.
+Spectral is a generic linter, but a lot of effort has been put in to making sure [AsyncAPI v2](https://www.asyncapi.com/docs/specifications/v2.0.0) is well supported.
 
 Run Spectral against a document without specifying a ruleset will trigger an auto-detect, where Spectral will look to see if `asyncapi: 2.0.0` is in the root of the document. If it finds it, it will load `spectral:asyncapi`, which is documented in our [Reference > AsyncAPI Rules](../reference/asyncapi-rules.md).

--- a/docs/reference/asyncapi-rules.md
+++ b/docs/reference/asyncapi-rules.md
@@ -1,6 +1,6 @@
 # AsyncAPI Rules
 
-Spectral has a built-in "asyncapi" ruleset for the [AsyncAPI Specification](https://www.asyncapi.com/docs/specifications/2.0.0/).
+Spectral has a built-in "asyncapi" ruleset for the [AsyncAPI Specification](https://www.asyncapi.com/docs/specifications/v2.0.0).
 
 In your ruleset file you can add `extends: "spectral:asyncapi"` and you'll get all of the following rules applied.
 


### PR DESCRIPTION
The current page yields 404 making the markdown-link-checker check fail in all PR

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No


