### PR TITLE
fix(core): bump nimma from 0.1.8 to 0.2.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,7 @@
     "lodash": "~4.17.21",
     "lodash.topath": "^4.5.2",
     "minimatch": "3.0.4",
-    "nimma": "0.1.8",
+    "nimma": "0.2.0",
     "pony-cause": "^1.0.0",
     "simple-eval": "1.0.0",
     "tslib": "^2.3.0"

--- a/packages/core/src/runner/runner.ts
+++ b/packages/core/src/runner/runner.ts
@@ -99,6 +99,7 @@ function execute(input: unknown, callbacks: Record<string, Callback[]>, jsonPath
     fallback: jsonPathPlus,
     unsafe: false,
     output: 'auto',
+    customShorthands: {},
   });
 
   nimma.query(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2403,7 +2403,7 @@ __metadata:
     lodash: ~4.17.21
     lodash.topath: ^4.5.2
     minimatch: 3.0.4
-    nimma: 0.1.8
+    nimma: 0.2.0
     nock: ^13.1.0
     pony-cause: ^1.0.0
     simple-eval: 1.0.0
@@ -9337,9 +9337,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nimma@npm:0.1.8":
-  version: 0.1.8
-  resolution: "nimma@npm:0.1.8"
+"nimma@npm:0.2.0":
+  version: 0.2.0
+  resolution: "nimma@npm:0.2.0"
   dependencies:
     "@jsep-plugin/regex": ^1.0.1
     "@jsep-plugin/ternary": ^1.0.2
@@ -9352,7 +9352,7 @@ __metadata:
       optional: true
     lodash.topath:
       optional: true
-  checksum: 0e2f832b20f7c4cc4497c82fef1bd1fee6512db5251eb59223445f9ea7749c3baa981389ef5008b46efd0aa4e11472b62e81118b5933aeafd6f234d87dd49df7
+  checksum: ed404ab3aca227a51e924e2b8d7d9ae75695c6c3fbdbaffee9990b42b5491f3c240ef3cdbbaffd1b9c3564bf062c936cb8b921de6b21ce8aa22733a00597fd2d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes https://github.com/stoplightio/spectral/issues/2066

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

Changelog:
https://github.com/P0lip/nimma/commit/c85e8ac8ed88293d762fc27dbd35ca38d616d128
https://github.com/P0lip/nimma/commit/9ac2b792280cbd968bd76e98b0ba18a32a45b43a - this will presumably be used by #2018 
https://github.com/P0lip/nimma/commit/3ffbc622a9f751d39f2da906f87469426298a46c - the actual fix