### PR TITLE
fix(ruleset-migrator): nested local dependencies not resolved correctly

### DIFF
--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-8/assets/ruleset.yaml
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-8/assets/ruleset.yaml
@@ -1,0 +1,9 @@
+extends:
+  - ./shared/ruleset-2.yaml
+  - ./shared/ruleset-3.yaml
+rules:
+  my-rule:
+    message: ruleset
+    given: $
+    then:
+      function: truthy

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-8/assets/shared/ruleset-2.yaml
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-8/assets/shared/ruleset-2.yaml
@@ -1,0 +1,6 @@
+rules:
+  my-rule:
+    message: ruleset 2
+    given: $
+    then:
+      function: falsy

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-8/assets/shared/ruleset-3.yaml
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-8/assets/shared/ruleset-3.yaml
@@ -1,0 +1,8 @@
+functions:
+  - pascalCase
+rules:
+  my-rule:
+    message: ruleset 3
+    given: $
+    then:
+      function: pascalCase

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-8/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-8/output.cjs
@@ -1,0 +1,44 @@
+const { truthy: truthy, falsy: falsy } = require('@stoplight/spectral-functions');
+const pascalCase = _interopDefault(require('/.tmp/spectral/extends-variant-8/assets/shared/functions/pascalCase.js'));
+module.exports = {
+  extends: [
+    {
+      extends: [
+        {
+          rules: {
+            "my-rule": {
+              message: "ruleset 2",
+              given: "$",
+              then: {
+                function: falsy,
+              },
+            },
+          },
+        },
+        {
+          rules: {
+            "my-rule": {
+              message: "ruleset 3",
+              given: "$",
+              then: {
+                function: pascalCase,
+              },
+            },
+          },
+        },
+      ],
+      rules: {
+        "my-rule": {
+          message: "ruleset",
+          given: "$",
+          then: {
+            function: truthy,
+          },
+        },
+      },
+    },
+  ],
+};
+function _interopDefault(ex) {
+  return ex && typeof ex === "object" && "default" in ex ? ex["default"] : ex;
+}

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-8/output.mjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-8/output.mjs
@@ -1,0 +1,41 @@
+import { truthy, falsy } from "@stoplight/spectral-functions";
+import pascalCase from "/.tmp/spectral/extends-variant-8/assets/shared/functions/pascalCase.js";
+export default {
+  extends: [
+    {
+      extends: [
+        {
+          rules: {
+            'my-rule': {
+              message: 'ruleset 2',
+              given: '$',
+              then: {
+                function: falsy,
+              },
+            },
+          },
+        },
+        {
+          rules: {
+            'my-rule': {
+              message: 'ruleset 3',
+              given: '$',
+              then: {
+                function: pascalCase,
+              },
+            },
+          },
+        },
+      ],
+      rules: {
+        'my-rule': {
+          message: 'ruleset',
+          given: '$',
+          then: {
+            function: truthy,
+          },
+        },
+      },
+    },
+  ],
+};

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-8/ruleset.yaml
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-8/ruleset.yaml
@@ -1,0 +1,2 @@
+extends:
+  - ./assets/ruleset.yaml

--- a/packages/ruleset-migrator/src/__tests__/ruleset.test.ts
+++ b/packages/ruleset-migrator/src/__tests__/ruleset.test.ts
@@ -246,6 +246,43 @@ export default {
 `);
     });
 
+    it('should not apply to custom functions living outside of cwd', async () => {
+      await fs.promises.writeFile(
+        path.join(cwd, 'custom-npm-provider-custom-functions.json'),
+        JSON.stringify({
+          functionsDir: '../fns',
+          functions: ['customFunction'],
+          rules: {
+            rule: {
+              then: {
+                given: '$',
+                function: 'customFunction',
+              },
+            },
+          },
+        }),
+      );
+
+      expect(
+        await migrateRuleset(path.join(cwd, 'custom-npm-provider-custom-functions.json'), {
+          format: 'esm',
+          fs: fs as any,
+          npmRegistry: 'https://unpkg.com/',
+        }),
+      ).toEqual(`import customFunction from "/.tmp/fns/customFunction.js";
+export default {
+  "rules": {
+    "rule": {
+      "then": {
+        "given": "$",
+        "function": customFunction
+      }
+    }
+  }
+};
+`);
+    });
+
     it('given commonjs output format, should be unsupported', async () => {
       await expect(
         migrateRuleset(

--- a/packages/ruleset-migrator/src/index.ts
+++ b/packages/ruleset-migrator/src/index.ts
@@ -31,7 +31,6 @@ export async function migrateRuleset(filepath: string, opts: MigrationOptions): 
   const { fs, fetch = defaultFetch, format, npmRegistry } = opts;
   const cwd = dirname(filepath);
   const tree = new Tree({
-    cwd,
     format,
     npmRegistry,
     scope: new Scope(),

--- a/packages/ruleset-migrator/src/transformers/extends.ts
+++ b/packages/ruleset-migrator/src/transformers/extends.ts
@@ -22,13 +22,13 @@ async function processExtend(
     return ctx.tree.addImport(REPLACEMENTS[name], '@stoplight/spectral-rulesets');
   }
 
-  const filepath = ctx.tree.resolveModule(name);
+  const existingCwd = ctx.cwd;
+  const filepath = ctx.tree.resolveModule(name, existingCwd);
 
   if (KNOWN_JS_EXTS.test(path.extname(filepath))) {
     return ctx.tree.addImport(`${path.basename(filepath, true)}_${path.extname(filepath)}`, filepath, true);
   }
 
-  const existingCwd = ctx.cwd;
   const scope = ctx.tree.scope;
   try {
     ctx.cwd = path.dirname(filepath);

--- a/packages/ruleset-migrator/src/transformers/functions.ts
+++ b/packages/ruleset-migrator/src/transformers/functions.ts
@@ -13,7 +13,9 @@ const transformer: Transformer = function (ctx) {
       const { functionsDir, functions } = ruleset;
 
       if (Array.isArray(functions) && functions.length > 0) {
-        ruleset.functions = functions.map(fn => path.join(ctx.cwd, functionsDir ?? 'functions', `${fn}.js`));
+        ruleset.functions = functions.map(fn =>
+          ctx.tree.resolveModule(`${fn}.js`, path.join(ctx.cwd, functionsDir ?? 'functions')),
+        );
         delete ruleset.functionsDir;
       }
     },


### PR DESCRIPTION
Fixes #1861 

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No



**Additional context**


I had to update `packages/ruleset-migrator/scripts/generate-test-fixtures.ts` to ensure the nested assets are populated into our memfs instance.
