### PR TITLE
fix(functions): reset RegExp.lastIndex to zero when using cached RegExp objects

### DIFF
--- a/packages/functions/src/__tests__/pattern.test.ts
+++ b/packages/functions/src/__tests__/pattern.test.ts
@@ -18,6 +18,12 @@ describe('Core Functions / Pattern', () => {
       expect(await runPattern('aBc', { match: '/[abc]+/im' })).toEqual([]);
     });
 
+    it('should return same results when given a global (g) marker (pattern cache usecase)', async () => {
+      expect(await runPattern('abc', { match: '/[abc]+/gi' })).toEqual([]);
+      expect(await runPattern('abc', { match: '/[abc]+/gi' })).toEqual([]);
+      expect(await runPattern('abc', { match: '/[abc]+/gi' })).toEqual([]);
+    });
+
     it('given string regex containing invalid flags, should throw an exception', async () => {
       await expect(runPattern('aBc', { match: '/[abc]+/invalid' })).rejects.toThrow(
         "Invalid flags supplied to RegExp constructor 'invalid'",

--- a/packages/functions/src/pattern.ts
+++ b/packages/functions/src/pattern.ts
@@ -27,6 +27,7 @@ const cache = new Map<string, RegExp>();
 function getFromCache(pattern: string): RegExp {
   const existingPattern = cache.get(pattern);
   if (existingPattern !== void 0) {
+    existingPattern.lastIndex = 0;
     return existingPattern;
   }
 


### PR DESCRIPTION
We have noticed that when `g` marker is used the Spectral becomes non-deterministic due to RegExp cache in `pattern` function. So, in our case, validator returns different results on every second run (please see added tests).

More details on RegExp.lastIndex:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex
https://stackoverflow.com/a/13587801/280989

**Quick example:**
```js
const rg = new RegExp("^[\\w]+$", "gi");
rg.exec("123"); // ['123', index: 0, input: '123', groups: undefined]
rg.exec("123"); // null
rg.exec("123"); // ['123', index: 0, input: '123', groups: undefined]
```


**Checklist**

- [x] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
