### PR TITLE
feat(core): aliases take only array-ish given

### DIFF
--- a/docs/guides/4-custom-rulesets.md
+++ b/docs/guides/4-custom-rulesets.md
@@ -31,7 +31,7 @@ It has a specific syntax known as [JSONPath](https://goessner.net/articles/JsonP
 Both of them support all the main JSONPath functionality and a little bit more, but this syntax may differ slightly from other JSONPath implementations.
 
 Your `given` value can be a string containing any valid JSONPath expression, or an array of expressions to apply a rule to multiple parts of a document.
-You can also consume your [aliases][#aliases] here if you have some defined.
+You can also consume your (aliases)[#aliases] here if you have some defined.
 
 Use the [JSONPath Online Evaluator](http://jsonpath.com/) to determine what `given` path you want.
 
@@ -328,17 +328,22 @@ Targeting certain parts of an OpenAPI spec is powerful but it can become cumbers
 Define aliases for commonly used JSONPath expressions on a global level which can then be reused across the ruleset.
 
 Aliases can be defined in an array of key-value pairs at the root level of the ruleset.
-It's a superset of `given`, with the notable difference being the possibility to distinguish between different formats.
+It's similar to `given`, with the notable difference being the possibility to distinguish between different formats.
 
 **Example**
 
 ```yaml
 aliases:
-  HeaderNames: "$..parameters.[?(@.in === 'header')].name"
-  Info: "$..info"
-  InfoDescription: "#Info.description"
-  InfoContact: "#Info.contact"
-  Paths: "$.paths[*]~"
+  HeaderNames:
+    - "$..parameters.[?(@.in === 'header')].name"
+  Info:
+    - "$..info"
+  InfoDescription:
+    - "#Info.description"
+  InfoContact:
+    - "#Info.contact"
+  Paths:
+    - "$.paths[*]~"
 ```
 
 If you deal with a variety of different spec, you may find the above approach insufficient, particularly when the shape of the document is notably different.
@@ -351,10 +356,12 @@ aliases:
     targets:
       - formats:
           - oas2
-        given: $.parameters[*]
+        given:
+          - $.parameters[*]
       - formats:
           - oas3
-        given: $.components.parameters[*]
+        given:
+          - $.components.parameters[*]
 ```
 
 Now, if you referenced `SharedParameterObject` alias, the chosen path would be determined based on the document you use.
@@ -366,8 +373,10 @@ To make it more feasible and avoid overly complex JSONPath expressions, `given` 
 
 ```yaml
 aliases:
-  PathItemObject: $.paths[*]
-  OperationObject: "#PathItem[get,put,post,delete,options,head,patch,trace]"
+  PathItemObject:
+    - $.paths[*]
+  OperationObject:
+    - "#PathItem[get,put,post,delete,options,head,patch,trace]"
   ParameterObject:
     description: an optional property describing the purpose of the alias
     targets:

--- a/packages/core/src/meta/ruleset.schema.json
+++ b/packages/core/src/meta/ruleset.schema.json
@@ -191,7 +191,7 @@
                     "$ref": "shared#formats"
                   },
                   "given": {
-                    "$ref": "shared#given"
+                    "$ref": "shared#arrayish-given"
                   }
                 },
                 "required": ["formats", "given"],
@@ -208,7 +208,7 @@
           }
         },
         "else": {
-          "$ref": "shared#given"
+          "$ref": "shared#arrayish-given"
         }
       }
     }

--- a/packages/core/src/meta/shared.json
+++ b/packages/core/src/meta/shared.json
@@ -39,6 +39,7 @@
         "type": "array"
       },
       "then": {
+        "$anchor": "arrayish-given",
         "type": "array",
         "items": {
           "$ref": "path-expression"

--- a/packages/core/src/ruleset/__tests__/__fixtures__/overrides/aliases/scope.ts
+++ b/packages/core/src/ruleset/__tests__/__fixtures__/overrides/aliases/scope.ts
@@ -1,12 +1,12 @@
 import { DiagnosticSeverity } from '@stoplight/types';
-import {falsy, pattern, truthy} from '@stoplight/spectral-functions';
+import { falsy, pattern, truthy } from '@stoplight/spectral-functions';
 import { RulesetDefinition } from '@stoplight/spectral-core';
 
 export { ruleset as default };
 
 const ruleset: RulesetDefinition = {
   aliases: {
-    Stoplight: '$..stoplight',
+    Stoplight: ['$..stoplight'],
   },
   overrides: [
     {
@@ -29,7 +29,7 @@ const ruleset: RulesetDefinition = {
     {
       files: ['**/*.json'],
       aliases: {
-        Value: '$..value',
+        Value: ['$..value'],
       },
       rules: {
         'truthy-stoplight-property': {

--- a/packages/core/src/ruleset/__tests__/ruleset.test.ts
+++ b/packages/core/src/ruleset/__tests__/ruleset.test.ts
@@ -1004,10 +1004,10 @@ describe('Ruleset', () => {
         print(
           new Ruleset({
             aliases: {
-              Info: '$.info',
-              PathItem: '$.paths[*][*]',
-              Description: '$..description',
-              Name: '$..name',
+              Info: ['$.info'],
+              PathItem: ['$.paths[*][*]'],
+              Description: ['$..description'],
+              Name: ['$..name'],
             },
 
             rules: {
@@ -1066,10 +1066,10 @@ describe('Ruleset', () => {
           JSON.stringify(
             new Ruleset({
               aliases: {
-                Info: '$.info',
-                PathItem: '$.paths[*][*]',
-                Description: '$..description',
-                Name: '$..name',
+                Info: ['$.info'],
+                PathItem: ['$.paths[*][*]'],
+                Description: ['$..description'],
+                Name: ['$..name'],
               },
 
               rules: {
@@ -1108,10 +1108,10 @@ describe('Ruleset', () => {
           incompatibleValues: DiagnosticSeverity.Error,
         },
         aliases: {
-          Info: '$.info',
-          PathItem: '$.paths[*][*]',
-          Description: '$..description',
-          Name: '$..name',
+          Info: ['$.info'],
+          PathItem: ['$.paths[*][*]'],
+          Description: ['$..description'],
+          Name: ['$..name'],
         },
         rules: {
           'valid-path': {
@@ -1179,10 +1179,10 @@ describe('Ruleset', () => {
         print(
           new Ruleset({
             aliases: {
-              Info: '$.info',
-              InfoDescription: '#Info.description',
-              InfoContact: '#Info.contact',
-              InfoContactName: '#InfoContact.name',
+              Info: ['$.info'],
+              InfoDescription: ['#Info.description'],
+              InfoContact: ['#Info.contact'],
+              InfoContactName: ['#InfoContact.name'],
             },
 
             rules: {
@@ -1241,7 +1241,7 @@ describe('Ruleset', () => {
           new Ruleset({
             extends: {
               aliases: {
-                PathItem: '$.paths[*][*]',
+                PathItem: ['$.paths[*][*]'],
               },
               rules: {},
             },
@@ -1262,10 +1262,10 @@ describe('Ruleset', () => {
         () =>
           new Ruleset({
             aliases: {
-              Root: '#Info',
-              Info: '#Root.test',
-              Contact: '#Info',
-              Test: '#Contact.test',
+              Root: ['#Info'],
+              Info: ['#Root.test'],
+              Contact: ['#Info'],
+              Test: ['#Contact.test'],
             },
             rules: {
               'valid-path': {
@@ -1287,9 +1287,9 @@ describe('Ruleset', () => {
           new Ruleset({
             extends: {
               aliases: {
-                PathItem: '$.paths[*][*]',
-                Description: '$..description',
-                Name: '$..name',
+                PathItem: ['$.paths[*][*]'],
+                Description: ['$..description'],
+                Name: ['$..name'],
               },
               rules: {},
             },
@@ -1331,17 +1331,17 @@ describe('Ruleset', () => {
               targets: [
                 {
                   formats: [draft4],
-                  given: '$..id',
+                  given: ['$..id'],
                 },
                 {
                   formats: [draft6, draft7],
-                  given: '$..$id',
+                  given: ['$..$id'],
                 },
               ],
             },
 
-            PathItem: '$.paths[*]',
-            OperationObject: '#PathItem[get,put,post,delete,options,head,patch,trace]',
+            PathItem: ['$.paths[*]'],
+            OperationObject: ['#PathItem[get,put,post,delete,options,head,patch,trace]'],
             ParametersDefinitionsObject: {
               targets: [
                 { formats: [oas2], given: ['$.parameters'] },
@@ -1461,7 +1461,7 @@ describe('Ruleset', () => {
               targets: [
                 {
                   formats: [draft6],
-                  given: '$..$id',
+                  given: ['$..$id'],
                 },
               ],
             },
@@ -1500,11 +1500,11 @@ describe('Ruleset', () => {
                     targets: [
                       {
                         formats: [draft4],
-                        given: '$..id',
+                        given: ['$..id'],
                       },
                       {
                         formats: [draft6, draft7],
-                        given: '$..$id',
+                        given: ['$..$id'],
                       },
                     ],
                   },
@@ -1536,11 +1536,11 @@ describe('Ruleset', () => {
               targets: [
                 {
                   formats: ['draft4'],
-                  given: '$..id',
+                  given: ['$..id'],
                 },
                 {
                   formats: ['draft6', 'draft7'],
-                  given: '$..$id',
+                  given: ['$..$id'],
                 },
               ],
             },

--- a/packages/core/src/ruleset/__tests__/validation.test.ts
+++ b/packages/core/src/ruleset/__tests__/validation.test.ts
@@ -345,19 +345,19 @@ Error at #/rules/rule/formats/1: must be a valid format`,
           assertValidRuleset.bind(null, {
             rules: {},
             aliases: {
-              [alias]: '$',
+              [alias]: ['$'],
             },
           }),
         ).not.toThrow();
       },
     );
 
-    it.each(['#Info', '#i', '#Info.contact', '#Info[*]'])('recognizes %s as a valid value of an alias', alias => {
+    it.each(['#Info', '#i', '#Info.contact', '#Info[*]'])('recognizes %s as a valid value of an alias', value => {
       expect(
         assertValidRuleset.bind(null, {
           rules: {},
           aliases: {
-            alias,
+            alias: [value],
           },
         }),
       ).not.toThrow();
@@ -372,17 +372,17 @@ Error at #/rules/rule/formats/1: must be a valid format`,
       ).toThrow(new RulesetValidationError('Error at #/aliases: must be object'));
     });
 
-    it.each([null, 5])('recognizes %p as an invalid type of aliases', alias => {
+    it.each([null, 5])('recognizes %p as an invalid type of aliases', value => {
       expect(
         assertValidRuleset.bind(null, {
           rules: {},
           aliases: {
-            alias,
+            alias: [value],
           },
         }),
       ).toThrow(
         new RulesetValidationError(
-          'Error at #/aliases/alias: must be a valid JSON Path expression or a reference to the existing Alias optionally paired with a JSON Path expression subset',
+          'Error at #/aliases/alias/0: must be a valid JSON Path expression or a reference to the existing Alias optionally paired with a JSON Path expression subset',
         ),
       );
     });
@@ -392,7 +392,7 @@ Error at #/rules/rule/formats/1: must be a valid format`,
         assertValidRuleset.bind(null, {
           rules: {},
           aliases: {
-            [key]: '$.foo',
+            [key]: ['$.foo'],
           },
         }),
       ).toThrow(
@@ -402,14 +402,14 @@ Error at #/rules/rule/formats/1: must be a valid format`,
       );
     });
 
-    it.each<[unknown, string]>([
+    it.each<[unknown[], string]>([
       [
-        '',
-        'Error at #/aliases/PathItem: must be a valid JSON Path expression or a reference to the existing Alias optionally paired with a JSON Path expression subset',
+        [''],
+        'Error at #/aliases/PathItem/0: must be a valid JSON Path expression or a reference to the existing Alias optionally paired with a JSON Path expression subset',
       ],
       [
-        'foo',
-        'Error at #/aliases/PathItem: must be a valid JSON Path expression or a reference to the existing Alias optionally paired with a JSON Path expression subset',
+        ['foo'],
+        'Error at #/aliases/PathItem/0: must be a valid JSON Path expression or a reference to the existing Alias optionally paired with a JSON Path expression subset',
       ],
       [[], 'Error at #/aliases/PathItem: must be a non-empty array of expressions'],
       [
@@ -454,7 +454,7 @@ Error at #/rules/rule/formats/1: must be a valid format`,
                   targets: [
                     {
                       formats: [formatA],
-                      given: '$.definitions[*]',
+                      given: ['$.definitions[*]'],
                     },
                   ],
                 },
@@ -464,7 +464,7 @@ Error at #/rules/rule/formats/1: must be a valid format`,
         },
       );
 
-      it.each(['#Info', '#i', '#Info.contact', '#Info[*]'])('recognizes %s as a valid value of an alias', alias => {
+      it.each(['#Info', '#i', '#Info.contact', '#Info[*]'])('recognizes %s as a valid value of an alias', value => {
         expect(
           assertValidRuleset.bind(null, {
             rules: {},
@@ -473,7 +473,7 @@ Error at #/rules/rule/formats/1: must be a valid format`,
                 targets: [
                   {
                     formats: [formatA],
-                    given: alias,
+                    given: [value],
                   },
                 ],
               },
@@ -512,7 +512,7 @@ Error at #/rules/rule/formats/1: must be a valid format`,
         );
       });
 
-      it.each([{}, { formats: [] }, { given: '$' }])('demands given & formats to be present', targets => {
+      it.each([{}, { formats: [] }, { given: ['$'] }])('demands given & formats to be present', targets => {
         expect(
           assertValidRuleset.bind(null, {
             rules: {},
@@ -538,11 +538,11 @@ Error at #/rules/rule/formats/1: must be a valid format`,
                 targets: [
                   {
                     formats: [2],
-                    given: '$.definitions[*]',
+                    given: ['$.definitions[*]'],
                   },
                   {
                     formats: [formatA, 'formatB'],
-                    given: '$.components.schemas[*]',
+                    given: ['$.components.schemas[*]'],
                   },
                 ],
               },
@@ -565,11 +565,11 @@ Error at #/aliases/SchemaObject/targets/1/formats/1: must be a valid format`,
                 targets: [
                   {
                     formats: [formatA],
-                    given: '#.definitions[*]',
+                    given: ['#.definitions[*]'],
                   },
                   {
                     formats: [formatA, formatB],
-                    given: '!.components.schemas[*]',
+                    given: ['!.components.schemas[*]'],
                   },
                 ],
               },
@@ -577,7 +577,7 @@ Error at #/aliases/SchemaObject/targets/1/formats/1: must be a valid format`,
           }),
         ).toThrow(
           new RulesetValidationError(
-            `Error at #/aliases/SchemaObject/targets/1/given: must be a valid JSON Path expression or a reference to the existing Alias optionally paired with a JSON Path expression subset`,
+            `Error at #/aliases/SchemaObject/targets/1/given/0: must be a valid JSON Path expression or a reference to the existing Alias optionally paired with a JSON Path expression subset`,
           ),
         );
       });

--- a/packages/core/src/ruleset/types.ts
+++ b/packages/core/src/ruleset/types.ts
@@ -82,11 +82,11 @@ export type RulesetScopedAliasDefinition = {
   description?: string;
   targets: {
     formats: FormatsSet | Format[];
-    given: GivenDefinition;
+    given: string[];
   }[];
 };
 
-export type RulesetAliasesDefinition = Record<string, GivenDefinition | RulesetScopedAliasDefinition>;
+export type RulesetAliasesDefinition = Record<string, string[] | RulesetScopedAliasDefinition>;
 
 export type RulesetDefinition = Readonly<
   {

--- a/packages/rulesets/src/oas/index.ts
+++ b/packages/rulesets/src/oas/index.ts
@@ -32,8 +32,8 @@ const ruleset = {
   documentationUrl: 'https://meta.stoplight.io/docs/spectral/docs/reference/openapi-rules.md',
   formats: [oas2, oas3, oas3_0, oas3_1],
   aliases: {
-    PathItem: '$.paths[*]',
-    OperationObject: '#PathItem[get,put,post,delete,options,head,patch,trace]',
+    PathItem: ['$.paths[*]'],
+    OperationObject: ['#PathItem[get,put,post,delete,options,head,patch,trace]'],
   },
   rules: {
     'operation-success-response': {

--- a/test-harness/scenarios/aliases.scenario
+++ b/test-harness/scenarios/aliases.scenario
@@ -11,10 +11,10 @@ const { truthy, falsy } = require('@stoplight/spectral-functions');
 
 module.exports = {
   aliases: {
-    Info: '$..info',
-    InfoDescription: '#Info.description',
-    InfoContact: '#Info.contact',
-    InfoContactName: '#InfoContact.name',
+    Info: ['$..info'],
+    InfoDescription: ['#Info.description'],
+    InfoContact: ['#Info.contact'],
+    InfoContactName: ['#InfoContact.name'],
   },
   rules: {
     'valid-info': {

--- a/test-harness/scenarios/overrides/aliases.scenario
+++ b/test-harness/scenarios/overrides/aliases.scenario
@@ -8,7 +8,7 @@ const scenarioId = '{scenarioId}';
 
 module.exports = {
   aliases: {
-    Info: '$.info',
+    Info: ['$.info'],
   },
   rules: {
     'description-matches-stoplight': {


### PR DESCRIPTION
As requested by @mnaumanali94, aliases are arrays-only now.
This is in line with that @marbemac suggested back in the previous PR.

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [x] Yes
- [ ] No

