### PR TITLE
chore(core): update nimma

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,7 +252,7 @@ workflows:
               node-version:
                 - "12.21"
                 - lts
-                - current
+                - "16.8" # see https://github.com/nodejs/node/issues/40030, fixed in 16.9.1, but cimg/node:current is still at 16.9.0
       - test-windows
       - test-browser
       - lint
@@ -305,7 +305,7 @@ workflows:
               node-version:
                 - "12.21"
                 - lts
-                - current
+                - "16.8"
           requires:
             - lint
       - test-windows:

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@stoplight/better-ajv-errors": "0.2.0",
-    "@stoplight/json": "3.15.0",
+    "@stoplight/json": "3.17.0",
     "@stoplight/lifecycle": "2.3.2",
     "@stoplight/path": "1.3.2",
     "@stoplight/spectral-parsers": "^1.0.0",
@@ -40,8 +40,8 @@
     "lodash": "~4.17.21",
     "lodash.topath": "^4.5.2",
     "minimatch": "3.0.4",
-    "nimma": "0.1.1",
-    "tslib": "~2.3.0"
+    "nimma": "0.1.3",
+    "tslib": "^2.3.0"
   },
   "devDependencies": {
     "@stoplight/spectral-formats": "*",

--- a/packages/core/src/__tests__/linter.test.ts
+++ b/packages/core/src/__tests__/linter.test.ts
@@ -52,6 +52,40 @@ describe('linter', () => {
     return expect(spectral.run('123')).resolves.toEqual([]);
   });
 
+  test('given @ in the property key, should still lint as normal', () => {
+    spectral.setRuleset({
+      rules: {
+        example: {
+          given: '$.properties[*]~',
+          message: 'Key must contains letters only',
+          then: {
+            function: pattern,
+            functionOptions: {
+              match: '^[a-z]+$',
+            },
+          },
+        },
+      },
+    });
+
+    return expect(
+      spectral.run({
+        properties: {
+          '@foo': true,
+          foo: true,
+        },
+      }),
+    ).resolves.toEqual([
+      {
+        code: 'example',
+        message: 'Key must contains letters only',
+        path: ['properties', '@foo'],
+        range: expect.any(Object),
+        severity: 1,
+      },
+    ]);
+  });
+
   test('given failing JSON Path expression, should refuse to lint', async () => {
     spectral.setRuleset({
       rules: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7442,10 +7442,10 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-nimma@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/nimma/-/nimma-0.1.1.tgz#da96d3ec8802b133aed6cf8109c1613c648cc7a1"
-  integrity sha512-mYdfYSmKa9FoKfza0KtPxaAD/WF0DhitMEkr+4nq9scNSlwiBrn/a3aR7wHVgXGI20lfxyNUUVPHKasXYXLuyg==
+nimma@0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/nimma/-/nimma-0.1.3.tgz#30c2093d9dab7b0516f9d0c041e69ad9e58b4fdc"
+  integrity sha512-HSxAD97kPH1uODkAkHejrSaFpKfT9ZqiwSoK7jCu04IcaZMPKSYwQHZF1w2OQa9imD7WKxo36eea88QlLlqL2w==
   dependencies:
     astring "^1.7.5"
   optionalDependencies:
@@ -10009,7 +10009,7 @@ tslib@^1.14.1, tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.1, tslib@^2.2.0, tslib@^2.3.0, tslib@^2.3.1, tslib@~2.3.0:
+tslib@^2.0.1, tslib@^2.2.0, tslib@^2.3.0, tslib@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==


### PR DESCRIPTION
Here's the whole diff https://github.com/P0lip/nimma/compare/0.1.1...0.1.3
A list of commits interesting from Spectral's point of view:
https://github.com/P0lip/nimma/commit/a6ffabe10a5cb28048f72f0d52fdfb00d2a90fb3
https://github.com/P0lip/nimma/commit/22105d360ff9b9a87a9962b73150ea866e09e0cc
https://github.com/P0lip/nimma/commit/43bf38685bd029da0458e1db00c09db3799a71ce
https://github.com/P0lip/nimma/commit/8598021f80272b9087210b423fd65ff154a515ca
https://github.com/P0lip/nimma/commit/4f772655c7f96768bf2bee621729527c4934953d
https://github.com/P0lip/nimma/commit/d32d4cadca519f844a22f8a26562c38117b3e54c

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Additional context**

I set up some simple [REPL](https://nimma.rozek.tech/) where one can check out the code live