### PR TITLE
feat(ruleset-migrator): cleaner output

### DIFF
--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/aliases-variant-2/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/aliases-variant-2/output.cjs
@@ -1,4 +1,4 @@
-const { oas2: oas2, oas3_0: oas3_0, oas3_1: oas3_1 } = require('@stoplight/spectral-formats');
+const { oas2, oas3_0, oas3_1 } = require('@stoplight/spectral-formats');
 module.exports = {
   aliases: {
     schema: {

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/apisyouwonthate/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/apisyouwonthate/output.cjs
@@ -1,5 +1,5 @@
-const { truthy, pattern, schema, falsy, enumeration } = require('@stoplight/spectral-functions');
 const { oas2, oas3 } = require('@stoplight/spectral-formats');
+const { enumeration, falsy, pattern, schema, truthy } = require('@stoplight/spectral-functions');
 module.exports = {
   rules: {
     'api-home': {

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/apisyouwonthate/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/apisyouwonthate/output.cjs
@@ -1,11 +1,5 @@
-const {
-  truthy: truthy,
-  pattern: pattern,
-  schema: schema,
-  falsy: falsy,
-  enumeration: enumeration,
-} = require('@stoplight/spectral-functions');
-const { oas2: oas2, oas3: oas3 } = require('@stoplight/spectral-formats');
+const { truthy, pattern, schema, falsy, enumeration } = require('@stoplight/spectral-functions');
+const { oas2, oas3 } = require('@stoplight/spectral-formats');
 module.exports = {
   rules: {
     'api-home': {

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/apisyouwonthate/output.mjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/apisyouwonthate/output.mjs
@@ -1,5 +1,5 @@
-import { truthy, pattern, schema, falsy, enumeration } from '@stoplight/spectral-functions';
 import { oas2, oas3 } from '@stoplight/spectral-formats';
+import { enumeration, falsy, pattern, schema, truthy } from '@stoplight/spectral-functions';
 export default {
   rules: {
     'api-home': {

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/exceptions-variant-1/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/exceptions-variant-1/output.cjs
@@ -1,4 +1,4 @@
-const { oas: oas } = require("@stoplight/spectral-rulesets");
+const { oas } = require('@stoplight/spectral-rulesets');
 module.exports = {
   extends: oas,
   overrides: [

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/exceptions-variant-2/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/exceptions-variant-2/output.cjs
@@ -1,4 +1,4 @@
-const { oas: oas } = require('@stoplight/spectral-rulesets');
+const { oas } = require('@stoplight/spectral-rulesets');
 module.exports = {
   extends: oas,
   overrides: [

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-1/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-1/output.cjs
@@ -1,4 +1,4 @@
-const { oas: oas } = require('@stoplight/spectral-rulesets');
+const { oas } = require('@stoplight/spectral-rulesets');
 module.exports = {
   extends: [oas],
 };

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-2/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-2/output.cjs
@@ -1,4 +1,4 @@
-const { oas: oas, asyncapi: asyncapi } = require('@stoplight/spectral-rulesets');
+const { oas, asyncapi } = require('@stoplight/spectral-rulesets');
 module.exports = {
   extends: [oas, asyncapi],
 };

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-2/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-2/output.cjs
@@ -1,4 +1,4 @@
-const { oas, asyncapi } = require('@stoplight/spectral-rulesets');
+const { asyncapi, oas } = require('@stoplight/spectral-rulesets');
 module.exports = {
   extends: [oas, asyncapi],
 };

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-2/output.mjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-2/output.mjs
@@ -1,4 +1,4 @@
-import { oas, asyncapi } from '@stoplight/spectral-rulesets';
+import { asyncapi, oas } from '@stoplight/spectral-rulesets';
 export default {
   extends: [oas, asyncapi],
 };

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-3/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-3/output.cjs
@@ -1,4 +1,4 @@
-const { oas: oas } = require('@stoplight/spectral-rulesets');
+const { oas } = require('@stoplight/spectral-rulesets');
 module.exports = {
   extends: oas,
 };

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-4/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-4/output.cjs
@@ -1,4 +1,4 @@
-const { oas: oas } = require('@stoplight/spectral-rulesets');
+const { oas } = require('@stoplight/spectral-rulesets');
 module.exports = {
   extends: [[oas, 'off']],
 };

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-5/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-5/output.cjs
@@ -1,4 +1,4 @@
-const { truthy: truthy } = require('@stoplight/spectral-functions');
+const { truthy } = require('@stoplight/spectral-functions');
 module.exports = {
   extends: [
     {

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-6/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-6/output.cjs
@@ -1,5 +1,5 @@
-const ruleset_js = _interopDefault(require('/.tmp/spectral/extends-variant-6/assets/ruleset.js'));
 const ruleset_cjs = _interopDefault(require('/.tmp/spectral/extends-variant-6/assets/ruleset.cjs'));
+const ruleset_js = _interopDefault(require('/.tmp/spectral/extends-variant-6/assets/ruleset.js'));
 const ruleset_mjs = _interopDefault(require('/.tmp/spectral/extends-variant-6/assets/ruleset.mjs'));
 module.exports = {
   extends: [ruleset_js, ruleset_cjs, ruleset_mjs],

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-6/output.mjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-6/output.mjs
@@ -1,5 +1,5 @@
-import ruleset_js from '/.tmp/spectral/extends-variant-6/assets/ruleset.js';
 import ruleset_cjs from '/.tmp/spectral/extends-variant-6/assets/ruleset.cjs';
+import ruleset_js from '/.tmp/spectral/extends-variant-6/assets/ruleset.js';
 import ruleset_mjs from '/.tmp/spectral/extends-variant-6/assets/ruleset.mjs';
 export default {
   extends: [ruleset_js, ruleset_cjs, ruleset_mjs],

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-7/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-7/output.cjs
@@ -1,8 +1,8 @@
-const { oas2: oas2, oas3: oas3, oas3_1: oas3_1, oas3_0: oas3_0 } = require('@stoplight/spectral-formats');
+const { oas2, oas3, oas3_1, oas3_0 } = require('@stoplight/spectral-formats');
 const pascalCase = _interopDefault(require('/.tmp/spectral/extends-variant-7/functions/pascalCase.js'));
 const pascalCase$0 = _interopDefault(require('/.tmp/spectral/extends-variant-7/assets/functions/pascalCase.js'));
 const oas3$0 = _interopDefault(require('/.tmp/spectral/extends-variant-7/assets/functions/oas3.js'));
-const { truthy: truthy } = require('@stoplight/spectral-functions');
+const { truthy } = require('@stoplight/spectral-functions');
 const pascalCase$1 = _interopDefault(require('/.tmp/spectral/extends-variant-7/assets/fns/pascalCase.js'));
 module.exports = {
   formats: [oas2, oas3],

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-7/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-7/output.cjs
@@ -1,9 +1,9 @@
-const { oas2, oas3, oas3_1, oas3_0 } = require('@stoplight/spectral-formats');
-const pascalCase = _interopDefault(require('/.tmp/spectral/extends-variant-7/functions/pascalCase.js'));
-const pascalCase$0 = _interopDefault(require('/.tmp/spectral/extends-variant-7/assets/functions/pascalCase.js'));
-const oas3$0 = _interopDefault(require('/.tmp/spectral/extends-variant-7/assets/functions/oas3.js'));
+const { oas2, oas3, oas3_0, oas3_1 } = require('@stoplight/spectral-formats');
 const { truthy } = require('@stoplight/spectral-functions');
 const pascalCase$1 = _interopDefault(require('/.tmp/spectral/extends-variant-7/assets/fns/pascalCase.js'));
+const oas3$0 = _interopDefault(require('/.tmp/spectral/extends-variant-7/assets/functions/oas3.js'));
+const pascalCase$0 = _interopDefault(require('/.tmp/spectral/extends-variant-7/assets/functions/pascalCase.js'));
+const pascalCase = _interopDefault(require('/.tmp/spectral/extends-variant-7/functions/pascalCase.js'));
 module.exports = {
   formats: [oas2, oas3],
   extends: [

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-7/output.mjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-7/output.mjs
@@ -1,9 +1,9 @@
-import { oas2, oas3, oas3_1, oas3_0 } from '@stoplight/spectral-formats';
-import pascalCase from '/.tmp/spectral/extends-variant-7/functions/pascalCase.js';
-import pascalCase$0 from '/.tmp/spectral/extends-variant-7/assets/functions/pascalCase.js';
-import oas3$0 from '/.tmp/spectral/extends-variant-7/assets/functions/oas3.js';
+import { oas2, oas3, oas3_0, oas3_1 } from '@stoplight/spectral-formats';
 import { truthy } from '@stoplight/spectral-functions';
 import pascalCase$1 from '/.tmp/spectral/extends-variant-7/assets/fns/pascalCase.js';
+import oas3$0 from '/.tmp/spectral/extends-variant-7/assets/functions/oas3.js';
+import pascalCase$0 from '/.tmp/spectral/extends-variant-7/assets/functions/pascalCase.js';
+import pascalCase from '/.tmp/spectral/extends-variant-7/functions/pascalCase.js';
 export default {
   formats: [oas2, oas3],
   extends: [

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-8/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-8/output.cjs
@@ -1,4 +1,4 @@
-const { truthy: truthy, falsy: falsy } = require('@stoplight/spectral-functions');
+const { falsy, truthy } = require('@stoplight/spectral-functions');
 const pascalCase = _interopDefault(require('/.tmp/spectral/extends-variant-8/assets/shared/functions/pascalCase.js'));
 module.exports = {
   extends: [

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-8/output.mjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/extends-variant-8/output.mjs
@@ -1,4 +1,4 @@
-import { truthy, falsy } from "@stoplight/spectral-functions";
+import { falsy, truthy } from "@stoplight/spectral-functions";
 import pascalCase from "/.tmp/spectral/extends-variant-8/assets/shared/functions/pascalCase.js";
 export default {
   extends: [

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/formats-variant-1/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/formats-variant-1/output.cjs
@@ -1,4 +1,4 @@
-const { oas2, oas3_1, oas3_0, jsonSchemaLoose, jsonSchemaDraft2019_09 } = require('@stoplight/spectral-formats');
+const { jsonSchemaDraft2019_09, jsonSchemaLoose, oas2, oas3_0, oas3_1 } = require('@stoplight/spectral-formats');
 module.exports = {
   formats: [oas2, oas3_1, oas3_0, jsonSchemaLoose, jsonSchemaDraft2019_09],
   rules: {},

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/formats-variant-1/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/formats-variant-1/output.cjs
@@ -1,10 +1,4 @@
-const {
-  oas2: oas2,
-  oas3_1: oas3_1,
-  oas3_0: oas3_0,
-  jsonSchemaLoose: jsonSchemaLoose,
-  jsonSchemaDraft2019_09: jsonSchemaDraft2019_09,
-} = require('@stoplight/spectral-formats');
+const { oas2, oas3_1, oas3_0, jsonSchemaLoose, jsonSchemaDraft2019_09 } = require('@stoplight/spectral-formats');
 module.exports = {
   formats: [oas2, oas3_1, oas3_0, jsonSchemaLoose, jsonSchemaDraft2019_09],
   rules: {},

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/formats-variant-1/output.mjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/formats-variant-1/output.mjs
@@ -1,4 +1,4 @@
-import { oas2, oas3_1, oas3_0, jsonSchemaLoose, jsonSchemaDraft2019_09 } from '@stoplight/spectral-formats';
+import { jsonSchemaDraft2019_09, jsonSchemaLoose, oas2, oas3_0, oas3_1 } from '@stoplight/spectral-formats';
 export default {
   formats: [oas2, oas3_1, oas3_0, jsonSchemaLoose, jsonSchemaDraft2019_09],
   rules: {},

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/formats-variant-2/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/formats-variant-2/output.cjs
@@ -1,12 +1,5 @@
-const {
-  oas2: oas2,
-  oas3_1: oas3_1,
-  oas3_0: oas3_0,
-  jsonSchemaLoose: jsonSchemaLoose,
-  asyncapi2: asyncapi2,
-  oas3: oas3,
-} = require('@stoplight/spectral-formats');
-const { truthy: truthy } = require('@stoplight/spectral-functions');
+const { oas2, oas3_1, oas3_0, jsonSchemaLoose, asyncapi2, oas3 } = require('@stoplight/spectral-formats');
+const { truthy } = require('@stoplight/spectral-functions');
 module.exports = {
   formats: [oas2, oas3_1, oas3_0, jsonSchemaLoose],
   rules: {

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/formats-variant-2/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/formats-variant-2/output.cjs
@@ -1,4 +1,4 @@
-const { oas2, oas3_1, oas3_0, jsonSchemaLoose, asyncapi2, oas3 } = require('@stoplight/spectral-formats');
+const { asyncapi2, jsonSchemaLoose, oas2, oas3, oas3_0, oas3_1 } = require('@stoplight/spectral-formats');
 const { truthy } = require('@stoplight/spectral-functions');
 module.exports = {
   formats: [oas2, oas3_1, oas3_0, jsonSchemaLoose],

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/formats-variant-2/output.mjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/formats-variant-2/output.mjs
@@ -1,4 +1,4 @@
-import { oas2, oas3_1, oas3_0, jsonSchemaLoose, asyncapi2, oas3 } from '@stoplight/spectral-formats';
+import { asyncapi2, jsonSchemaLoose, oas2, oas3, oas3_0, oas3_1 } from '@stoplight/spectral-formats';
 import { truthy } from '@stoplight/spectral-functions';
 export default {
   formats: [oas2, oas3_1, oas3_0, jsonSchemaLoose],

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/formats-variant-3/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/formats-variant-3/output.cjs
@@ -1,8 +1,5 @@
-const {
-  jsonSchemaDraft2019_09: jsonSchemaDraft2019_09,
-  jsonSchemaDraft2020_12: jsonSchemaDraft2020_12,
-} = require('@stoplight/spectral-formats');
-const { truthy: truthy } = require('@stoplight/spectral-functions');
+const { jsonSchemaDraft2019_09, jsonSchemaDraft2020_12 } = require('@stoplight/spectral-formats');
+const { truthy } = require('@stoplight/spectral-functions');
 module.exports = {
   formats: [jsonSchemaDraft2019_09, jsonSchemaDraft2020_12],
   rules: {

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-1/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-1/output.cjs
@@ -3,8 +3,8 @@ const oasDocumentSchema = _interopDefault(require('/.tmp/spectral/functions-vari
 const oasExample = _interopDefault(require('/.tmp/spectral/functions-variant-1/functions/oasExample.js'));
 const oasOp2xxResponse = _interopDefault(require('/.tmp/spectral/functions-variant-1/functions/oasOp2xxResponse.js'));
 const oasOpFormDataConsumeCheck = _interopDefault(require('/.tmp/spectral/functions-variant-1/functions/oasOpFormDataConsumeCheck.js'));
-const typedEnum = _interopDefault(require('/.tmp/spectral/functions-variant-1/functions/typedEnum.js'));
 const refSiblings = _interopDefault(require('/.tmp/spectral/functions-variant-1/functions/refSiblings.js'));
+const typedEnum = _interopDefault(require('/.tmp/spectral/functions-variant-1/functions/typedEnum.js'));
 module.exports = {
   documentationUrl: 'https://meta.stoplight.io/docs/spectral/docs/reference/openapi-rules.md',
   formats: [oas2, oas3],

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-1/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-1/output.cjs
@@ -1,4 +1,4 @@
-const { oas2: oas2, oas3: oas3 } = require('@stoplight/spectral-formats');
+const { oas2, oas3 } = require('@stoplight/spectral-formats');
 const oasDocumentSchema = _interopDefault(require('/.tmp/spectral/functions-variant-1/functions/oasDocumentSchema.js'));
 const oasExample = _interopDefault(require('/.tmp/spectral/functions-variant-1/functions/oasExample.js'));
 const oasOp2xxResponse = _interopDefault(require('/.tmp/spectral/functions-variant-1/functions/oasOp2xxResponse.js'));

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-1/output.mjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-1/output.mjs
@@ -3,8 +3,8 @@ import oasDocumentSchema from '/.tmp/spectral/functions-variant-1/functions/oasD
 import oasExample from '/.tmp/spectral/functions-variant-1/functions/oasExample.js';
 import oasOp2xxResponse from '/.tmp/spectral/functions-variant-1/functions/oasOp2xxResponse.js';
 import oasOpFormDataConsumeCheck from '/.tmp/spectral/functions-variant-1/functions/oasOpFormDataConsumeCheck.js';
-import typedEnum from '/.tmp/spectral/functions-variant-1/functions/typedEnum.js';
 import refSiblings from '/.tmp/spectral/functions-variant-1/functions/refSiblings.js';
+import typedEnum from '/.tmp/spectral/functions-variant-1/functions/typedEnum.js';
 export default {
   documentationUrl: 'https://meta.stoplight.io/docs/spectral/docs/reference/openapi-rules.md',
   formats: [oas2, oas3],

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-3/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-3/output.cjs
@@ -1,8 +1,8 @@
-const uppercase = _interopDefault(require('/.tmp/spectral/functions-variant-3/functions/upper-case.js'));
-const no = _interopDefault(require('/.tmp/spectral/functions-variant-3/functions/no-@.js'));
 const _400response = _interopDefault(require('/.tmp/spectral/functions-variant-3/functions/400-response.js'));
 const import$0 = _interopDefault(require('/.tmp/spectral/functions-variant-3/functions/import.js'));
+const no = _interopDefault(require('/.tmp/spectral/functions-variant-3/functions/no-@.js'));
 const require$0 = _interopDefault(require('/.tmp/spectral/functions-variant-3/functions/require.js'));
+const uppercase = _interopDefault(require('/.tmp/spectral/functions-variant-3/functions/upper-case.js'));
 module.exports = {
   rules: {
     rule: {

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-3/output.mjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-3/output.mjs
@@ -1,8 +1,8 @@
-import uppercase from '/.tmp/spectral/functions-variant-3/functions/upper-case.js';
-import no from '/.tmp/spectral/functions-variant-3/functions/no-@.js';
 import _400response from '/.tmp/spectral/functions-variant-3/functions/400-response.js';
 import import$0 from '/.tmp/spectral/functions-variant-3/functions/import.js';
+import no from '/.tmp/spectral/functions-variant-3/functions/no-@.js';
 import require$0 from '/.tmp/spectral/functions-variant-3/functions/require.js';
+import uppercase from '/.tmp/spectral/functions-variant-3/functions/upper-case.js';
 export default {
   rules: {
     rule: {

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-4/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/functions-variant-4/output.cjs
@@ -1,4 +1,4 @@
-const { oas3: oas3, oas3_1: oas3_1 } = require('@stoplight/spectral-formats');
+const { oas3, oas3_1 } = require('@stoplight/spectral-formats');
 const oas3$0 = _interopDefault(require('/.tmp/spectral/functions-variant-4/functions/oas3.js'));
 module.exports = {
   formats: [oas3, oas3_1],

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/overrides-variant-1/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/overrides-variant-1/output.cjs
@@ -1,5 +1,5 @@
-const { oas } = require('@stoplight/spectral-rulesets');
 const { oas2, oas3 } = require('@stoplight/spectral-formats');
+const { oas } = require('@stoplight/spectral-rulesets');
 module.exports = {
   overrides: [
     {

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/overrides-variant-1/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/overrides-variant-1/output.cjs
@@ -1,5 +1,5 @@
-const { oas: oas } = require("@stoplight/spectral-rulesets");
-const { oas2: oas2, oas3: oas3 } = require("@stoplight/spectral-formats");
+const { oas } = require('@stoplight/spectral-rulesets');
+const { oas2, oas3 } = require('@stoplight/spectral-formats');
 module.exports = {
   overrides: [
     {

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/overrides-variant-1/output.mjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/overrides-variant-1/output.mjs
@@ -1,5 +1,5 @@
-import { oas } from "@stoplight/spectral-rulesets";
 import { oas2, oas3 } from "@stoplight/spectral-formats";
+import { oas } from "@stoplight/spectral-rulesets";
 export default {
   overrides: [
     {

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/rules-variant-1/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/rules-variant-1/output.cjs
@@ -1,4 +1,4 @@
-const { oas2: oas2 } = require('@stoplight/spectral-formats');
+const { oas2 } = require('@stoplight/spectral-formats');
 module.exports = {
   rules: {
     'oas3-schema': 'error',

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/rules-variant-3/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/rules-variant-3/output.cjs
@@ -1,4 +1,4 @@
-const { truthy: truthy, length: length$0 } = require('@stoplight/spectral-functions');
+const { truthy, length: length$0 } = require('@stoplight/spectral-functions');
 module.exports = {
   rules: {
     rule: {

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/rules-variant-3/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/rules-variant-3/output.cjs
@@ -1,4 +1,4 @@
-const { truthy, length: length$0 } = require('@stoplight/spectral-functions');
+const { length: length$0, truthy } = require('@stoplight/spectral-functions');
 module.exports = {
   rules: {
     rule: {

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/rules-variant-3/output.mjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/rules-variant-3/output.mjs
@@ -1,4 +1,4 @@
-import { truthy, length as length$0 } from '@stoplight/spectral-functions';
+import { length as length$0, truthy } from '@stoplight/spectral-functions';
 export default {
   rules: {
     rule: {

--- a/packages/ruleset-migrator/src/__tests__/__fixtures__/rules-variant-4/output.cjs
+++ b/packages/ruleset-migrator/src/__tests__/__fixtures__/rules-variant-4/output.cjs
@@ -1,4 +1,4 @@
-const { truthy: truthy } = require("@stoplight/spectral-functions");
+const { truthy } = require('@stoplight/spectral-functions');
 module.exports = {
   rules: {
     rule: {

--- a/packages/ruleset-migrator/src/__tests__/ruleset.test.ts
+++ b/packages/ruleset-migrator/src/__tests__/ruleset.test.ts
@@ -193,9 +193,9 @@ describe('migrator', () => {
           fs: fs as any,
           npmRegistry: 'https://unpkg.com/',
         }),
-      ).toEqual(`import {asyncapi} from "https://unpkg.com/@stoplight/spectral-rulesets";
-import {oas2} from "https://unpkg.com/@stoplight/spectral-formats";
+      ).toEqual(`import {oas2} from "https://unpkg.com/@stoplight/spectral-formats";
 import {truthy} from "https://unpkg.com/@stoplight/spectral-functions";
+import {asyncapi} from "https://unpkg.com/@stoplight/spectral-rulesets";
 export default {
   "extends": asyncapi,
   "formats": [oas2],

--- a/packages/ruleset-migrator/src/tree/commonjs.ts
+++ b/packages/ruleset-migrator/src/tree/commonjs.ts
@@ -35,7 +35,16 @@ export const commonjs = <IModule>{
   ): namedTypes.VariableDeclaration {
     return b.variableDeclaration('const', [
       b.variableDeclarator(
-        b.objectPattern(identifiers.map(([imported, local]) => b.property('init', imported, local))),
+        b.objectPattern(
+          identifiers.map(([imported, local]) =>
+            b.property.from({
+              kind: 'init',
+              key: imported,
+              value: local,
+              shorthand: local.name === imported.name,
+            }),
+          ),
+        ),
         b.callExpression(b.identifier('require'), [b.literal(source)]),
       ),
     ]);


### PR DESCRIPTION
2 changes here:
- import members are sorted
- for CJS, shorthand object properties are used when possible 

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No.
