### PR TITLE
fix(rulesets): oasSchema not using correct dialect for OAS 3.1

### DIFF
--- a/packages/rulesets/package.json
+++ b/packages/rulesets/package.json
@@ -20,9 +20,9 @@
   "dependencies": {
     "@stoplight/better-ajv-errors": "0.2.0",
     "@stoplight/json": "3.15.0",
-    "@stoplight/spectral-core": "^1.1.0",
-    "@stoplight/spectral-formats": "^1.0.0",
-    "@stoplight/spectral-functions": "^1.0.0",
+    "@stoplight/spectral-core": "^1.3.0",
+    "@stoplight/spectral-formats": "^1.0.1",
+    "@stoplight/spectral-functions": "^1.1.2",
     "@stoplight/types": "^12.3.0",
     "@types/json-schema": "^7.0.7",
     "ajv": "~8.6.0",

--- a/packages/rulesets/src/oas/functions/__tests__/oasSchema.test.ts
+++ b/packages/rulesets/src/oas/functions/__tests__/oasSchema.test.ts
@@ -1,4 +1,4 @@
-import { oas2, oas3 } from '@stoplight/spectral-formats';
+import { oas2, oas3, oas3_0, oas3_1 } from '@stoplight/spectral-formats';
 import { DeepPartial } from '@stoplight/types';
 import oasSchema from '../../functions/oasSchema';
 import { createWithRules } from '../../__tests__/__helpers__/tester';
@@ -56,9 +56,9 @@ describe('oasSchema', () => {
     });
   });
 
-  test('given OAS3, supports nullable', () => {
+  test('given OAS 3.0, supports nullable', () => {
     const document = {
-      formats: new Set([oas3]),
+      formats: new Set([oas3, oas3_0]),
     };
 
     const testSchema = {
@@ -99,6 +99,26 @@ describe('oasSchema', () => {
         },
       },
     });
+  });
+
+  test('given OAS 3.1, supports numeric exclusiveMinimum & exclusiveMaximum', () => {
+    const document = {
+      formats: new Set([oas3, oas3_1]),
+    };
+
+    const testSchema = {
+      type: 'number',
+      exclusiveMinimum: 1,
+    };
+
+    expect(runSchema(1, testSchema, { document })).toEqual([
+      {
+        message: 'Number must be > 1',
+        path: [],
+      },
+    ]);
+
+    expect(runSchema(1.5, testSchema, { document })).toEqual([]);
   });
 
   test('should remove all redundant ajv errors', async () => {


### PR DESCRIPTION
Fixes https://github.com/stoplightio/spectral/issues/1752

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

