### PR TITLE
docs(repo): make shell command in README actually work

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you intend to lint an OpenAPI or AsyncAPI document, we have a few predefined 
 To reference them, you can run the following command:
 
 ```bash
-echo '{\n\t"extends": ["spectral:oas", "spectral:asyncapi"]\n}' > .spectral.json
+printf '{\n  "extends": ["spectral:oas", "spectral:asyncapi"]\n}\n' > .spectral.json
 ```
 
 **Lint**


### PR DESCRIPTION
Use printf to actually interpret the escape sequence correctly

**Checklist**

- [ ] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

