### PR TITLE
fix(functions): schema fn should allow redundant escapes

### DIFF
--- a/packages/functions/src/__tests__/schema.test.ts
+++ b/packages/functions/src/__tests__/schema.test.ts
@@ -42,6 +42,34 @@ describe('Core Functions / Schema', () => {
     expect(await runSchema(2, { schema, dialect: 'auto' })).toStrictEqual(result);
   });
 
+  it('allows redundant escapes', async () => {
+    let schema = {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'string',
+      pattern: '[\\-_]', // this one is good and would work with unicodeRegExp: true
+    };
+
+    expect(await runSchema(2, { schema })).toEqual([
+      {
+        message: 'Value type must be string',
+        path: [],
+      },
+    ]);
+
+    schema = {
+      $schema: 'http://json-schema.org/draft-06/schema#',
+      type: 'string',
+      pattern: '[\\_-]', // the escape here is redundant
+    };
+
+    expect(await runSchema(2, { schema })).toEqual([
+      {
+        message: 'Value type must be string',
+        path: [],
+      },
+    ]);
+  });
+
   describe('validates falsy values such as', () => {
     it('empty string', async () => {
       const schema: JSONSchema = {

--- a/packages/functions/src/schema/ajv.ts
+++ b/packages/functions/src/schema/ajv.ts
@@ -23,7 +23,15 @@ const logger = {
 };
 
 function createAjvInstance(Ajv: typeof AjvCore, allErrors: boolean): AjvCore {
-  const ajv = new Ajv({ allErrors, meta: true, messages: true, strict: false, allowUnionTypes: true, logger });
+  const ajv = new Ajv({
+    allErrors,
+    meta: true,
+    messages: true,
+    strict: false,
+    allowUnionTypes: true,
+    logger,
+    unicodeRegExp: false,
+  });
   addFormats(ajv);
   if (allErrors) {
     ajvErrors(ajv);


### PR DESCRIPTION
Fixes #1782 

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No


**Additional context**

This is not a bug in Ajv or anything, it's just how the unicode flag works.
