### PR TITLE
fix(core): consider `message` when de-duplicating results

### DIFF
--- a/docs/guides/3-javascript.md
+++ b/docs/guides/3-javascript.md
@@ -132,28 +132,3 @@ const spectral = new Spectral({ resolver: customFileResolver });
 The custom resolver we've just created will resolve all remote file refs relatively to the current working directory.
 
 More on that can be found in the [json-ref-resolver repo](https://github.com/stoplightio/json-ref-resolver).
-
-### Using a Custom De-duplication Strategy
-
-By default, Spectral will de-duplicate results based on the result code and document location. You can customize this
-behavior with the `computeFingerprint` option. For example, here is the default fingerprint implementation:
-
-The final reported results are de-duplicated based on their computed fingerprint.
-
-```ts
-const spectral = new Spectral({
-  computeFingerprint: (rule: IRuleResult, hash) => {
-    let id = String(rule.code);
-
-    if (rule.path && rule.path.length) {
-      id += JSON.stringify(rule.path);
-    } else if (rule.range) {
-      id += JSON.stringify(rule.range);
-    }
-
-    if (rule.source) id += rule.source;
-
-    return hash(id);
-  },
-});
-```

--- a/packages/core/src/utils/__tests__/__fixtures__/non-duplicate-validation-results.json
+++ b/packages/core/src/utils/__tests__/__fixtures__/non-duplicate-validation-results.json
@@ -1,0 +1,80 @@
+[
+  {
+    "code": "valid-schema-example-in-content",
+    "message": "\"schema.example\" property type should be integer",
+    "path": [
+      "paths",
+      "/resource",
+      "get",
+      "responses",
+      "200",
+      "content",
+      "application/json",
+      "schema",
+      "example"
+    ],
+    "severity": 0,
+    "range": {
+      "start": {
+        "line": 20,
+        "character": 15
+      },
+      "end": {
+        "line": 20,
+        "character": 19
+      }
+    }
+  },
+  {
+    "code": "valid-schema-example-in-content",
+    "message": "\"schema.example\" has some other valid problem",
+    "path": [
+      "paths",
+      "/resource",
+      "get",
+      "responses",
+      "200",
+      "content",
+      "application/json",
+      "schema",
+      "example"
+    ],
+    "severity": 0,
+    "range": {
+      "start": {
+        "line": 20,
+        "character": 15
+      },
+      "end": {
+        "line": 20,
+        "character": 19
+      }
+    }
+  },
+  {
+    "code": "valid-schema-example-in-content",
+    "message": "\"schema.example\" property type should be integer",
+    "path": [
+      "paths",
+      "/resource",
+      "get",
+      "responses",
+      "200",
+      "content",
+      "application/json",
+      "schema",
+      "example"
+    ],
+    "severity": 0,
+    "range": {
+      "start": {
+        "line": 20,
+        "character": 15
+      },
+      "end": {
+        "line": 20,
+        "character": 19
+      }
+    }
+  }
+]

--- a/packages/core/src/utils/__tests__/prepareResults.test.ts
+++ b/packages/core/src/utils/__tests__/prepareResults.test.ts
@@ -40,4 +40,16 @@ describe('prepareResults util', () => {
 
     expect(prepareResults(onlyDuplicates, defaultComputeResultFingerprint).length).toBe(1);
   });
+
+  it('deduplicate only exact validation results', () => {
+    // verifies that results with the same code/path but different messages will not be de-duplicated
+    expect(prepareResults(duplicateValidationResults, defaultComputeResultFingerprint)).toEqual([
+      expect.objectContaining({
+        code: 'valid-example-in-schemas',
+      }),
+      expect.objectContaining({
+        code: 'valid-schema-example-in-content',
+      }),
+    ]);
+  });
 });

--- a/packages/core/src/utils/prepareResults.ts
+++ b/packages/core/src/utils/prepareResults.ts
@@ -21,6 +21,10 @@ export const defaultComputeResultFingerprint: ComputeFingerprintFunc = (rule, ha
     id += rule.source;
   }
 
+  if (rule.message !== void 0) {
+    id += rule.message;
+  }
+
   return hash(id);
 };
 

--- a/packages/rulesets/src/oas/__tests__/duplicated-entry-in-enum.test.ts
+++ b/packages/rulesets/src/oas/__tests__/duplicated-entry-in-enum.test.ts
@@ -42,16 +42,6 @@ testRule('duplicated-entry-in-enum', [
         path: ['definitions', 'Test', 'enum'],
         severity: DiagnosticSeverity.Warning,
       },
-      {
-        message: '"enum" property must not be valid',
-        path: [ 'definitions', 'Test', 'enum' ],
-        severity: DiagnosticSeverity.Warning,
-      },
-      {
-        message: '"enum" property must match exactly one schema in oneOf',
-        path: [ 'definitions', 'Test', 'enum' ],
-        severity: DiagnosticSeverity.Warning,
-      }
     ],
   },
 
@@ -113,16 +103,6 @@ testRule('duplicated-entry-in-enum', [
         path: ['components', 'schemas', 'Test', 'enum'],
         severity: DiagnosticSeverity.Warning,
       },
-      {
-        message: '"enum" property must not be valid',
-        path: [ 'components', 'schemas', 'Test', 'enum' ],
-        severity: DiagnosticSeverity.Warning,
-      },
-      {
-        message: '"enum" property must match exactly one schema in oneOf',
-        path: [ 'components', 'schemas', 'Test', 'enum' ],
-        severity: DiagnosticSeverity.Warning,
-      }
     ],
   },
 ]);

--- a/packages/rulesets/src/oas/__tests__/duplicated-entry-in-enum.test.ts
+++ b/packages/rulesets/src/oas/__tests__/duplicated-entry-in-enum.test.ts
@@ -66,6 +66,16 @@ testRule('duplicated-entry-in-enum', [
         path: ['definitions', 'Test', 'enum'],
         severity: DiagnosticSeverity.Warning,
       },
+      {
+        message: '"enum" property must not be valid',
+        path: [ 'definitions', 'Test', 'enum' ],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        message: '"enum" property must match exactly one schema in oneOf',
+        path: [ 'definitions', 'Test', 'enum' ],
+        severity: DiagnosticSeverity.Warning,
+      }
     ],
   },
 
@@ -112,6 +122,16 @@ testRule('duplicated-entry-in-enum', [
         path: ['components', 'schemas', 'Test', 'enum'],
         severity: DiagnosticSeverity.Warning,
       },
+      {
+        message: '"enum" property must not be valid',
+        path: [ 'components', 'schemas', 'Test', 'enum' ],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        message: '"enum" property must match exactly one schema in oneOf',
+        path: [ 'components', 'schemas', 'Test', 'enum' ],
+        severity: DiagnosticSeverity.Warning,
+      }
     ],
   },
 ]);


### PR DESCRIPTION
Before this change, the `code` and `path` of the results were the primary factors
considered in de-duplication. Results that came from the same rule and same OpenAPI
artifact but had different messages were de-duplicated and not all unique results
were returned.

This change updates the logic to take `message` into account so that all unique
results are displayed to the user.

I added a new test to confirm the behavior. I also updated an existing test - one of the tests resulted in multiple results returned for the same OpenAPI artifact with different error messages. I looked into addressing the extra rules but in this case, they are a little bit redundant and so I updated the tests to make the additional results expected. Let me know how you feel about this as an approach.

I also removed the outdated docs about custom de-duplication logic.

Fixes #2038

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
