### PR TITLE
fix(functions): schema should respect "auto" dialect

### DIFF
--- a/packages/functions/src/__tests__/schema.test.ts
+++ b/packages/functions/src/__tests__/schema.test.ts
@@ -14,12 +14,15 @@ describe('Core Functions / Schema', () => {
       exclusiveMaximum: true,
     };
 
-    expect(await runSchema(2, { schema })).toEqual([
+    const result = await runSchema(2, { schema });
+    expect(result).toStrictEqual([
       {
         message: 'Number must be < 2',
         path: [],
       },
     ]);
+
+    expect(await runSchema(2, { schema, dialect: 'auto' })).toStrictEqual(result);
   });
 
   it('validates draft 6', async () => {
@@ -28,12 +31,15 @@ describe('Core Functions / Schema', () => {
       type: 'string',
     };
 
-    expect(await runSchema(2, { schema })).toEqual([
+    const result = await runSchema(2, { schema });
+    expect(result).toEqual([
       {
         message: 'Value type must be string',
         path: [],
       },
     ]);
+
+    expect(await runSchema(2, { schema, dialect: 'auto' })).toStrictEqual(result);
   });
 
   describe('validates falsy values such as', () => {
@@ -389,6 +395,13 @@ describe('Core Functions / Schema', () => {
       { schema: { type: 'string' }, dialect: 'auto' },
       { schema: { type: 'string' }, allErrors: true },
       { schema: { type: 'string' }, dialect: 'draft2019-09', allErrors: false },
+      {
+        schema: { type: 'string' },
+        dialect: 'draft2019-09',
+        prepareResults() {
+          /* no-op */
+        },
+      },
     ])('given valid %p options, should not throw', async opts => {
       expect(await runSchema('', opts)).toBeInstanceOf(Array);
     });

--- a/packages/functions/src/schema/index.ts
+++ b/packages/functions/src/schema/index.ts
@@ -25,11 +25,13 @@ export default createRulesetFunction<unknown, Options>(
         },
         dialect: {
           enum: ['auto', 'draft4', 'draft6', 'draft7', 'draft2019-09', 'draft2020-12'],
+          default: 'auto',
         },
         allErrors: {
           type: 'boolean',
+          default: false,
         },
-        prepareResults: {},
+        prepareResults: true,
       },
       required: ['schema'],
       type: 'object',
@@ -56,7 +58,9 @@ export default createRulesetFunction<unknown, Options>(
 
     try {
       let validator;
-      const dialect = opts?.dialect ?? detectDialect(schemaObj) ?? 'draft7';
+      const dialect =
+        (opts.dialect === void 0 || opts.dialect === 'auto' ? detectDialect(schemaObj) : opts?.dialect) ?? 'draft7';
+
       if (dialect === 'draft4' || dialect === 'draft6') {
         schemaObj = JSON.parse(JSON.stringify(schemaObj)) as Record<string, unknown>;
         schemaObj.$schema = 'http://json-schema.org/draft-07/schema#';


### PR DESCRIPTION
Currently when you pass "auto" we don't run `detectDialect` function, so nothing useful happens.

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
