### PR TITLE
chore(repo): install.sh should work in POSIX envs

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -27,7 +27,7 @@ elif [ "$UNAME" = "Linux" ] ; then
   fi
 fi
 
-if [ "$VERSION" == "latest" ] ; then
+if [ "$VERSION" = "latest" ] ; then
   URL="https://github.com/stoplightio/spectral/releases/latest/download/${FILENAME}"
 else
   URL="https://github.com/stoplightio/spectral/releases/download/v${VERSION}/${FILENAME}"


### PR DESCRIPTION
In case of no command line arguments script is failing with the following error:
./install-spectral.sh: 30: [: latest: unexpected operator
Error requesting. Download binary from https://github.com/stoplightio/spectral/releases/download/vlatest/spectral-linux

**Checklist**

- [ ] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

