### PR TITLE
feat(rulesets): validate channel servers, server securities and operation securities

### DIFF
--- a/docs/reference/asyncapi-rules.md
+++ b/docs/reference/asyncapi-rules.md
@@ -271,7 +271,7 @@ Operation `security` values must match a scheme defined in the `components.secur
 
 ```yaml
 channels:
-  'user/signup':
+  "user/signup":
     publish:
       security:
         - petstore_auth: []
@@ -284,7 +284,7 @@ components:
 
 ```yaml
 channels:
-  'user/signup':
+  "user/signup":
     publish:
       security:
         - not_defined: []

--- a/docs/reference/asyncapi-rules.md
+++ b/docs/reference/asyncapi-rules.md
@@ -30,6 +30,48 @@ All channel parameters should be defined in the `parameters` object of the chann
 
 **Recommended:** Yes
 
+### asyncapi-channel-servers
+
+Channel servers must be defined in the `servers` object.
+
+**Bad Example**
+
+```yaml
+asyncapi: "2.0.0"
+info:
+  title: Awesome API
+  description: A very well defined API
+  version: "1.0"
+servers:
+  production:
+    url: "stoplight.io"
+    protocol: "https"
+channels:
+  hello:
+    servers:
+      - development
+```
+
+**Good Example**
+
+```yaml
+asyncapi: "2.0.0"
+info:
+  title: Awesome API
+  description: A very well defined API
+  version: "1.0"
+servers:
+  production:
+    url: "stoplight.io"
+    protocol: "https"
+channels:
+  hello:
+    servers:
+      - production
+```
+
+**Recommended:** Yes
+
 ### asyncapi-headers-schema-type-object
 
 The schema definition of the application headers must be of type “object”.
@@ -368,6 +410,12 @@ servers:
 Server URL should not point at example.com.
 
 **Recommended:** No
+
+### asyncapi-server-security
+
+Server `security` values must match a scheme defined in the `components.securitySchemes` object. It also checks if there are `oauth2` scopes that have been defined for the given security.
+
+**Recommended:** Yes
 
 ### asyncapi-server-variables
 

--- a/docs/reference/asyncapi-rules.md
+++ b/docs/reference/asyncapi-rules.md
@@ -261,6 +261,38 @@ This operation ID is essentially a reference for the operation. Tools may use it
 
 **Recommended:** Yes
 
+### asyncapi-operation-security
+
+Operation `security` values must match a scheme defined in the `components.securitySchemes` object. It also checks if there are `oauth2` scopes that have been defined for the given security.
+
+**Recommended:** Yes
+
+**Good Example**
+
+```yaml
+channels:
+  'user/signup':
+    publish:
+      security:
+        - petstore_auth: []
+components:
+  securitySchemes:
+    petstore_auth: ...
+```
+
+**Bad Example**
+
+```yaml
+channels:
+  'user/signup':
+    publish:
+      security:
+        - not_defined: []
+components:
+  securitySchemes:
+    petstore_auth: ...
+```
+
 ### asyncapi-parameter-description
 
 Parameter objects should have a `description`.
@@ -416,6 +448,32 @@ Server URL should not point at example.com.
 Server `security` values must match a scheme defined in the `components.securitySchemes` object. It also checks if there are `oauth2` scopes that have been defined for the given security.
 
 **Recommended:** Yes
+
+**Good Example**
+
+```yaml
+servers:
+  production:
+    url: test.mosquitto.org
+    security:
+      - petstore_auth: []
+components:
+  securitySchemes:
+    petstore_auth: ...
+```
+
+**Bad Example**
+
+```yaml
+servers:
+  production:
+    url: test.mosquitto.org
+    security:
+      - not_defined: []
+components:
+  securitySchemes:
+    petstore_auth: ...
+```
 
 ### asyncapi-server-variables
 

--- a/packages/rulesets/src/asyncapi/__tests__/asyncapi-channel-servers.test.ts
+++ b/packages/rulesets/src/asyncapi/__tests__/asyncapi-channel-servers.test.ts
@@ -1,0 +1,118 @@
+import { DiagnosticSeverity } from '@stoplight/types';
+import testRule from './__helpers__/tester';
+
+testRule('asyncapi-channel-servers', [
+  {
+    name: 'valid case',
+    document: {
+      asyncapi: '2.2.0',
+      servers: {
+        development: {},
+        production: {},
+      },
+      channels: {
+        channel: {
+          servers: ['development'],
+        },
+      },
+    },
+    errors: [],
+  },
+
+  {
+    name: 'valid case - without defined servers',
+    document: {
+      asyncapi: '2.2.0',
+      servers: {
+        development: {},
+        production: {},
+      },
+      channels: {
+        channel: {},
+      },
+    },
+    errors: [],
+  },
+
+  {
+    name: 'valid case - with empty array',
+    document: {
+      asyncapi: '2.2.0',
+      servers: {
+        development: {},
+        production: {},
+      },
+      channels: {
+        channel: {
+          servers: [],
+        },
+      },
+    },
+    errors: [],
+  },
+
+  {
+    name: 'invalid case',
+    document: {
+      asyncapi: '2.2.0',
+      servers: {
+        development: {},
+        production: {},
+      },
+      channels: {
+        channel: {
+          servers: ['another-server'],
+        },
+      },
+    },
+    errors: [
+      {
+        message: 'Channel contains server that are not defined on the "servers" object.',
+        path: ['channels', 'channel', 'servers', '0'],
+        severity: DiagnosticSeverity.Error,
+      },
+    ],
+  },
+
+  {
+    name: 'invalid case - one server is defined, another one not',
+    document: {
+      asyncapi: '2.2.0',
+      servers: {
+        development: {},
+        production: {},
+      },
+      channels: {
+        channel: {
+          servers: ['production', 'another-server'],
+        },
+      },
+    },
+    errors: [
+      {
+        message: 'Channel contains server that are not defined on the "servers" object.',
+        path: ['channels', 'channel', 'servers', '1'],
+        severity: DiagnosticSeverity.Error,
+      },
+    ],
+  },
+
+  {
+    name: 'invalid case - without defined servers',
+    document: {
+      asyncapi: '2.2.0',
+      channels: {
+        channel: {
+          servers: ['production'],
+        },
+      },
+    },
+    errors: [
+      {
+        message: 'Channel contains server that are not defined on the "servers" object.',
+        path: ['channels', 'channel', 'servers', '0'],
+        severity: DiagnosticSeverity.Error,
+      },
+    ],
+  },
+]);

--- a/packages/rulesets/src/asyncapi/__tests__/asyncapi-channel-servers.test.ts
+++ b/packages/rulesets/src/asyncapi/__tests__/asyncapi-channel-servers.test.ts
@@ -35,6 +35,29 @@ testRule('asyncapi-channel-servers', [
   },
 
   {
+    name: 'valid case - without defined servers in the root',
+    document: {
+      asyncapi: '2.2.0',
+      channels: {
+        channel: {},
+      },
+    },
+    errors: [],
+  },
+
+  {
+    name: 'valid case - without defined channels in the root',
+    document: {
+      asyncapi: '2.2.0',
+      servers: {
+        development: {},
+        production: {},
+      },
+    },
+    errors: [],
+  },
+
+  {
     name: 'valid case - with empty array',
     document: {
       asyncapi: '2.2.0',

--- a/packages/rulesets/src/asyncapi/__tests__/asyncapi-operation-security.test.ts
+++ b/packages/rulesets/src/asyncapi/__tests__/asyncapi-operation-security.test.ts
@@ -1,18 +1,20 @@
 import { DiagnosticSeverity } from '@stoplight/types';
 import testRule from './__helpers__/tester';
 
-testRule('asyncapi-server-security', [
+testRule('asyncapi-operation-security', [
   {
     name: 'valid case',
     document: {
-      asyncapi: '2.0.0',
-      servers: {
-        production: {
-          security: [
-            {
-              petstore_auth: [],
-            },
-          ],
+      asyncapi: '2.4.0',
+      channels: {
+        channel: {
+          publish: {
+            security: [
+              {
+                petstore_auth: [],
+              },
+            ],
+          },
         },
       },
       components: {
@@ -27,14 +29,16 @@ testRule('asyncapi-server-security', [
   {
     name: 'valid case (oauth2)',
     document: {
-      asyncapi: '2.0.0',
-      servers: {
-        production: {
-          security: [
-            {
-              petstore_auth: ['write:pets'],
-            },
-          ],
+      asyncapi: '2.4.0',
+      channels: {
+        channel: {
+          publish: {
+            security: [
+              {
+                petstore_auth: ['write:pets'],
+              },
+            ],
+          },
         },
       },
       components: {
@@ -57,16 +61,18 @@ testRule('asyncapi-server-security', [
   },
 
   {
-    name: 'invalid case',
+    name: 'invalid case (publish operation)',
     document: {
-      asyncapi: '2.0.0',
-      servers: {
-        production: {
-          security: [
-            {
-              not_defined: [],
-            },
-          ],
+      asyncapi: '2.4.0',
+      channels: {
+        channel: {
+          publish: {
+            security: [
+              {
+                not_defined: [],
+              },
+            ],
+          },
         },
       },
       components: {
@@ -77,8 +83,38 @@ testRule('asyncapi-server-security', [
     },
     errors: [
       {
-        message: 'Server must not reference an undefined security scheme.',
-        path: ['servers', 'production', 'security', '0', 'not_defined'],
+        message: 'Operation must not reference an undefined security scheme.',
+        path: ['channels', 'channel', 'publish', 'security', '0', 'not_defined'],
+        severity: DiagnosticSeverity.Error,
+      },
+    ],
+  },
+
+  {
+    name: 'invalid case (subscribe operation)',
+    document: {
+      asyncapi: '2.4.0',
+      channels: {
+        channel: {
+          subscribe: {
+            security: [
+              {
+                not_defined: [],
+              },
+            ],
+          },
+        },
+      },
+      components: {
+        securitySchemes: {
+          petstore_auth: {},
+        },
+      },
+    },
+    errors: [
+      {
+        message: 'Operation must not reference an undefined security scheme.',
+        path: ['channels', 'channel', 'subscribe', 'security', '0', 'not_defined'],
         severity: DiagnosticSeverity.Error,
       },
     ],
@@ -87,14 +123,16 @@ testRule('asyncapi-server-security', [
   {
     name: 'invalid case (oauth2)',
     document: {
-      asyncapi: '2.0.0',
-      servers: {
-        production: {
-          security: [
-            {
-              petstore_auth: ['write:pets', 'not:defined'],
-            },
-          ],
+      asyncapi: '2.4.0',
+      channels: {
+        channel: {
+          publish: {
+            security: [
+              {
+                petstore_auth: ['write:pets', 'not:defined'],
+              },
+            ],
+          },
         },
       },
       components: {
@@ -116,7 +154,7 @@ testRule('asyncapi-server-security', [
     errors: [
       {
         message: 'Non-existing security scope for the specified security scheme. Available: [write:pets, read:pets]',
-        path: ['servers', 'production', 'security', '0', 'petstore_auth', '1'],
+        path: ['channels', 'channel', 'publish', 'security', '0', 'petstore_auth', '1'],
         severity: DiagnosticSeverity.Error,
       },
     ],
@@ -125,14 +163,16 @@ testRule('asyncapi-server-security', [
   {
     name: 'invalid case (oauth2) - multiple flows and not defined scopes',
     document: {
-      asyncapi: '2.0.0',
-      servers: {
-        production: {
-          security: [
-            {
-              petstore_auth: ['write:pets', 'not:defined1', 'not:defined2'],
-            },
-          ],
+      asyncapi: '2.4.0',
+      channels: {
+        channel: {
+          publish: {
+            security: [
+              {
+                petstore_auth: ['write:pets', 'not:defined1', 'not:defined2'],
+              },
+            ],
+          },
         },
       },
       components: {
@@ -167,13 +207,13 @@ testRule('asyncapi-server-security', [
       {
         message:
           'Non-existing security scope for the specified security scheme. Available: [write:pets, read:pets, write:dogs, read:dogs, write:cats, read:cats]',
-        path: ['servers', 'production', 'security', '0', 'petstore_auth', '1'],
+        path: ['channels', 'channel', 'publish', 'security', '0', 'petstore_auth', '1'],
         severity: DiagnosticSeverity.Error,
       },
       {
         message:
           'Non-existing security scope for the specified security scheme. Available: [write:pets, read:pets, write:dogs, read:dogs, write:cats, read:cats]',
-        path: ['servers', 'production', 'security', '0', 'petstore_auth', '2'],
+        path: ['channels', 'channel', 'publish', 'security', '0', 'petstore_auth', '2'],
         severity: DiagnosticSeverity.Error,
       },
     ],
@@ -182,14 +222,16 @@ testRule('asyncapi-server-security', [
   {
     name: 'invalid case (oauth2) - not valid flow',
     document: {
-      asyncapi: '2.0.0',
-      servers: {
-        production: {
-          security: [
-            {
-              petstore_auth: ['write:pets', 'not:defined'],
-            },
-          ],
+      asyncapi: '2.4.0',
+      channels: {
+        channel: {
+          publish: {
+            security: [
+              {
+                petstore_auth: ['write:pets', 'not:defined'],
+              },
+            ],
+          },
         },
       },
       components: {
@@ -217,7 +259,7 @@ testRule('asyncapi-server-security', [
     errors: [
       {
         message: 'Non-existing security scope for the specified security scheme. Available: [write:pets, read:pets]',
-        path: ['servers', 'production', 'security', '0', 'petstore_auth', '1'],
+        path: ['channels', 'channel', 'publish', 'security', '0', 'petstore_auth', '1'],
         severity: DiagnosticSeverity.Error,
       },
     ],
@@ -226,17 +268,19 @@ testRule('asyncapi-server-security', [
   {
     name: 'invalid case (multiple securities)',
     document: {
-      asyncapi: '2.0.0',
-      servers: {
-        production: {
-          security: [
-            {
-              not_defined: [],
-            },
-            {
-              petstore_auth: ['write:pets', 'not:defined'],
-            },
-          ],
+      asyncapi: '2.4.0',
+      channels: {
+        channel: {
+          publish: {
+            security: [
+              {
+                not_defined: [],
+              },
+              {
+                petstore_auth: ['write:pets', 'not:defined'],
+              },
+            ],
+          },
         },
       },
       components: {
@@ -263,13 +307,13 @@ testRule('asyncapi-server-security', [
     },
     errors: [
       {
-        message: 'Server must not reference an undefined security scheme.',
-        path: ['servers', 'production', 'security', '0', 'not_defined'],
+        message: 'Operation must not reference an undefined security scheme.',
+        path: ['channels', 'channel', 'publish', 'security', '0', 'not_defined'],
         severity: DiagnosticSeverity.Error,
       },
       {
         message: 'Non-existing security scope for the specified security scheme. Available: [write:pets, read:pets]',
-        path: ['servers', 'production', 'security', '1', 'petstore_auth', '1'],
+        path: ['channels', 'channel', 'publish', 'security', '1', 'petstore_auth', '1'],
         severity: DiagnosticSeverity.Error,
       },
     ],

--- a/packages/rulesets/src/asyncapi/__tests__/asyncapi-operation-security.test.ts
+++ b/packages/rulesets/src/asyncapi/__tests__/asyncapi-operation-security.test.ts
@@ -27,6 +27,25 @@ testRule('asyncapi-operation-security', [
   },
 
   {
+    name: 'valid case (without security field)',
+    document: {
+      asyncapi: '2.4.0',
+      channels: {
+        channel: {
+          publish: {},
+          subscribe: {},
+        },
+      },
+      components: {
+        securitySchemes: {
+          petstore_auth: {},
+        },
+      },
+    },
+    errors: [],
+  },
+
+  {
     name: 'valid case (oauth2)',
     document: {
       asyncapi: '2.4.0',

--- a/packages/rulesets/src/asyncapi/__tests__/asyncapi-server-security.test.ts
+++ b/packages/rulesets/src/asyncapi/__tests__/asyncapi-server-security.test.ts
@@ -25,6 +25,22 @@ testRule('asyncapi-server-security', [
   },
 
   {
+    name: 'valid case (without security field)',
+    document: {
+      asyncapi: '2.0.0',
+      servers: {
+        production: {},
+      },
+      components: {
+        securitySchemes: {
+          petstore_auth: {},
+        },
+      },
+    },
+    errors: [],
+  },
+
+  {
     name: 'valid case (oauth2)',
     document: {
       asyncapi: '2.0.0',

--- a/packages/rulesets/src/asyncapi/__tests__/asyncapi-server-security.test.ts
+++ b/packages/rulesets/src/asyncapi/__tests__/asyncapi-server-security.test.ts
@@ -1,0 +1,225 @@
+import { DiagnosticSeverity } from '@stoplight/types';
+import testRule from './__helpers__/tester';
+
+testRule('asyncapi-server-security', [
+  {
+    name: 'valid case',
+    document: {
+      asyncapi: '2.0.0',
+      servers: {
+        production: {
+          security: [
+            {
+              petstore_auth: [],
+            },
+          ],
+        },
+      },
+      components: {
+        securitySchemes: {
+          petstore_auth: {},
+        },
+      },
+    },
+    errors: [],
+  },
+
+  {
+    name: 'valid case (oauth2)',
+    document: {
+      asyncapi: '2.0.0',
+      servers: {
+        production: {
+          security: [
+            {
+              petstore_auth: ['write:pets'],
+            },
+          ],
+        },
+      },
+      components: {
+        securitySchemes: {
+          petstore_auth: {
+            type: 'oauth2',
+            flows: {
+              implicit: {
+                scopes: {
+                  'write:pets': '...',
+                  'read:pets': '...',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+
+  {
+    name: 'invalid case',
+    document: {
+      asyncapi: '2.0.0',
+      servers: {
+        production: {
+          security: [
+            {
+              not_defined: [],
+            },
+          ],
+        },
+      },
+      components: {
+        securitySchemes: {
+          petstore_auth: {},
+        },
+      },
+    },
+    errors: [
+      {
+        message: 'Server must not reference an undefined security scheme.',
+        path: ['servers', 'production', 'security', '0', 'not_defined'],
+        severity: DiagnosticSeverity.Error,
+      },
+    ],
+  },
+
+  {
+    name: 'invalid case (oauth2)',
+    document: {
+      asyncapi: '2.0.0',
+      servers: {
+        production: {
+          security: [
+            {
+              petstore_auth: ['write:pets', 'not:defined'],
+            },
+          ],
+        },
+      },
+      components: {
+        securitySchemes: {
+          petstore_auth: {
+            type: 'oauth2',
+            flows: {
+              implicit: {
+                scopes: {
+                  'write:pets': '...',
+                  'read:pets': '...',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        message: 'Non-existing security scope for the specified security scheme. Available: [write:pets, read:pets]',
+        path: ['servers', 'production', 'security', '0', 'petstore_auth', '1'],
+        severity: DiagnosticSeverity.Error,
+      },
+    ],
+  },
+
+  {
+    name: 'invalid case (oauth2) - multiple flows and not defined scopes',
+    document: {
+      asyncapi: '2.0.0',
+      servers: {
+        production: {
+          security: [
+            {
+              petstore_auth: ['write:pets', 'not:defined1', 'not:defined2'],
+            },
+          ],
+        },
+      },
+      components: {
+        securitySchemes: {
+          petstore_auth: {
+            type: 'oauth2',
+            flows: {
+              implicit: {
+                scopes: {
+                  'write:pets': '...',
+                  'read:pets': '...',
+                },
+              },
+              password: {
+                scopes: {
+                  'write:dogs': '...',
+                  'read:dogs': '...',
+                },
+              },
+              clientCredentials: {
+                scopes: {
+                  'write:cats': '...',
+                  'read:cats': '...',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        message:
+          'Non-existing security scope for the specified security scheme. Available: [write:pets, read:pets, write:dogs, read:dogs, write:cats, read:cats]',
+        path: ['servers', 'production', 'security', '0', 'petstore_auth', '1'],
+        severity: DiagnosticSeverity.Error,
+      },
+      {
+        message:
+          'Non-existing security scope for the specified security scheme. Available: [write:pets, read:pets, write:dogs, read:dogs, write:cats, read:cats]',
+        path: ['servers', 'production', 'security', '0', 'petstore_auth', '2'],
+        severity: DiagnosticSeverity.Error,
+      },
+    ],
+  },
+
+  {
+    name: 'invalid case (oauth2) - not valid flow',
+    document: {
+      asyncapi: '2.0.0',
+      servers: {
+        production: {
+          security: [
+            {
+              petstore_auth: ['write:pets', 'not:defined'],
+            },
+          ],
+        },
+      },
+      components: {
+        securitySchemes: {
+          petstore_auth: {
+            type: 'oauth2',
+            flows: {
+              implicit: {
+                scopes: {
+                  'write:pets': '...',
+                  'read:pets': '...',
+                },
+              },
+              notDefinedFlow: {
+                scopes: {
+                  'write:dogs': '...',
+                  'read:dogs': '...',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        message: 'Non-existing security scope for the specified security scheme. Available: [write:pets, read:pets]',
+        path: ['servers', 'production', 'security', '0', 'petstore_auth', '1'],
+        severity: DiagnosticSeverity.Error,
+      },
+    ],
+  },
+]);

--- a/packages/rulesets/src/asyncapi/functions/asyncApi2ChannelServers.ts
+++ b/packages/rulesets/src/asyncapi/functions/asyncApi2ChannelServers.ts
@@ -36,7 +36,7 @@ export default createRulesetFunction<
     if (!targetVal.channels) return results;
     const serverNames = Object.keys(targetVal.servers ?? {});
 
-    Object.entries(targetVal.channels).forEach(([channelAddress, channel]) => {
+    Object.entries(targetVal.channels ?? {}).forEach(([channelAddress, channel]) => {
       if (!channel.servers) return;
 
       channel.servers.forEach((serverName, index) => {

--- a/packages/rulesets/src/asyncapi/functions/asyncApi2ChannelServers.ts
+++ b/packages/rulesets/src/asyncapi/functions/asyncApi2ChannelServers.ts
@@ -1,0 +1,54 @@
+import { createRulesetFunction } from '@stoplight/spectral-core';
+
+import type { IFunctionResult } from '@stoplight/spectral-core';
+
+export default createRulesetFunction<
+  { servers?: Record<string, unknown>; channels?: Record<string, { servers?: Array<string> }> },
+  null
+>(
+  {
+    input: {
+      type: 'object',
+      properties: {
+        servers: {
+          type: 'object',
+        },
+        channels: {
+          type: 'object',
+          additionalProperties: {
+            type: 'object',
+            properties: {
+              servers: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    options: null,
+  },
+  function asyncApi2ChannelServers(targetVal, _) {
+    const results: IFunctionResult[] = [];
+    if (!targetVal.channels) return results;
+    const serverNames = Object.keys(targetVal.servers ?? {});
+
+    Object.entries(targetVal.channels).forEach(([channelAddress, channel]) => {
+      if (!channel.servers) return;
+
+      channel.servers.forEach((serverName, index) => {
+        if (!serverNames.includes(serverName)) {
+          results.push({
+            message: `Channel contains server that are not defined on the "servers" object.`,
+            path: ['channels', channelAddress, 'servers', index],
+          });
+        }
+      });
+    });
+
+    return results;
+  },
+);

--- a/packages/rulesets/src/asyncapi/functions/asyncApi2Security.ts
+++ b/packages/rulesets/src/asyncapi/functions/asyncApi2Security.ts
@@ -1,0 +1,75 @@
+import { createRulesetFunction } from '@stoplight/spectral-core';
+
+import type { IFunctionResult } from '@stoplight/spectral-core';
+import { isPlainObject } from '@stoplight/json';
+
+type Scopes = {
+  scopes: Record<string, unknown>;
+};
+type OAuth2Security = {
+  implicit?: Scopes;
+  password?: Scopes;
+  clientCredentials?: Scopes;
+  authorizationCode?: Scopes;
+};
+
+const OAuth2Keys = ['implicit', 'password', 'clientCredentials', 'authorizationCode'];
+function getAllScopes(oauth2: OAuth2Security): string[] {
+  const scopes: string[] = [];
+  OAuth2Keys.forEach(key => {
+    const flow = oauth2[key] as Scopes;
+    if (isPlainObject(flow) && isPlainObject(flow)) {
+      scopes.push(...Object.keys(flow.scopes));
+    }
+  });
+  return Array.from(new Set(scopes));
+}
+
+export default createRulesetFunction<Record<string, string[]>, null>(
+  {
+    input: {
+      type: 'object',
+      additionalProperties: {
+        type: 'array',
+        items: {
+          type: 'string',
+        },
+      },
+    },
+    options: null,
+  },
+  function asyncApi2Security(targetVal = {}, _, ctx) {
+    const results: IFunctionResult[] = [];
+    const spec = ctx.document.data as {
+      components: { securitySchemes: Record<string, { type: string; flows?: OAuth2Security }> };
+    };
+    const securitySchemes = spec?.components?.securitySchemes ?? {};
+    const securitySchemesKeys = Object.keys(securitySchemes);
+
+    Object.keys(targetVal).forEach(securityKey => {
+      if (!securitySchemesKeys.includes(securityKey)) {
+        results.push({
+          message: `Server must not reference an undefined security scheme.`,
+          path: [...ctx.path, securityKey],
+        });
+      }
+
+      const securityScheme = securitySchemes[securityKey];
+      if (securityScheme?.type === 'oauth2') {
+        const availableScopes = getAllScopes(securityScheme.flows ?? {});
+        targetVal[securityKey].forEach((securityScope, index) => {
+          if (!availableScopes.includes(securityScope)) {
+            results.push({
+              message: `Non-existing security scope for the specified security scheme. Available: [${availableScopes.join(
+                ', ',
+              )}]`,
+              path: [...ctx.path, securityKey, index],
+            });
+          }
+        });
+      }
+    });
+
+    return results;
+  },
+);

--- a/packages/rulesets/src/asyncapi/functions/asyncApi2Security.ts
+++ b/packages/rulesets/src/asyncapi/functions/asyncApi2Security.ts
@@ -25,7 +25,7 @@ function getAllScopes(oauth2: OAuth2Security): string[] {
   return Array.from(new Set(scopes));
 }
 
-export default createRulesetFunction<Record<string, string[]>, null>(
+export default createRulesetFunction<Record<string, string[]>, { objectType: 'Server' | 'Operation' }>(
   {
     input: {
       type: 'object',
@@ -36,9 +36,17 @@ export default createRulesetFunction<Record<string, string[]>, null>(
         },
       },
     },
-    options: null,
+    options: {
+      type: 'object',
+      properties: {
+        objectType: {
+          type: 'string',
+          enum: ['Server', 'Operation'],
+        },
+      },
+    },
   },
-  function asyncApi2Security(targetVal = {}, _, ctx) {
+  function asyncApi2Security(targetVal = {}, { objectType }, ctx) {
     const results: IFunctionResult[] = [];
     const spec = ctx.document.data as {
       components: { securitySchemes: Record<string, { type: string; flows?: OAuth2Security }> };
@@ -49,7 +57,7 @@ export default createRulesetFunction<Record<string, string[]>, null>(
     Object.keys(targetVal).forEach(securityKey => {
       if (!securitySchemesKeys.includes(securityKey)) {
         results.push({
-          message: `Server must not reference an undefined security scheme.`,
+          message: `${objectType} must not reference an undefined security scheme.`,
           path: [...ctx.path, securityKey],
         });
       }

--- a/packages/rulesets/src/asyncapi/index.ts
+++ b/packages/rulesets/src/asyncapi/index.ts
@@ -227,6 +227,20 @@ export default {
         function: truthy,
       },
     },
+    'asyncapi-operation-security': {
+      description: 'Operation have to reference a defined security schemes.',
+      message: '{{error}}',
+      severity: 'error',
+      type: 'validation',
+      recommended: true,
+      given: '$.channels[*][publish,subscribe].security.*',
+      then: {
+        function: asyncApi2Security,
+        functionOptions: {
+          objectType: 'Operation',
+        },
+      },
+    },
     'asyncapi-parameter-description': {
       description: 'Parameter objects must have "description".',
       recommended: false,
@@ -402,6 +416,9 @@ export default {
       given: '$.servers.*.security.*',
       then: {
         function: asyncApi2Security,
+        functionOptions: {
+          objectType: 'Server',
+        },
       },
     },
     'asyncapi-servers': {

--- a/packages/rulesets/src/asyncapi/index.ts
+++ b/packages/rulesets/src/asyncapi/index.ts
@@ -9,6 +9,7 @@ import {
 } from '@stoplight/spectral-functions';
 
 import asyncApi2ChannelParameters from './functions/asyncApi2ChannelParameters';
+import asyncApi2ChannelServers from './functions/asyncApi2ChannelServers';
 import asyncApi2DocumentSchema from './functions/asyncApi2DocumentSchema';
 import asyncApi2MessageExamplesValidation from './functions/asyncApi2MessageExamplesValidation';
 import asyncApi2OperationIdUniqueness from './functions/asyncApi2OperationIdUniqueness';
@@ -16,6 +17,7 @@ import asyncApi2SchemaValidation from './functions/asyncApi2SchemaValidation';
 import asyncApi2PayloadValidation from './functions/asyncApi2PayloadValidation';
 import asyncApi2ServerVariables from './functions/asyncApi2ServerVariables';
 import { uniquenessTags } from '../shared/functions';
+import asyncApi2Security from './functions/asyncApi2Security';
 
 export default {
   documentationUrl: 'https://meta.stoplight.io/docs/spectral/docs/reference/asyncapi-rules.md',
@@ -69,6 +71,17 @@ export default {
       given: ['$.channels.*', '$.components.channels.*'],
       then: {
         function: asyncApi2ChannelParameters,
+      },
+    },
+    'asyncapi-channel-servers': {
+      description: 'Channel servers must be defined in the "servers" object.',
+      message: '{{error}}',
+      severity: 'error',
+      type: 'validation',
+      recommended: true,
+      given: '$',
+      then: {
+        function: asyncApi2ChannelServers,
       },
     },
     'asyncapi-headers-schema-type-object': {
@@ -378,6 +391,17 @@ export default {
         functionOptions: {
           notMatch: 'example\\.com',
         },
+      },
+    },
+    'asyncapi-server-security': {
+      description: 'Server have to reference a defined security schemes.',
+      message: '{{error}}',
+      severity: 'error',
+      type: 'validation',
+      recommended: true,
+      given: '$.servers.*.security.*',
+      then: {
+        function: asyncApi2Security,
       },
     },
     'asyncapi-servers': {


### PR DESCRIPTION
Fixes #2124 
Fixes #2123  
Fixes #2162

**Checklist**

- [X] Tests added / updated
- [X] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

**Additional context**

Part of #2100

This PR adds three rules:
- one validates that channel-level `servers` exist (we compare names in `servers` with those defined in `channels.*.servers`).
- second rule checks if defined security schemas in `servers.*.security` exist in `components.securitySchemes`.
- third rule checks if defined security schemas in `channels.*.[publish,subscribe].security` exist in `components.securitySchemes`.
