### PR TITLE
fix(ruleset-migrator): order of functions property should not matter

### DIFF
--- a/packages/ruleset-migrator/package.json
+++ b/packages/ruleset-migrator/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/stoplightio/spectral.git"
   },
   "dependencies": {
-    "@stoplight/json": "3.17.0",
+    "@stoplight/json": "~3.17.0",
     "@stoplight/ordered-object-literal": "1.0.2",
     "@stoplight/path": "1.3.2",
     "@stoplight/spectral-functions": "^1.0.0",

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-4/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-4/output.cjs
@@ -1,13 +1,13 @@
-const { oas3, oas3_1 } = require('@stoplight/spectral-formats');
-const oas3$0 = _interopDefault(require('/.tmp/spectral/functions-variant-4/functions/oas3.js'));
+const { oas3: oas3$0, oas3_1 } = require('@stoplight/spectral-formats');
+const oas3 = _interopDefault(require('/.tmp/spectral/functions-variant-4/functions/oas3.js'));
 module.exports = {
-  formats: [oas3, oas3_1],
+  formats: [oas3$0, oas3_1],
   rules: {
     rule: {
       given: '$',
       then: [
         {
-          function: oas3$0,
+          function: oas3,
         },
       ],
     },

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-4/output.mjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-4/output.mjs
@@ -1,13 +1,13 @@
-import { oas3, oas3_1 } from '@stoplight/spectral-formats';
-import oas3$0 from '/.tmp/spectral/functions-variant-4/functions/oas3.js';
+import { oas3 as oas3$0, oas3_1 } from '@stoplight/spectral-formats';
+import oas3 from '/.tmp/spectral/functions-variant-4/functions/oas3.js';
 export default {
-  formats: [oas3, oas3_1],
+  formats: [oas3$0, oas3_1],
   rules: {
     rule: {
       given: '$',
       then: [
         {
-          function: oas3$0,
+          function: oas3,
         },
       ],
     },

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-5/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-5/output.cjs
@@ -1,0 +1,14 @@
+const donothing = _interopDefault(require('/.tmp/spectral/functions-variant-5/custom-functions/do-nothing.js'));
+module.exports = {
+  rules: {
+    rule: {
+      given: '$',
+      then: {
+        function: donothing,
+      },
+    },
+  },
+};
+function _interopDefault(ex) {
+  return ex && typeof ex === 'object' && 'default' in ex ? ex['default'] : ex;
+}

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-5/output.mjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-5/output.mjs
@@ -1,0 +1,11 @@
+import donothing from '/.tmp/spectral/functions-variant-5/custom-functions/do-nothing.js';
+export default {
+  rules: {
+    rule: {
+      given: '$',
+      then: {
+        function: donothing,
+      },
+    },
+  },
+};

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-5/ruleset.yaml
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-5/ruleset.yaml
@@ -1,0 +1,8 @@
+rules:
+  rule:
+    given: $
+    then:
+      function: do-nothing
+functionsDir: custom-functions
+functions:
+  - do-nothing

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-6/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-6/output.cjs
@@ -1,0 +1,11 @@
+const { truthy } = require('@stoplight/spectral-functions');
+module.exports = {
+  rules: {
+    rule: {
+      given: '$',
+      then: {
+        function: truthy,
+      },
+    },
+  },
+};

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-6/output.mjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-6/output.mjs
@@ -1,0 +1,11 @@
+import { truthy } from '@stoplight/spectral-functions';
+export default {
+  rules: {
+    rule: {
+      given: '$',
+      then: {
+        function: truthy,
+      },
+    },
+  },
+};

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-6/ruleset.yaml
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-6/ruleset.yaml
@@ -1,0 +1,6 @@
+rules:
+  rule:
+    given: $
+    then:
+      function: truthy
+functionsDir: custom-fns

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-7/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-7/output.cjs
@@ -1,0 +1,10 @@
+module.exports = {
+  rules: {
+    rule: {
+      given: '$',
+      then: {
+        function: void 0,
+      },
+    },
+  },
+};

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-7/output.mjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-7/output.mjs
@@ -1,0 +1,10 @@
+export default {
+  rules: {
+    rule: {
+      given: '$',
+      then: {
+        function: void 0,
+      },
+    },
+  },
+};

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-7/ruleset.yaml
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-7/ruleset.yaml
@@ -1,0 +1,5 @@
+rules:
+  rule:
+    given: $
+    then:
+      function: do-nothing

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/rules-variant-1/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/rules-variant-1/output.cjs
@@ -1,4 +1,5 @@
 const { oas2 } = require('@stoplight/spectral-formats');
+const { truthy } = require('@stoplight/spectral-functions');
 module.exports = {
   rules: {
     'oas3-schema': 'error',
@@ -11,7 +12,7 @@ module.exports = {
       given:
         "$.paths.*[?( @property === 'get' || @property === 'put' || @property === 'post' || @property === 'delete' || @property === 'options' || @property === 'head' || @property === 'patch' || @property === 'trace' )]",
       then: {
-        function: void 0,
+        function: truthy,
         functionOptions: null,
       },
     },

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/rules-variant-1/output.mjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/rules-variant-1/output.mjs
@@ -1,4 +1,5 @@
 import { oas2 } from '@stoplight/spectral-formats';
+import { truthy } from '@stoplight/spectral-functions';
 export default {
   rules: {
     'oas3-schema': 'error',
@@ -11,7 +12,7 @@ export default {
       given:
         "$.paths.*[?( @property === 'get' || @property === 'put' || @property === 'post' || @property === 'delete' || @property === 'options' || @property === 'head' || @property === 'patch' || @property === 'trace' )]",
       then: {
-        function: void 0,
+        function: truthy,
         functionOptions: null,
       },
     },

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/rules-variant-1/ruleset.yaml
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/rules-variant-1/ruleset.yaml
@@ -12,5 +12,5 @@ rules:
       "$.paths.*[?( @property === 'get' || @property === 'put' || @property === 'post' || @property === 'delete' ||
       @property === 'options' || @property === 'head' || @property === 'patch' || @property === 'trace' )]"
     then:
-      function: oasOpFormDataConsumeCheck
+      function: truthy
       functionOptions: null

--- a/packages/ruleset-migrator/src/index.ts
+++ b/packages/ruleset-migrator/src/index.ts
@@ -50,7 +50,7 @@ export async function migrateRuleset(filepath: string, opts: MigrationOptions): 
   };
 
   for (const transformer of transformers) {
-    transformer((...hook) => void ctx.hooks.add(hook));
+    transformer(ctx.hooks);
   }
 
   tree.ruleset = await process(ruleset, ctx);

--- a/packages/ruleset-migrator/src/transformers/except.ts
+++ b/packages/ruleset-migrator/src/transformers/except.ts
@@ -3,27 +3,24 @@ import { Ruleset } from '../validation/types';
 
 export { transformer as default };
 
-const transformer: Transformer = function (ctx) {
-  ctx.hooks.add([
-    /^$/,
-    (_ruleset): void => {
-      const ruleset = _ruleset as Ruleset;
-      const { except } = ruleset;
+const transformer: Transformer = function (registerHook) {
+  registerHook(/^$/, (_ruleset): void => {
+    const ruleset = _ruleset as Ruleset;
+    const { except } = ruleset;
 
-      if (except === void 0) return;
+    if (except === void 0) return;
 
-      delete ruleset.except;
+    delete ruleset.except;
 
-      const overrides = (ruleset.overrides ??= []) as unknown[];
-      overrides.push(
-        ...Object.keys(except).map(pattern => ({
-          files: [pattern.startsWith('#') ? `**${pattern}` : pattern],
-          rules: except[pattern].reduce((rules, rule) => {
-            rules[rule] = 'off';
-            return rules;
-          }, {}),
-        })),
-      );
-    },
-  ]);
+    const overrides = (ruleset.overrides ??= []) as unknown[];
+    overrides.push(
+      ...Object.keys(except).map(pattern => ({
+        files: [pattern.startsWith('#') ? `**${pattern}` : pattern],
+        rules: except[pattern].reduce((rules, rule) => {
+          rules[rule] = 'off';
+          return rules;
+        }, {}),
+      })),
+    );
+  });
 };

--- a/packages/ruleset-migrator/src/transformers/except.ts
+++ b/packages/ruleset-migrator/src/transformers/except.ts
@@ -3,24 +3,27 @@ import { Ruleset } from '../validation/types';
 
 export { transformer as default };
 
-const transformer: Transformer = function (registerHook) {
-  registerHook(/^$/, (_ruleset): void => {
-    const ruleset = _ruleset as Ruleset;
-    const { except } = ruleset;
+const transformer: Transformer = function (hooks) {
+  hooks.add([
+    /^$/,
+    (_ruleset): void => {
+      const ruleset = _ruleset as Ruleset;
+      const { except } = ruleset;
 
-    if (except === void 0) return;
+      if (except === void 0) return;
 
-    delete ruleset.except;
+      delete ruleset.except;
 
-    const overrides = (ruleset.overrides ??= []) as unknown[];
-    overrides.push(
-      ...Object.keys(except).map(pattern => ({
-        files: [pattern.startsWith('#') ? `**${pattern}` : pattern],
-        rules: except[pattern].reduce((rules, rule) => {
-          rules[rule] = 'off';
-          return rules;
-        }, {}),
-      })),
-    );
-  });
+      const overrides = (ruleset.overrides ??= []) as unknown[];
+      overrides.push(
+        ...Object.keys(except).map(pattern => ({
+          files: [pattern.startsWith('#') ? `**${pattern}` : pattern],
+          rules: except[pattern].reduce((rules, rule) => {
+            rules[rule] = 'off';
+            return rules;
+          }, {}),
+        })),
+      );
+    },
+  ]);
 };

--- a/packages/ruleset-migrator/src/transformers/extends.ts
+++ b/packages/ruleset-migrator/src/transformers/extends.ts
@@ -35,8 +35,8 @@ async function processExtend(
   });
 }
 
-const transformer: Transformer = function (registerHook) {
-  registerHook(
+const transformer: Transformer = function (hooks) {
+  hooks.add([
     /^(\/overrides\/\d+)?\/extends$/,
     async (input, ctx): Promise<namedTypes.ArrayExpression | namedTypes.ObjectExpression | namedTypes.Identifier> => {
       const _extends = input as Ruleset['extends'];
@@ -58,5 +58,5 @@ const transformer: Transformer = function (registerHook) {
 
       return b.arrayExpression(extendedRulesets);
     },
-  );
+  ]);
 };

--- a/packages/ruleset-migrator/src/transformers/formats.ts
+++ b/packages/ruleset-migrator/src/transformers/formats.ts
@@ -35,8 +35,8 @@ function transform(input: unknown, ctx: TransformerCtx): namedTypes.ArrayExpress
 
 export { transformer as default };
 
-const transformer: Transformer = function (registerHook) {
-  registerHook(/^\/aliases\/[^/]+\/targets\/\d+\/formats$/, transform);
-  registerHook(/^(\/overrides\/\d+)?\/formats$/, transform);
-  registerHook(/^(\/overrides\/\d+)?\/rules\/[^/]+\/formats$/, transform);
+const transformer: Transformer = function (hooks) {
+  hooks.add([/^\/aliases\/[^/]+\/targets\/\d+\/formats$/, transform]);
+  hooks.add([/^(\/overrides\/\d+)?\/formats$/, transform]);
+  hooks.add([/^(\/overrides\/\d+)?\/rules\/[^/]+\/formats$/, transform]);
 };

--- a/packages/ruleset-migrator/src/transformers/formats.ts
+++ b/packages/ruleset-migrator/src/transformers/formats.ts
@@ -18,7 +18,7 @@ const REPLACEMENTS = Object.fromEntries(
   ]),
 );
 
-function transform(ctx: TransformerCtx, input: unknown): namedTypes.ArrayExpression {
+function transform(input: unknown, ctx: TransformerCtx): namedTypes.ArrayExpression {
   assertArray(input);
 
   return b.arrayExpression(
@@ -35,10 +35,8 @@ function transform(ctx: TransformerCtx, input: unknown): namedTypes.ArrayExpress
 
 export { transformer as default };
 
-const transformer: Transformer = function (ctx) {
-  const t = transform.bind(null, ctx);
-
-  ctx.hooks.add([/^\/aliases\/[^/]+\/targets\/\d+\/formats$/, t]);
-  ctx.hooks.add([/^(\/overrides\/\d+)?\/formats$/, t]);
-  ctx.hooks.add([/^(\/overrides\/\d+)?\/rules\/[^/]+\/formats$/, t]);
+const transformer: Transformer = function (registerHook) {
+  registerHook(/^\/aliases\/[^/]+\/targets\/\d+\/formats$/, transform);
+  registerHook(/^(\/overrides\/\d+)?\/formats$/, transform);
+  registerHook(/^(\/overrides\/\d+)?\/rules\/[^/]+\/formats$/, transform);
 };

--- a/packages/ruleset-migrator/src/transformers/functions.ts
+++ b/packages/ruleset-migrator/src/transformers/functions.ts
@@ -5,32 +5,41 @@ import { Ruleset } from '../validation/types';
 
 export { transformer as default };
 
-const transformer: Transformer = function (registerHook) {
-  registerHook(/^$/, (_ruleset, ctx): void => {
-    const ruleset = _ruleset as Ruleset;
-    const { functionsDir, functions } = ruleset;
+const transformer: Transformer = function (hooks) {
+  hooks.add([
+    /^$/,
+    (_ruleset, ctx): void => {
+      const ruleset = _ruleset as Ruleset;
+      const { functionsDir, functions } = ruleset;
 
-    if (Array.isArray(functions) && functions.length > 0) {
-      for (const fn of functions) {
-        assertString(fn);
-        const resolved = ctx.tree.resolveModule(
-          `${fn}.js`,
-          path.join(ctx.cwd, typeof functionsDir === 'string' ? functionsDir : 'functions'),
-        );
-        const fnName = path.basename(resolved, true);
-        const identifier = ctx.tree.addImport(fnName, resolved, true);
-        ctx.tree.scope.store(`function-${fnName}`, identifier.name);
+      if (Array.isArray(functions) && functions.length > 0) {
+        for (const fn of functions) {
+          assertString(fn);
+          const resolved = ctx.tree.resolveModule(
+            `${fn}.js`,
+            path.join(ctx.cwd, typeof functionsDir === 'string' ? functionsDir : 'functions'),
+          );
+          const fnName = path.basename(resolved, true);
+          const identifier = ctx.tree.addImport(fnName, resolved, true);
+          ctx.tree.scope.store(`function-${fnName}`, identifier.name);
+        }
       }
-    }
-  });
+    },
+  ]);
 
-  registerHook(/^\/functions$/, (value): null => {
-    assertArray(value);
-    return null;
-  });
+  hooks.add([
+    /^\/functions$/,
+    (value): null => {
+      assertArray(value);
+      return null;
+    },
+  ]);
 
-  registerHook(/^\/functionsDir$/, (value): null => {
-    assertString(value);
-    return null;
-  });
+  hooks.add([
+    /^\/functionsDir$/,
+    (value): null => {
+      assertString(value);
+      return null;
+    },
+  ]);
 };

--- a/packages/ruleset-migrator/src/transformers/rules.ts
+++ b/packages/ruleset-migrator/src/transformers/rules.ts
@@ -53,35 +53,38 @@ function getDiagnosticSeverity(severity: DiagnosticSeverity | string): Diagnosti
   return Number.isNaN(Number(severity)) ? SEVERITY_MAP[severity] : Number(severity);
 }
 
-const transformer: Transformer = function (registerHook) {
-  registerHook(/^$/, (_ruleset): void => {
-    const ruleset = _ruleset as Ruleset;
-    if (ruleset.rules === void 0) return;
+const transformer: Transformer = function (hooks) {
+  hooks.add([
+    /^$/,
+    (_ruleset): void => {
+      const ruleset = _ruleset as Ruleset;
+      if (ruleset.rules === void 0) return;
 
-    const { rules } = ruleset;
+      const { rules } = ruleset;
 
-    // this is to make sure order of rules is preserved after transformation
-    ruleset.rules = createOrderedLiteral(rules);
-    const order = Object.keys(rules);
+      // this is to make sure order of rules is preserved after transformation
+      ruleset.rules = createOrderedLiteral(rules);
+      const order = Object.keys(rules);
 
-    for (const [i, key] of order.entries()) {
-      if (!(key in REPLACEMENTS)) continue;
-      if (typeof rules[key] === 'object') continue; // we do not touch new definitions (aka custom rules). If one defines a rule like operation-2xx-response in their own ruleset, we shouldn't touch it.
-      const newName = REPLACEMENTS[key];
-      if (newName in rules) {
-        rules[newName] = max(String(rules[key]), String(rules[newName]));
-      } else {
-        rules[newName] ??= rules[key];
+      for (const [i, key] of order.entries()) {
+        if (!(key in REPLACEMENTS)) continue;
+        if (typeof rules[key] === 'object') continue; // we do not touch new definitions (aka custom rules). If one defines a rule like operation-2xx-response in their own ruleset, we shouldn't touch it.
+        const newName = REPLACEMENTS[key];
+        if (newName in rules) {
+          rules[newName] = max(String(rules[key]), String(rules[newName]));
+        } else {
+          rules[newName] ??= rules[key];
+        }
+
+        order[i] = newName;
+        delete rules[key];
       }
 
-      order[i] = newName;
-      delete rules[key];
-    }
+      setOrder(rules, [...new Set([...order])]);
+    },
+  ]);
 
-    setOrder(rules, [...new Set([...order])]);
-  });
-
-  registerHook(
+  hooks.add([
     /^\/rules\/[^/]+\/then\/(?:[0-9]+\/)?function$/,
     (value, ctx): namedTypes.Identifier | namedTypes.UnaryExpression => {
       assertString(value);
@@ -93,5 +96,5 @@ const transformer: Transformer = function (registerHook) {
       const alias = ctx.tree.scope.load(`function-${value}`);
       return alias !== void 0 ? b.identifier(alias) : b.unaryExpression('void', b.literal(0));
     },
-  );
+  ]);
 };

--- a/packages/ruleset-migrator/src/tree/index.ts
+++ b/packages/ruleset-migrator/src/tree/index.ts
@@ -129,4 +129,22 @@ export class Tree {
 
     return resolved;
   }
+
+  public fork(): Tree {
+    const scope = this.scope.fork();
+    return new Proxy(this, {
+      get: (target, prop): Tree[keyof Tree] => {
+        if (prop === 'scope') {
+          return scope;
+        }
+
+        const value = Reflect.get(target, prop, target) as Tree[keyof Tree];
+        if (typeof value === 'function') {
+          return value.bind(target);
+        }
+
+        return value;
+      },
+    });
+  }
 }

--- a/packages/ruleset-migrator/src/types.ts
+++ b/packages/ruleset-migrator/src/types.ts
@@ -26,10 +26,10 @@ export type MigrationOptions = {
 
 export type Hook = [
   pattern: RegExp,
-  hook: (input: unknown) => Promise<ExpressionKind | null | void> | ExpressionKind | null | void,
+  hook: (input: unknown, ctx: TransformerCtx) => Promise<ExpressionKind | null | void> | ExpressionKind | null | void,
 ];
 
-export type Transformer = (ctx: TransformerCtx) => void;
+export type Transformer = (registerHook: (...params: Hook) => void) => void;
 
 export type TransformerCtx = {
   readonly tree: Tree;

--- a/packages/ruleset-migrator/src/types.ts
+++ b/packages/ruleset-migrator/src/types.ts
@@ -29,7 +29,7 @@ export type Hook = [
   hook: (input: unknown, ctx: TransformerCtx) => Promise<ExpressionKind | null | void> | ExpressionKind | null | void,
 ];
 
-export type Transformer = (registerHook: (...params: Hook) => void) => void;
+export type Transformer = (hooks: Set<Hook>) => void;
 
 export type TransformerCtx = {
   readonly tree: Tree;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1935,7 +1935,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stoplight/json@npm:3.17.0, @stoplight/json@npm:^3.17.0, @stoplight/json@npm:~3.17.1":
+"@stoplight/json@npm:3.17.0, @stoplight/json@npm:^3.17.0, @stoplight/json@npm:~3.17.0, @stoplight/json@npm:~3.17.1":
   version: 3.17.0
   resolution: "@stoplight/json@npm:3.17.0"
   dependencies:
@@ -2129,7 +2129,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@stoplight/spectral-ruleset-migrator@workspace:packages/ruleset-migrator"
   dependencies:
-    "@stoplight/json": 3.17.0
+    "@stoplight/json": ~3.17.0
     "@stoplight/ordered-object-literal": 1.0.2
     "@stoplight/path": 1.3.2
     "@stoplight/spectral-core": ^1.1.0


### PR DESCRIPTION
Right now, if you place `functions` somewhere below `rules`, you'll see `void 0` inserted.

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No


