### PR TITLE
fix(cli): add path to JUnit testcase name

### DIFF
--- a/packages/cli/src/formatters/__tests__/junit.test.ts
+++ b/packages/cli/src/formatters/__tests__/junit.test.ts
@@ -31,7 +31,7 @@ describe('JUnit formatter', () => {
               {
                 $: {
                   classname: '/home/Stoplight/spectral/src/__tests__/__fixtures__/petstore.invalid-schema.oas3',
-                  name: 'org.spectral.oas3-schema',
+                  name: 'org.spectral.oas3-schema(#/paths/~1pets/get/responses/200/headers/header-1)',
                   time: '0',
                 },
                 failure: [
@@ -46,7 +46,7 @@ describe('JUnit formatter', () => {
               {
                 $: {
                   classname: '/home/Stoplight/spectral/src/__tests__/__fixtures__/petstore.invalid-schema.oas3',
-                  name: 'org.spectral.oas3-schema',
+                  name: 'org.spectral.oas3-schema(#/paths/~1pets/get/responses/200/headers/header-1)',
                   time: '0',
                 },
                 failure: [
@@ -61,7 +61,7 @@ describe('JUnit formatter', () => {
               {
                 $: {
                   classname: '/home/Stoplight/spectral/src/__tests__/__fixtures__/petstore.invalid-schema.oas3',
-                  name: 'org.spectral.oas3-schema',
+                  name: 'org.spectral.oas3-schema(#/paths/~1pets/get/responses/200/headers/header-1)',
                   time: '0',
                 },
                 failure: [
@@ -98,7 +98,7 @@ describe('JUnit formatter', () => {
               {
                 $: {
                   classname: '/home/Stoplight/spectral/src/__tests__/__fixtures__/petstore.oas3',
-                  name: 'org.spectral.info-matches-stoplight',
+                  name: 'org.spectral.info-matches-stoplight(#/info/title)',
                   time: '0',
                 },
                 failure: [
@@ -135,7 +135,7 @@ describe('JUnit formatter', () => {
               {
                 $: {
                   classname: '/home/Stoplight/spectral/src/__tests__/__fixtures__/petstore.oas3',
-                  name: 'org.spectral.info-description',
+                  name: 'org.spectral.info-description(#/info)',
                   time: '0',
                 },
                 failure: [
@@ -150,7 +150,7 @@ describe('JUnit formatter', () => {
               {
                 $: {
                   classname: '/home/Stoplight/spectral/src/__tests__/__fixtures__/petstore.oas3',
-                  name: 'org.spectral.info-matches-stoplight',
+                  name: 'org.spectral.info-matches-stoplight(#/info/title)',
                   time: '0',
                 },
                 failure: [

--- a/packages/cli/src/formatters/junit.ts
+++ b/packages/cli/src/formatters/junit.ts
@@ -46,12 +46,15 @@ export const junit: Formatter = (results, { failSeverity }) => {
       output += `<testsuite package="org.spectral" time="0" tests="${filteredValidationResults.length}" errors="0" failures="${filteredValidationResults.length}" name="${source}">\n`;
 
       for (const result of filteredValidationResults) {
-        output += `<testcase time="0" name="org.spectral.${result.code ?? 'unknown'}" classname="${classname}">`;
+        const path = printPath(result.path, PrintStyle.EscapedPointer);
+        output += `<testcase time="0" name="org.spectral.${result.code ?? 'unknown'}${
+          path.length > 0 ? `(${xmlEscape(path)})` : ''
+        }" classname="${classname}">`;
         output += `<failure message="${xmlEscape(result.message)}">`;
         output += '<![CDATA[';
         output += `line ${result.range.start.line + 1}, col ${result.range.start.character + 1}, `;
         output += `${xmlEscape(result.message)} (${result.code}) `;
-        output += `at path ${xmlEscape(printPath(result.path, PrintStyle.EscapedPointer))}`;
+        output += `at path ${xmlEscape(path)}`;
         output += ']]>';
         output += `</failure>`;
         output += '</testcase>\n';


### PR DESCRIPTION
This helps downstream tools disambiguate individual test failures better.

There is no formal spec for the JUnit XML format but JUnit itself does it in a very similar way for dynamic/parametrized tests (see https://github.com/junit-team/junit5/pull/1236).

Fixes #2025.

**Checklist**

- [x] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

🛠 with ❤ at [Siemens](https://opensource.siemens.io)