### PR TITLE
fix(core): redeclared rules should always be re-enabled

### DIFF
--- a/packages/core/src/ruleset/__tests__/__fixtures__/severity/off-redeclared.ts
+++ b/packages/core/src/ruleset/__tests__/__fixtures__/severity/off-redeclared.ts
@@ -1,0 +1,15 @@
+import { RulesetDefinition } from '@stoplight/spectral-core';
+import shared from './shared';
+import { truthy } from '@stoplight/spectral-functions/src';
+
+export default {
+  extends: [[shared, 'off']],
+  rules: {
+    'overridable-rule': {
+      given: '$.foo',
+      then: {
+        function: truthy,
+      },
+    },
+  },
+} as RulesetDefinition;

--- a/packages/core/src/ruleset/__tests__/ruleset.test.ts
+++ b/packages/core/src/ruleset/__tests__/ruleset.test.ts
@@ -68,6 +68,18 @@ describe('Ruleset', () => {
       expect(getEnabledRules(rules)).toEqual(['overridable-rule']);
     });
 
+    it('given ruleset with extends set to off, should disable all rules but explicitly redeclared', async () => {
+      const { rules } = await loadRuleset(import('./__fixtures__/severity/off-redeclared'));
+      expect(Object.keys(rules)).toEqual([
+        'description-matches-stoplight',
+        'title-matches-stoplight',
+        'contact-name-matches-stoplight',
+        'overridable-rule',
+      ]);
+
+      expect(getEnabledRules(rules)).toEqual(['overridable-rule']);
+    });
+
     it('given nested extends with severity set to off', async () => {
       const { rules } = await loadRuleset(import('./__fixtures__/severity/off-proxy'));
       expect(Object.keys(rules)).toEqual([

--- a/packages/core/src/ruleset/mergers/rules.ts
+++ b/packages/core/src/ruleset/mergers/rules.ts
@@ -39,7 +39,10 @@ export function mergeRule(
       break;
     case 'object':
       if (existingRule !== void 0) {
-        Object.assign(existingRule, rule, { owner: existingRule.owner });
+        Object.assign(existingRule, rule, {
+          enabled: true,
+          owner: existingRule.owner,
+        });
       } else {
         assertValidRule(rule);
         return new Rule(name, rule, ruleset);


### PR DESCRIPTION
Fixes https://github.com/stoplightio/spectral/issues/2133

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

