### PR TITLE
feat(ruleset-migrator): overridable fetch

### DIFF
--- a/packages/ruleset-migrator/package.json
+++ b/packages/ruleset-migrator/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@stoplight/spectral-core": "^1.1.0",
     "@stoplight/spectral-rulesets": "^1.1.0",
+    "fetch-mock": "^9.11.0",
     "json-schema-to-typescript": "^10.1.4",
     "memfs": "^3.2.2",
     "prettier": "^2.3.2"

--- a/packages/ruleset-migrator/src/transformers/extends.ts
+++ b/packages/ruleset-migrator/src/transformers/extends.ts
@@ -31,7 +31,7 @@ async function processExtend(
   const existingCwd = ctx.cwd;
   try {
     ctx.cwd = path.dirname(filepath);
-    return await process(await ctx.read(filepath, ctx.opts.fs), ctx.hooks);
+    return await process(await ctx.read(filepath, ctx.opts.fs, ctx.opts.fetch), ctx.hooks);
   } finally {
     ctx.cwd = existingCwd;
   }

--- a/packages/ruleset-migrator/src/types.ts
+++ b/packages/ruleset-migrator/src/types.ts
@@ -1,6 +1,10 @@
+/// <reference lib="dom" />
+
 import type { Tree, Scope } from './tree';
 import type { ExpressionKind } from 'ast-types/gen/kinds';
 import { Ruleset } from './validation/types';
+
+export type Fetch = Window['fetch'] | typeof import('@stoplight/spectral-runtime').fetch;
 
 export type MigrationOptions = {
   fs: {
@@ -8,6 +12,7 @@ export type MigrationOptions = {
       readFile: typeof import('fs').promises.readFile;
     };
   };
+  fetch?: Fetch;
   npmRegistry?: string;
   format?: 'esm' | 'commonjs';
   scope?: Scope;
@@ -22,8 +27,11 @@ export type Transformer = (ctx: TransformerCtx) => void;
 
 export type TransformerCtx = {
   readonly tree: Tree;
-  readonly opts: MigrationOptions;
+  readonly opts: MigrationOptions & {
+    scope: Scope;
+    fetch: Fetch;
+  };
   readonly hooks: Set<Hook>;
   cwd: string;
-  read(filepath: string, fs: MigrationOptions['fs']): Promise<Ruleset>;
+  read(filepath: string, fs: MigrationOptions['fs'], fetch: Fetch): Promise<Ruleset>;
 };


### PR DESCRIPTION
Fixes Will's issue with injecting Auth into requests for shared style guides. (It's yalced into https://github.com/stoplightio/platform-internal/pull/7323)

**Checklist**

- [x] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

> If indicated yes above, please describe the breaking change(s).
>
> **Remove this quote before creating the PR.**

**Additional context**

@P0lip wrote the code, I just made the PR. So that @P0lip can approve and merge his own code.
