### PR TITLE
fix(ruleset-migrator): npmRegistry allowed for CJS output

### DIFF
--- a/packages/ruleset-migrator/package.json
+++ b/packages/ruleset-migrator/package.json
@@ -21,11 +21,11 @@
     "url": "https://github.com/stoplightio/spectral.git"
   },
   "dependencies": {
-    "@stoplight/json": "3.15.0",
-    "@stoplight/ordered-object-literal": "^1.0.2",
+    "@stoplight/json": "3.17.0",
+    "@stoplight/ordered-object-literal": "1.0.2",
     "@stoplight/path": "1.3.2",
     "@stoplight/spectral-functions": "^1.0.0",
-    "@stoplight/spectral-runtime": "*",
+    "@stoplight/spectral-runtime": "^1.1.0",
     "@stoplight/types": "12.3.0",
     "@stoplight/yaml": "4.2.2",
     "@types/node": "*",

--- a/packages/ruleset-migrator/src/__tests__/ruleset.test.ts
+++ b/packages/ruleset-migrator/src/__tests__/ruleset.test.ts
@@ -245,5 +245,19 @@ export default {
 };
 `);
     });
+
+    it('given commonjs output format, should be unsupported', async () => {
+      await expect(
+        migrateRuleset(
+          path.join(cwd, 'custom-npm-provider-custom-functions.json'),
+          // @ts-expect-error: npmRegistry not accepted
+          {
+            format: 'commonjs',
+            fs: fs as any,
+            npmRegistry: 'https://unpkg.com/',
+          },
+        ),
+      ).rejects.toThrowError("'npmRegistry' option must not be used with commonjs output format.");
+    });
   });
 });

--- a/packages/ruleset-migrator/src/tree/index.ts
+++ b/packages/ruleset-migrator/src/tree/index.ts
@@ -33,6 +33,9 @@ export class Tree {
     this.#cwd = cwd;
     this.#npmRegistry = npmRegistry ?? null;
     this.#module = format === 'commonjs' ? commonjs : esm;
+    if (format === 'commonjs' && this.#npmRegistry !== null) {
+      throw new Error(`'npmRegistry' option must not be used with commonjs output format.`);
+    }
   }
 
   addImport(specifier: string, source: string, _default = false): namedTypes.Identifier {

--- a/packages/ruleset-migrator/src/types.ts
+++ b/packages/ruleset-migrator/src/types.ts
@@ -13,9 +13,16 @@ export type MigrationOptions = {
     };
   };
   fetch?: Fetch;
-  npmRegistry?: string;
-  format?: 'esm' | 'commonjs';
-};
+} & (
+  | {
+      format?: 'esm';
+      npmRegistry?: string;
+    }
+  | {
+      format?: 'commonjs';
+      npmRegistry?: never;
+    }
+);
 
 export type Hook = [
   pattern: RegExp,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1679,7 +1679,7 @@
     tslib "^2.1.0"
     urijs "^1.19.5"
 
-"@stoplight/json@3.15.0", "@stoplight/json@^3.10.2", "@stoplight/json@^3.15.0":
+"@stoplight/json@3.15.0":
   version "3.15.0"
   resolved "https://registry.yarnpkg.com/@stoplight/json/-/json-3.15.0.tgz#e7c2919aaa12dc4dafb43d4da71e29d101106f34"
   integrity sha512-FxdmBaZyt6FZVN8F/GaGzevLxjkW1gLHC5cPeb4slMM8BIXCxKluIkGLzmb4bnkk2+4gPaYj75V28U6s0WNrbQ==
@@ -1690,6 +1690,17 @@
     lodash "^4.17.15"
     safe-stable-stringify "^1.1"
 
+"@stoplight/json@3.17.0", "@stoplight/json@^3.10.2", "@stoplight/json@^3.15.0":
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/json/-/json-3.17.0.tgz#9d864b63b9c6398c7cecae1340225b15953cac74"
+  integrity sha512-WW0z2bb0D4t8FTl+zNTCu46J8lEOsrUhBPgwEYQ3Ri2Y0MiRE4U1/9ZV8Ki+pIJznZgY9i42bbFwOBxyZn5/6w==
+  dependencies:
+    "@stoplight/ordered-object-literal" "^1.0.2"
+    "@stoplight/types" "^12.3.0"
+    jsonc-parser "~2.2.1"
+    lodash "^4.17.21"
+    safe-stable-stringify "^1.1"
+
 "@stoplight/lifecycle@2.3.2":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@stoplight/lifecycle/-/lifecycle-2.3.2.tgz#d61dff9ba20648241432e2daaef547214dc8976e"
@@ -1697,7 +1708,7 @@
   dependencies:
     wolfy87-eventemitter "~5.2.8"
 
-"@stoplight/ordered-object-literal@^1.0.1", "@stoplight/ordered-object-literal@^1.0.2":
+"@stoplight/ordered-object-literal@1.0.2", "@stoplight/ordered-object-literal@^1.0.1", "@stoplight/ordered-object-literal@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@stoplight/ordered-object-literal/-/ordered-object-literal-1.0.2.tgz#2a88a5ebc8b68b54837ac9a9ae7b779cdd862062"
   integrity sha512-0ZMS/9sNU3kVo/6RF3eAv7MK9DY8WLjiVJB/tVyfF2lhr2R4kqh534jZ0PlrFB9CRXrdndzn1DbX6ihKZXft2w==


### PR DESCRIPTION
For https://github.com/stoplightio/platform-internal/issues/7847
 
**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

