### PR TITLE
build(repo): missing latest tag for Docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,6 +218,7 @@ jobs:
               docker tag stoplight/spectral:${GIT_SHA} stoplight/spectral:${FULL_VERSION};
               docker tag stoplight/spectral:${GIT_SHA} stoplight/spectral:${MINOR_VERSION};
               docker tag stoplight/spectral:${GIT_SHA} stoplight/spectral:${MAJOR_VERSION};
+              docker tag stoplight/spectral:${GIT_SHA} stoplight/spectral:latest;
             fi
             echo "Docker tags:";
             docker images stoplight/spectral --format="{{ .Tag }}";
@@ -227,6 +228,7 @@ jobs:
               docker push stoplight/spectral:${FULL_VERSION};
               docker push stoplight/spectral:${MINOR_VERSION};
               docker push stoplight/spectral:${MAJOR_VERSION};
+              docker push stoplight/spectral:latest;
               echo "Pushed stoplight/spectral:${FULL_VERSION}";
             fi
             if [[ -n "$DOCKER_BRANCH" ]]; then


### PR DESCRIPTION
Overall things get released correctly, but we don't tag the most recent image as "latest", so when you reference `stoplight/docker` without any particular tag, it'll still pull the 6.0 version.

https://hub.docker.com/r/stoplight/spectral/tags

**Checklist**

- [ ] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

