### PR TITLE
chore(repo): bump @stoplight/better-ajv-errors from 0.2.0 to 1.0.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {},
   "dependencies": {
-    "@stoplight/better-ajv-errors": "0.2.0",
+    "@stoplight/better-ajv-errors": "1.0.1",
     "@stoplight/json": "3.17.0",
     "@stoplight/lifecycle": "2.3.2",
     "@stoplight/path": "1.3.2",

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -19,7 +19,7 @@
     "node": ">=12"
   },
   "dependencies": {
-    "@stoplight/better-ajv-errors": "0.2.0",
+    "@stoplight/better-ajv-errors": "1.0.1",
     "@stoplight/json": "3.17.0",
     "@stoplight/spectral-core": "^1.1.0",
     "@stoplight/spectral-formats": "^1.0.0",

--- a/packages/rulesets/package.json
+++ b/packages/rulesets/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/stoplightio/spectral.git"
   },
   "dependencies": {
-    "@stoplight/better-ajv-errors": "0.2.0",
+    "@stoplight/better-ajv-errors": "1.0.1",
     "@stoplight/json": "3.17.0",
     "@stoplight/spectral-core": "^1.3.0",
     "@stoplight/spectral-formats": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1387,12 +1387,12 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@stoplight/better-ajv-errors@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/better-ajv-errors/-/better-ajv-errors-0.2.0.tgz#86aa8072dece24e2aa7e132f889390c18ca1ca6d"
-  integrity sha512-3vBbXBDplfeOGS2rT4PyOwJ1K0A7/NqlVXI6sJ/XchQlrMXFMKtj4qExBLxr4M9ZiiESu48uhbdS3Nx8A0S+ZA==
+"@stoplight/better-ajv-errors@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stoplight/better-ajv-errors/-/better-ajv-errors-1.0.1.tgz#b2756fabc951e85fc6e047edbcae2e72d900d4cb"
+  integrity sha512-rgxT+ZMeZbYRiOLNk6Oy6e/Ig1iQKo0IL8v/Y9E/0FewzgtkGs/p5dMeUpIFZXWj3RZaEPmfL9yh0oUEmNXZjg==
   dependencies:
-    jsonpointer "^4.0.1"
+    jsonpointer "^5.0.0"
     leven "^3.1.0"
 
 "@stoplight/json-ref-readers@1.2.2":
@@ -5132,10 +5132,10 @@ jsonpath-plus@6.0.1, jsonpath-plus@^6.0.1:
   resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-6.0.1.tgz#9a3e16cedadfab07a3d8dc4e8cd5df4ed8f49c4d"
   integrity sha512-EvGovdvau6FyLexFH2OeXfIITlgIbgZoAZe3usiySeaIDm5QS+A10DKNpaPBBqqRSZr2HN6HVNXxtwUAr2apEw==
 
-jsonpointer@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
-  integrity sha1-T9kss04OnbPInIYi7PUfm5eMbLk=
+jsonpointer@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-5.0.0.tgz#f802669a524ec4805fa7389eadbc9921d5dc8072"
+  integrity sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==
 
 karma-chrome-launcher@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
Fixes https://github.com/stoplightio/spectral/issues/1947

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Additional Context**
https://github.com/stoplightio/better-ajv-errors/compare/0.2.0...1.0.1
