### PR TITLE
docs(repo): clarify how to version pin rulesets 

### DIFF
--- a/docs/guides/7-sharing-rulesets.md
+++ b/docs/guides/7-sharing-rulesets.md
@@ -116,11 +116,21 @@ extends:
   - example-spectral-ruleset
 ```
 
-Pegging a ruleset on given version is possible:
+Pegging a ruleset on given version is possible through a `package.json`:
+
+```json
+{
+  "dependencies": {
+    "example-spectral-ruleset": "0.2.0"
+  }
+}
+```
+
+Or through the use of CDNs for NPM repository, such as [unpkg.com](https://unpkg.com/):
 
 ```yaml
 extends:
-  - "example-spectral-ruleset@0.2.0"
+  - "https://unpkg.com/example-spectral-ruleset@0.2.0"
 ```
 
 ## Filesystem


### PR DESCRIPTION
As noted in #2022, the version pinning can only be done using
`package.json`s, not the `extends` rule.

**Checklist**

- [ ] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Screenshots**

N/A

**Additional context**

N/A
