### PR TITLE
docs: add all AsyncAPI formats

### DIFF
--- a/docs/getting-started/3-rulesets.md
+++ b/docs/getting-started/3-rulesets.md
@@ -75,7 +75,11 @@ The `extends` keyword can be combined with extra rules in order to extend and ov
 
 Formats are an optional way to specify which API description formats a rule, or ruleset, is applicable to. Currently Spectral supports these formats:
 
-- `asyncapi2` (AsyncAPI v2.0)
+- `aas2` (AsyncAPI v2.x)
+- `aas2_0` (AsyncAPI v2.0.0)
+- `aas2_1` (AsyncAPI v2.1.0)
+- `aas2_2` (AsyncAPI v2.2.0)
+- `aas2_3` (AsyncAPI v2.3.0)
 - `oas2` (OpenAPI v2.0)
 - `oas3` (OpenAPI v3.x)
 - `oas3.0` (OpenAPI v3.0.x)


### PR DESCRIPTION
After https://github.com/stoplightio/spectral/pull/2067 I think this change was missed 🙂

Technically I think `asyncapi2` [is still supported](https://github.com/stoplightio/spectral/blob/48395273d28fc58ab450277681956b1b50f3f8ee/packages/formats/src/asyncapi.ts#L19) as is `asyncApi2` (which is not present in the docs) 🤔

I decided to remove it for the docs, not sure if that is desirable?  

##### Checklist

- [ ] Tests added / updated
- [X] Docs added / updated

##### Does this PR introduce a breaking change?

- [X] Yes
- [X] No

See above.