### PR TITLE
fix(rulesets): operation-tags should fail on empty array

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,7 +170,7 @@ yarn test.harness
 3. In your terminal, navigate to the directory you cloned Spectral into.
 4. Install the dependencies: `yarn`
 5. Build Spectral: `yarn build`
-6. Run Spectral from your local installation: `./packages/cli/dist/index.js lint [openapi_spec_file]`
+6. Run Spectral from your local installation: `node ./packages/cli/dist/index.js lint [openapi_spec_file] --ruleset /path/to/ruleset.yaml`
 7. Create a new branch for your work: `git checkout -b [name_of_your_new_branch]`
 8. Make changes, add tests, and then run the tests: `yarn test` and `yarn workspace @stoplight/spectral-cli build.binary && yarn test.harness`
 9. Update the documentation if appropriate. For example, if you added a new rule to an OpenAPI ruleset,

--- a/packages/rulesets/src/oas/__tests__/operation-tags.test.ts
+++ b/packages/rulesets/src/oas/__tests__/operation-tags.test.ts
@@ -37,4 +37,26 @@ testRule('operation-tags', [
       },
     ],
   },
+
+  {
+    name: 'tags is empty',
+    document: {
+      swagger: '2.0',
+      paths: {
+        '/todos': {
+          get: {
+            tags: [],
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'operation-tags',
+        message: 'Operation must have non-empty "tags" array.',
+        path: ['paths', '/todos', 'get', 'tags'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
 ]);

--- a/packages/rulesets/src/oas/index.ts
+++ b/packages/rulesets/src/oas/index.ts
@@ -290,7 +290,14 @@ const ruleset = {
       given: '#OperationObject',
       then: {
         field: 'tags',
-        function: truthy,
+        function: schema,
+        functionOptions: {
+          dialect: 'draft7',
+          schema: {
+            type: 'array',
+            minItems: 1,
+          },
+        },
       },
     },
     'path-declarations-must-exist': {


### PR DESCRIPTION
Because an empty array is truthy in JS, the `operation-tags` rule needs to explicitly check on number of items in the array

**Checklist**

- [X] Tests added / updated
- [X] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No
