### PR TITLE
feat(cli): implement --stdin-filepath flag

### DIFF
--- a/docs/guides/2-cli.md
+++ b/docs/guides/2-cli.md
@@ -21,23 +21,23 @@ spectral lint ./reference/**/*.oas*.{json,yml,yaml}
 Other options include:
 
 ```text
-  --version                    Show version number                                                         [boolean]
-  --help                       Show help                                                                   [boolean]
-  -e, --encoding               text encoding to use
-      [string] [choices: "utf8", "ascii", "utf-8", "utf16le", "ucs2", "ucs-2", "base64", "latin1"] [default: "utf8"]
-  --format, -f                 formatter to use for outputting results
-           [string] [choices: "json", "stylish", "junit", "html", "text", "teamcity", "pretty"] [default: "stylish"]
-  --output, -o                 output to a file instead of stdout                                           [string]
-  --resolver                   path to custom json-ref-resolver instance                                    [string]
-  --ruleset, -r                path/URL to a ruleset file                                                   [string]
-  --fail-severity, -F          results of this level or above will trigger a failure exit code
-                                         [string] [choices: "error", "warn", "info", "hint"] [default: "error"]
-  --display-only-failures, -D  only output results equal to or greater than --fail-severity
-                                                                                          [boolean] [default: false]
-  --ignore-unknown-format      do not warn about unmatched formats                        [boolean] [default: false]
-  --fail-on-unmatched-globs    fail on unmatched glob patterns                            [boolean] [default: false]
-  --verbose, -v                increase verbosity                                                          [boolean]
-  --quiet, -q                  no logging - output only                                                    [boolean]
+      --version                  Show version number                                                                       [boolean]
+      --help                     Show help                                                                                 [boolean]
+  -e, --encoding                 text encoding to use
+                      [string] [choices: "utf8", "ascii", "utf-8", "utf16le", "ucs2", "ucs-2", "base64", "latin1"] [default: "utf8"]
+  -f, --format                   formatter to use for outputting results
+                           [string] [choices: "json", "stylish", "junit", "html", "text", "teamcity", "pretty"] [default: "stylish"]
+  -o, --output                   output to a file instead of stdout                                                         [string]
+      --stdin-filepath           path to a file to pretend that stdin comes from                                            [string]
+      --resolver                 path to custom json-ref-resolver instance                                                  [string]
+  -r, --ruleset                  path/URL to a ruleset file                                                                 [string]
+  -F, --fail-severity            results of this level or above will trigger a failure exit code
+                                                              [string] [choices: "error", "warn", "info", "hint"] [default: "error"]
+  -D, --display-only-failures    only output results equal to or greater than --fail-severity             [boolean] [default: false]
+      --ignore-unknown-format    do not warn about unmatched formats                                      [boolean] [default: false]
+      --fail-on-unmatched-globs  fail on unmatched glob patterns                                          [boolean] [default: false]
+  -v, --verbose                  increase verbosity                                                                        [boolean]
+  -q, --quiet                    no logging - output only                                                                  [boolean]
 ```
 
 The Spectral CLI supports loading documents as YAML or JSON, and validation of OpenAPI v2/v3 documents via our built-in ruleset.
@@ -57,7 +57,7 @@ Spectral has a few different error severities: `error`, `warn`, `info` and `hint
 
 The default behavior can be modified with the `--fail-severity=` option. Setting fail severity to `--fail-severity=info` would return a failure status code of 1 for any info results or higher. Using `--fail-severity=warn` will cause a failure status code for errors or warnings.
 
-Changing the fail severity will not effect output. To change what results Spectral CLI prints to the screen, add the `--display-only-failures` switch (or just `-D` for short). This will strip out any results which are below the specified fail severity.
+Changing the fail severity will not affect output. To change what results Spectral CLI prints to the screen, add the `--display-only-failures` switch (or just `-D` for short). This will strip out any results which are below the specified fail severity.
 
 ## Proxying
 
@@ -83,4 +83,4 @@ module.exports = new Resolver({
 });
 ```
 
-You can learn more about `$ref` resolving in the [JS section](./3-javascript.md#using-custom-resolver).
+You can learn more about `$ref` resolving in the [JS section](./3-javascript.md#using-a-custom-resolver).

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -65,6 +65,10 @@ const lintCommand: CommandModule = {
           description: 'output to a file instead of stdout',
           type: 'string',
         },
+        'stdin-filepath': {
+          description: 'path to a file to pretend that stdin comes from',
+          type: 'string',
+        },
         resolver: {
           description: 'path to custom json-ref-resolver instance',
           type: 'string',
@@ -115,6 +119,7 @@ const lintCommand: CommandModule = {
       failSeverity,
       displayOnlyFailures,
       ruleset,
+      stdinFilepath,
       format,
       output,
       encoding,
@@ -134,6 +139,7 @@ const lintCommand: CommandModule = {
       ignoreUnknownFormat,
       failOnUnmatchedGlobs,
       ruleset,
+      stdinFilepath,
       ...pick<Partial<ILintConfig>, keyof ILintConfig>(config, ['verbose', 'quiet', 'resolver']),
     })
       .then(results => {

--- a/packages/cli/src/services/config.ts
+++ b/packages/cli/src/services/config.ts
@@ -18,6 +18,7 @@ export interface ILintConfig {
   output?: string;
   resolver?: string;
   ruleset?: string;
+  stdinFilepath?: string;
   ignoreUnknownFormat: boolean;
   failOnUnmatchedGlobs: boolean;
   verbose?: boolean;

--- a/packages/cli/src/services/linter/linter.ts
+++ b/packages/cli/src/services/linter/linter.ts
@@ -38,7 +38,7 @@ export async function lint(documents: Array<number | string>, flags: ILintConfig
       console.info(`Linting ${targetUri}`);
     }
 
-    const document = await createDocument(targetUri, { encoding: flags.encoding });
+    const document = await createDocument(targetUri, { encoding: flags.encoding }, flags.stdinFilepath ?? '<STDIN>');
 
     results.push(
       ...(await spectral.run(document, {
@@ -53,10 +53,11 @@ export async function lint(documents: Array<number | string>, flags: ILintConfig
 const createDocument = async (
   identifier: string | number,
   opts: IFileReadOptions,
+  source: string,
 ): Promise<Document<unknown, Parsers.YamlParserResult<unknown>>> => {
   if (typeof identifier === 'string') {
     return new Document(await readParsable(identifier, opts), Parsers.Yaml, identifier);
   }
 
-  return new Document(await readFileDescriptor(identifier, opts), Parsers.Yaml, '<STDIN>');
+  return new Document(await readFileDescriptor(identifier, opts), Parsers.Yaml, source);
 };

--- a/test-harness/scenarios/help-no-document.scenario
+++ b/test-harness/scenarios/help-no-document.scenario
@@ -22,6 +22,7 @@ Options:
   -e, --encoding                 text encoding to use  [string] [choices: "utf8", "ascii", "utf-8", "utf16le", "ucs2", "ucs-2", "base64", "latin1"] [default: "utf8"]
   -f, --format                   formatter to use for outputting results  [string] [choices: "json", "stylish", "junit", "html", "text", "teamcity", "pretty"] [default: "stylish"]
   -o, --output                   output to a file instead of stdout  [string]
+      --stdin-filepath           path to a file to pretend that stdin comes from  [string]
       --resolver                 path to custom json-ref-resolver instance  [string]
   -r, --ruleset                  path/URL to a ruleset file  [string]
   -F, --fail-severity            results of this level or above will trigger a failure exit code  [string] [choices: "error", "warn", "info", "hint"] [default: "error"]

--- a/test-harness/scenarios/stdin-filepath.scenario
+++ b/test-harness/scenarios/stdin-filepath.scenario
@@ -1,0 +1,46 @@
+====test====
+Respects stdin filepath
+====asset:ruleset.json====
+{
+  "rules": {
+    "title-matches-stoplight": {
+      "message": "Info must contain Stoplight",
+      "given": "$.title",
+      "then": {
+        "function": "pattern",
+        "functionOptions": {
+          "match": "Stoplight"
+        }
+      }
+    },
+    "description-matches-stoplight": {
+      "message": "Info must contain Stoplight",
+      "given": "$.description",
+      "then": {
+        "function": "pattern",
+        "functionOptions": {
+          "match": "Stoplight"
+        }
+      }
+    }
+  },
+  "overrides": [
+    {
+      "files": ["**/*.yaml"],
+      "rules": {
+        "title-matches-stoplight": "error"
+      }
+    }
+  ]
+}
+====asset:document.yaml====
+description: Test
+title: Oops
+====command====
+cat {asset:document.yaml} | {bin} lint --ruleset {asset:ruleset.json} --stdin-filepath={asset:document.yaml}
+====stdout====
+{asset:document.yaml}
+ 1:14  warning  description-matches-stoplight  Info must contain Stoplight  description
+  2:8    error  title-matches-stoplight        Info must contain Stoplight  title
+
+✖ 2 problems (1 error, 1 warning, 0 infos, 0 hints)

--- a/test-harness/scenarios/strict-options.scenario
+++ b/test-harness/scenarios/strict-options.scenario
@@ -22,6 +22,7 @@ Options:
   -e, --encoding                 text encoding to use  [string] [choices: "utf8", "ascii", "utf-8", "utf16le", "ucs2", "ucs-2", "base64", "latin1"] [default: "utf8"]
   -f, --format                   formatter to use for outputting results  [string] [choices: "json", "stylish", "junit", "html", "text", "teamcity", "pretty"] [default: "stylish"]
   -o, --output                   output to a file instead of stdout  [string]
+      --stdin-filepath           path to a file to pretend that stdin comes from  [string]
       --resolver                 path to custom json-ref-resolver instance  [string]
   -r, --ruleset                  path/URL to a ruleset file  [string]
   -F, --fail-severity            results of this level or above will trigger a failure exit code  [string] [choices: "error", "warn", "info", "hint"] [default: "error"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
       "@stoplight/spectral-parsers": ["packages/parsers/src/index.ts"],
       "@stoplight/spectral-ref-resolver": ["packages/ref-resolver/src/index.ts"],
       "@stoplight/spectral-runtime": ["packages/runtime/src/index.ts"],
+      "@stoplight/spectral-ruleset-migrator": ["packages/ruleset-migrator/src/index.ts"],
       "@stoplight/spectral-rulesets": ["packages/rulesets/src/index.ts"]
     },
     "moduleResolution": "node",


### PR DESCRIPTION
Closes https://github.com/stoplightio/spectral/issues/1001

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No


**Additional context**

A low-hanging fruit.

We follow ESLint & Prettier here.

- ESLint
```
Using stdin:
  --stdin                         Lint code provided on <STDIN> - default: false
  --stdin-filename String         Specify filename to process STDIN as
```

- Prettier
```
  --stdin-filepath <path>  Path to the file to pretend that stdin comes from.
```