### PR TITLE
perf(functions): lazy Ajv initialization

### DIFF
--- a/packages/functions/src/schema/ajv.ts
+++ b/packages/functions/src/schema/ajv.ts
@@ -45,9 +45,18 @@ function createAjvInstance(Ajv: typeof AjvCore, allErrors: boolean): AjvCore {
 }
 
 function createAjvInstances(Ajv: typeof AjvCore): { default: AjvCore; allErrors: AjvCore } {
+  let _default: AjvCore;
+  let _allErrors: AjvCore;
+
   return {
-    default: createAjvInstance(Ajv, false),
-    allErrors: createAjvInstance(Ajv, true),
+    get default(): AjvCore {
+      _default ??= createAjvInstance(Ajv, false);
+      return _default;
+    },
+    get allErrors(): AjvCore {
+      _allErrors ??= createAjvInstance(Ajv, true);
+      return _allErrors;
+    },
   };
 }
 


### PR DESCRIPTION
Although not a big deal for programmatic usage of Spectral where the initialization time doesn't play a huge role, this simple change shoved a bit over 100ms for `spectral lint <document>`, as in the vast majority of cases we tend to make use of a single draft.

![image](https://user-images.githubusercontent.com/9273484/132998734-c7310057-d704-449c-840c-073d7ab8f3d5.png)


**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

