### PR TITLE
docs(repo): update spectral in javascript examples

### DIFF
--- a/docs/guides/3-javascript.md
+++ b/docs/guides/3-javascript.md
@@ -6,7 +6,7 @@ The Spectral CLI is a thin wrapper around a JavaScript (TypeScript) API, which c
 
 In order to consume the Spectral JS API you need to install the appropriate package.
 
-For NPM users:
+For npm users:
 
 ```bash
 npm install -g @stoplight/spectral-core

--- a/docs/guides/3-javascript.md
+++ b/docs/guides/3-javascript.md
@@ -69,7 +69,7 @@ Let's look at some other examples and how to work with external files.
 
 If you would like to run this example, make sure that you have:
 
-- An OpenAPI description document in the same directory as your script named `petstore.yaml`. You can use the one found [here](https://github.com/OAI/OpenAPI-Specification/blob/main/examples/v3.0/petstore.yaml).
+- An OpenAPI description document in the same directory as your script named `openapi.yaml`. You can use the one found [here](https://github.com/stoplightio/Public-APIs/blob/master/reference/plaid/openapi.yaml).
 - A ruleset file named `.spectral.yaml`. It can have the following contents:
 
 ```yaml
@@ -94,10 +94,10 @@ const { fetch } = spectralRuntime;
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const myDocument = new Document(
-  // load an API specification file from your project's root directory. You can use the petstore.yaml example from here: https://github.com/OAI/OpenAPI-Specification/blob/main/examples/v3.0/petstore.yaml
-  fs.readFileSync(join(__dirname, "petstore.yaml"), "utf-8").trim(),
+  // load an API specification file from your project's root directory. You can use the openapi.yaml example from here: https://github.com/stoplightio/Public-APIs/blob/master/reference/plaid/openapi.yaml
+  fs.readFileSync(join(__dirname, "openapi.yaml"), "utf-8").trim(),
   Parsers.Yaml,
-  "petstore.yaml",
+  "openapi.yaml",
 );
 
 const spectral = new Spectral();

--- a/docs/guides/3-javascript.md
+++ b/docs/guides/3-javascript.md
@@ -169,7 +169,7 @@ s.setRuleset(await bundleAndLoadRuleset("/.spectral.yaml", { fs, fetch }));
 
 ### Load Multiple Rulesets
 
-If you'd like to use the `bundleAndLoadRuleset` method to load multiple rulesets, you'll have to create a new Spectral ruleset file, and use the [`extends`](https://meta.stoplight.io/docs/spectral/01baf06bdd05a-rulesets#extending-rulesets) functionality to extend the rulesets you'd like to use.
+If you'd like to use the `bundleAndLoadRuleset` method to load multiple rulesets, you'll have to create a new Spectral ruleset file, and use the [`extends`](../getting-started/3-rulesets.md#extending-rulesets) functionality to extend the rulesets you'd like to use.
 
 ## Advanced
 

--- a/docs/guides/3-javascript.md
+++ b/docs/guides/3-javascript.md
@@ -18,20 +18,6 @@ For Yarn users:
 yarn global add @stoplight/spectral-core
 ```
 
-### CommonJS and ESM
-
-The examples on this page are written in ESM. If you're using CommonJS, you have to import an additional module:
-
-```js
-const { commonjs } = require("@stoplight/spectral-ruleset-bundler/plugins/commonjs"); needed if you want to use CommonJS
-```
-
-And if you're using the `bundleAndLoadRuleset`, you'll have to pass that variable as a parameter:
-
-```js
-s.setRuleset(await bundleAndLoadRuleset(rulesetFilepath, { fs, fetch }), [commonjs()]);
-```
-
 ## Get Started
 
 Similar to using Spectral in the CLI, there are two things you'll need to run Spectral in JS:
@@ -115,7 +101,7 @@ const myDocument = new Document(
 );
 
 const spectral = new Spectral();
-// load a ruleset file from your project's root directory. 
+// load a ruleset file from your project's root directory.
 const rulesetFilepath = path.join(__dirname, ".spectral.yaml");
 spectral.setRuleset(await bundleAndLoadRuleset(rulesetFilepath, { fs, fetch }));
 
@@ -124,7 +110,7 @@ spectral.run(myDocument).then(console.log);
 
 ### Load a JavaScript Ruleset
 
-Starting in Spectral v6.0, support was added for rulesets to be written using JavaScript. 
+Starting in Spectral v6.0, support was added for rulesets to be written using JavaScript.
 
 You can find more information about it [here](./4-custom-rulesets.md#alternative-js-ruleset-format).
 
@@ -199,11 +185,11 @@ the document Spectral lints against. You can also add support for additional pro
 
 For example:
 
-```js title="example-5.mjs" lineNumbers
-import { join } from "path";
-import { readFile } from "fs";
-import { Spectral } from "@stoplight/spectral-cli";
-import { Resolver } from "@stoplight/json-ref-resolver";
+```js title="example-5.cjs" lineNumbers
+const path = require("path");
+const fs = require("fs");
+const { Spectral } = require("@stoplight/spectral-cli");
+const { Resolver } = require("@stoplight/json-ref-resolver");
 
 const customFileResolver = new Resolver({
   resolvers: {
@@ -212,7 +198,7 @@ const customFileResolver = new Resolver({
         return new Promise((resolve, reject) => {
           const basePath = process.cwd();
           const refPath = ref.path();
-          readFile(path.join(basePath, refPath), "utf8", (err, data) => {
+          fs.readFile(path.join(basePath, refPath), "utf8", (err, data) => {
             if (err) {
               reject(err);
             } else {

--- a/docs/guides/3-javascript.md
+++ b/docs/guides/3-javascript.md
@@ -82,7 +82,7 @@ Let's look at some other examples and how to work with external files.
 
 ### Load a JSON/YAML Ruleset
 
-If you would like to run these examples, make sure that you have:
+If you would like to run this example, make sure that you have:
 
 - An OpenAPI specification file in the same directory as your script named `petstore.yaml`. You can use the one found [here](https://github.com/OAI/OpenAPI-Specification/blob/main/examples/v3.0/petstore.yaml).
 - A ruleset file named `.spectral.yaml`. It can have the following contents:
@@ -92,7 +92,7 @@ extends:
   - spectral:oas
 ```
 
-Here's an example that shows how to load an external API specification file, and an external YAML ruleset:
+Here's a script that shows how to load an external API specification file, and an external YAML ruleset:
 
 ```js
 // example-2.mjs
@@ -145,10 +145,10 @@ spectral.setRuleset(ruleset);
 Here's an example script of how you could run Spectral in the browser:
 
 ```js
-const { Spectral } = require("@stoplight/spectral-core");
-const { bundleAndLoadRuleset } = require("@stoplight/spectral-ruleset-bundler/with-loader");
+import { Spectral } from "@stoplight/spectral-core"
+import { bundleAndLoadRuleset } from "@stoplight/spectral-ruleset-bundler/with-loader";
 
-// create a ruleset that just extends the spectral:oas ruleset
+// create a ruleset that extends the spectral:oas ruleset
 const myRuleset = `extends: spectral:oas
 rules: {}`;
 
@@ -173,18 +173,21 @@ s.setRuleset(await bundleAndLoadRuleset("/.spectral.yaml", { fs, fetch }));
 
 ### How to Use a Proxy
 
-Spectral supports HTTP(S) proxies when fetching remote assets.
+Spectral supports HTTP(S) proxies when fetching remote assets:
 
 ```js
-const { Spectral } = require("@stoplight/spectral-core");
-const ProxyAgent = require("proxy-agent");
-const { createHttpAndFileResolver } = require("@stoplight/spectral-ref-resolver");
+import { Spectral } from "@stoplight/spectral-core";
+import ProxyAgent from "proxy-agent";
+import { createHttpAndFileResolver } from "@stoplight/spectral-ref-resolver";
 
+// start Spectral using a proxy
 const spectral = new Spectral({
   resolver: createHttpAndFileResolver({ agent: new ProxyAgent(process.env.PROXY) }),
 });
 
-// lint as usual - $refs and rules will be requested using the proxy
+// ... load document
+
+// ... lint document - $refs and rules will be requested using the proxy
 ```
 
 ### How to Use a Custom Resolver
@@ -195,10 +198,10 @@ the document Spectral lints against. You can also add support for additional pro
 For example:
 
 ```js
-const path = require("path");
-const fs = require("fs");
-const { Spectral } = require("@stoplight/spectral-cli");
-const { Resolver } = require("@stoplight/json-ref-resolver");
+import { join } from "path";
+import { readFile } from "fs";
+import { Spectral } from "@stoplight/spectral-cli";
+import { Resolver } from "@stoplight/json-ref-resolver";
 
 const customFileResolver = new Resolver({
   resolvers: {
@@ -207,7 +210,7 @@ const customFileResolver = new Resolver({
         return new Promise((resolve, reject) => {
           const basePath = process.cwd();
           const refPath = ref.path();
-          fs.readFile(path.join(basePath, refPath), "utf8", (err, data) => {
+          readFile(path.join(basePath, refPath), "utf8", (err, data) => {
             if (err) {
               reject(err);
             } else {
@@ -222,7 +225,9 @@ const customFileResolver = new Resolver({
 
 const spectral = new Spectral({ resolver: customFileResolver });
 
-// lint document as usual
+// ... load document
+
+// ... lint document - $refs and rules will be requested using the proxy
 ```
 
 The custom resolver we've just created will resolve all remote file refs relatively to the current working directory.

--- a/docs/guides/3-javascript.md
+++ b/docs/guides/3-javascript.md
@@ -83,7 +83,7 @@ Here's a script that shows how to load an external API specification file, and a
 import * as fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import * as path from "node:path";
-import { join } from 'path';
+import { join } from "path";
 import { bundleAndLoadRuleset } from "@stoplight/spectral-ruleset-bundler/with-loader";
 import Parsers from "@stoplight/spectral-parsers"; // make sure to install the package if you intend to use default parsers!
 import spectralCore from "@stoplight/spectral-core";
@@ -95,9 +95,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const myDocument = new Document(
   // load an API specification file from your project's root directory. You can use the petstore.yaml example from here: https://github.com/OAI/OpenAPI-Specification/blob/main/examples/v3.0/petstore.yaml
-  fs.readFileSync(join(__dirname, 'petstore.yaml'), 'utf-8').trim(),
+  fs.readFileSync(join(__dirname, "petstore.yaml"), "utf-8").trim(),
   Parsers.Yaml,
-  'petstore.yaml'
+  "petstore.yaml",
 );
 
 const spectral = new Spectral();
@@ -116,7 +116,7 @@ You can find more information about it [here](./4-custom-rulesets.md#alternative
 
 To load a JavaScript ruleset, you have to import it similar to how you would import a module:
 
-```js  lineNumbers
+```js lineNumbers
 import { Spectral } from "@stoplight/spectral-core";
 import ruleset from "./my-javascript-ruleset";
 
@@ -129,7 +129,7 @@ spectral.setRuleset(ruleset);
 Here's an example script of how you could run Spectral in the browser:
 
 ```js title="example-3.mjs" lineNumbers
-import { Spectral } from "@stoplight/spectral-core"
+import { Spectral } from "@stoplight/spectral-core";
 import { bundleAndLoadRuleset } from "@stoplight/spectral-ruleset-bundler/with-loader";
 
 // create a ruleset that extends the spectral:oas ruleset

--- a/docs/guides/3-javascript.md
+++ b/docs/guides/3-javascript.md
@@ -20,15 +20,15 @@ yarn global add @stoplight/spectral-core
 
 ## Getting Started
 
-Similar to using Spectral in the CLI, there's two things you'll need to run Spectral in JS:
+Similar to using Spectral in the CLI, there are two things you'll need to run Spectral in JS:
 
-- a string or a file representing an API specification
-- an object or a file representing a ruleset
+- A string or a file representing an API specification
+- An object or a file representing a ruleset
 
 As an example, here's a script of Spectral in action:
 
 ```js
-// example.mjs
+// example-1.mjs
 import spectralCore from "@stoplight/spectral-core";
 const { Spectral, Document } = spectralCore;
 import Parsers from "@stoplight/spectral-parsers"; // make sure to install the package if you intend to use default parsers!
@@ -69,12 +69,24 @@ And here's the same example using CommonJS:
 
 ## Load Rulesets and API Specification Files
 
-Here's another example that shows how to load an external API specification file, and an external ruleset:
+Let's look at some other examples and how to work with external files.
 
 ### Load a JSON/YAML Ruleset
 
+If you would like to run these examples, make sure that you have:
+
+- An OpenAPI specification file in the same directory as your script named `petstore.yaml`. You can use the one found [here](https://github.com/OAI/OpenAPI-Specification/blob/main/examples/v3.0/petstore.yaml).
+- A ruleset file named `.spectral.yaml`. It can have the following contents:
+
+```yaml
+extends:
+  - spectral:oas
+```
+
+Here's an example that shows how to load an external API specification file, and an external YAML ruleset:
+
 ```js
-// example.mjs
+// example-2.mjs
 import * as fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import * as path from "node:path";
@@ -89,15 +101,15 @@ const { fetch } = spectralRuntime;
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const myDocument = new Document(
-  // load an API specification file from your project's root directory
+  // load an API specification file from your project's root directory. You can use the petstore.yaml example from here: https://github.com/OAI/OpenAPI-Specification/blob/main/examples/v3.0/petstore.yaml
   fs.readFileSync(join(__dirname, 'petstore.yaml'), 'utf-8').trim(),
   Parsers.Yaml,
   'petstore.yaml'
 );
 
 const spectral = new Spectral();
-// load a ruleset file from your project's root directory
-const rulesetFilepath = path.join(__dirname, "ruleset.yaml");
+// load a ruleset file from your project's root directory. 
+const rulesetFilepath = path.join(__dirname, ".spectral.yaml");
 spectral.setRuleset(await bundleAndLoadRuleset(rulesetFilepath, { fs, fetch }));
 
 spectral.run(myDocument).then(console.log);
@@ -123,7 +135,7 @@ s.setRuleset(await bundleAndLoadRuleset(rulesetFilepath, { fs, fetch }));
 
 ### Load a JavaScript Ruleset
 
-Starting in Spectral v6.0, we add support for rulesets to be written using JavaScript. 
+Starting in Spectral v6.0, we added support for rulesets to be written using JavaScript. 
 
 You can find more information about it [here](./4-custom-rulesets.md#alternative-js-ruleset-format).
 
@@ -188,7 +200,7 @@ const spectral = new Spectral({
 
 ### Using a Custom Resolver
 
-Spectral lets you provide any custom \$ref resolver. By default, http(s) and file protocols are resolved, relatively to
+Spectral lets you provide any custom \$ref resolver. By default, HTTP(S) and file protocols are resolved, relatively to
 the document Spectral lints against. You can also add support for additional protocols, or adjust the resolution. In order to achieve that, you need to create a custom json-ref-resolver instance.
 
 For example:

--- a/docs/guides/3-javascript.md
+++ b/docs/guides/3-javascript.md
@@ -18,9 +18,9 @@ For Yarn users:
 yarn global add @stoplight/spectral-core
 ```
 
-### CommonJS and ES6
+### CommonJS and ESM
 
-The examples on this page are written in ES6. If you're using CommonJS, you have to import an additional module:
+The examples on this page are written in ESM. If you're using CommonJS, you have to import an additional module:
 
 ```js
 const { commonjs } = require("@stoplight/spectral-ruleset-bundler/plugins/commonjs"); needed if you want to use CommonJS

--- a/docs/guides/3-javascript.md
+++ b/docs/guides/3-javascript.md
@@ -18,6 +18,20 @@ For Yarn users:
 yarn global add @stoplight/spectral-core
 ```
 
+### CommonJS and ES6
+
+The examples we're showing in this page are written in ES6. If you're using CommonJS, you have to import an additional module:
+
+```js
+const { commonjs } = require("@stoplight/spectral-ruleset-bundler/plugins/commonjs"); needed if you want to use CommonJS
+```
+
+And if you're using the `bundleAndLoadRuleset`, you'll have to pass that variable as a parameter:
+
+```js
+s.setRuleset(await bundleAndLoadRuleset(rulesetFilepath, { fs, fetch }), [commonjs()]);
+```
+
 ## Getting Started
 
 Similar to using Spectral in the CLI, there are two things you'll need to run Spectral in JS:
@@ -60,11 +74,6 @@ spectral.setRuleset({
 
 // we lint our document using the ruleset we passed to the Spectral object
 spectral.run(myDocument).then(console.log);
-```
-
-And here's the same example using CommonJS:
-
-```js
 ```
 
 ## Load Rulesets and API Specification Files
@@ -115,24 +124,6 @@ spectral.setRuleset(await bundleAndLoadRuleset(rulesetFilepath, { fs, fetch }));
 spectral.run(myDocument).then(console.log);
 ```
 
-And here's the same example using CommonJS:
-
-```js
-const path = require("path");
-const fs = require("fs");
-
-const { Spectral } = require("@stoplight/spectral-core");
-const { fetch } = require("@stoplight/spectral-runtime"); // can also use isomorphic-fetch, etc.. If you ruleset does not reference any external assets, you can provide some stub instead.
-const { bundleAndLoadRuleset } = require("@stoplight/spectral-ruleset-bundler/with-loader");
-// const { commonjs } = require("@stoplight/spectral-ruleset-bundler/plugins/commonjs"); needed if you want to use CommonJS
-
-const rulesetFilepath = path.join(__dirname, ".spectral.yaml");
-
-const spectral = new Spectral();
-s.setRuleset(await bundleAndLoadRuleset(rulesetFilepath, { fs, fetch }));
-// or, if you use module.exports (CommonJS) s.setRuleset(await bundleAndLoadRuleset(rulesetFilepath, { fs, fetch }), [commonjs()]);
-```
-
 ### Load a JavaScript Ruleset
 
 Starting in Spectral v6.0, we added support for rulesets to be written using JavaScript. 
@@ -156,7 +147,6 @@ Here's an example script of how you could run Spectral in the browser:
 ```js
 const { Spectral } = require("@stoplight/spectral-core");
 const { bundleAndLoadRuleset } = require("@stoplight/spectral-ruleset-bundler/with-loader");
-// const { commonjs } = require("@stoplight/spectral-ruleset-bundler/plugins/commonjs"); needed if you want to use CommonJS
 
 // create a ruleset that just extends the spectral:oas ruleset
 const myRuleset = `extends: spectral:oas
@@ -177,12 +167,11 @@ const fs = {
 
 const spectral = new Spectral();
 s.setRuleset(await bundleAndLoadRuleset("/.spectral.yaml", { fs, fetch }));
-// or, if you use module.exports (CommonJS) s.setRuleset(await bundleAndLoadRuleset(rulesetFilepath, { fs, fetch }), [commonjs()]);
 ```
 
 ## Advanced
 
-### Using a Proxy
+### How to Use a Proxy
 
 Spectral supports HTTP(S) proxies when fetching remote assets.
 
@@ -198,7 +187,7 @@ const spectral = new Spectral({
 // lint as usual - $refs and rules will be requested using the proxy
 ```
 
-### Using a Custom Resolver
+### How to Use a Custom Resolver
 
 Spectral lets you provide any custom \$ref resolver. By default, HTTP(S) and file protocols are resolved, relatively to
 the document Spectral lints against. You can also add support for additional protocols, or adjust the resolution. In order to achieve that, you need to create a custom json-ref-resolver instance.

--- a/docs/guides/3-javascript.md
+++ b/docs/guides/3-javascript.md
@@ -22,7 +22,7 @@ yarn global add @stoplight/spectral-core
 
 Similar to using Spectral in the CLI, there are two things you'll need to run Spectral in JS:
 
-- A string or a file representing an API specification
+- A string or a file containing your structured data (OpenAPI, AsyncAPI, Kubernetes, etc).
 - An object or a file representing a ruleset
 
 As an example, here's a script of Spectral in action:
@@ -69,7 +69,7 @@ Let's look at some other examples and how to work with external files.
 
 If you would like to run this example, make sure that you have:
 
-- An OpenAPI specification file in the same directory as your script named `petstore.yaml`. You can use the one found [here](https://github.com/OAI/OpenAPI-Specification/blob/main/examples/v3.0/petstore.yaml).
+- An OpenAPI description document in the same directory as your script named `petstore.yaml`. You can use the one found [here](https://github.com/OAI/OpenAPI-Specification/blob/main/examples/v3.0/petstore.yaml).
 - A ruleset file named `.spectral.yaml`. It can have the following contents:
 
 ```yaml

--- a/docs/guides/3-javascript.md
+++ b/docs/guides/3-javascript.md
@@ -4,7 +4,7 @@ The Spectral CLI is a thin wrapper around a JavaScript (TypeScript) API, which c
 
 ## Prerequisites
 
-In order to consume the Spectral JS API you need to install the appropriate package.
+To use the Spectral JS API, you need to install the appropriate package.
 
 For npm users:
 
@@ -20,7 +20,7 @@ yarn global add @stoplight/spectral-core
 
 ### CommonJS and ES6
 
-The examples we're showing in this page are written in ES6. If you're using CommonJS, you have to import an additional module:
+The examples on this page are written in ES6. If you're using CommonJS, you have to import an additional module:
 
 ```js
 const { commonjs } = require("@stoplight/spectral-ruleset-bundler/plugins/commonjs"); needed if you want to use CommonJS
@@ -32,7 +32,7 @@ And if you're using the `bundleAndLoadRuleset`, you'll have to pass that variabl
 s.setRuleset(await bundleAndLoadRuleset(rulesetFilepath, { fs, fetch }), [commonjs()]);
 ```
 
-## Getting Started
+## Get Started
 
 Similar to using Spectral in the CLI, there are two things you'll need to run Spectral in JS:
 
@@ -41,8 +41,7 @@ Similar to using Spectral in the CLI, there are two things you'll need to run Sp
 
 As an example, here's a script of Spectral in action:
 
-```js
-// example-1.mjs
+```js title="example-1.mjs" lineNumbers
 import spectralCore from "@stoplight/spectral-core";
 const { Spectral, Document } = spectralCore;
 import Parsers from "@stoplight/spectral-parsers"; // make sure to install the package if you intend to use default parsers!
@@ -94,8 +93,7 @@ extends:
 
 Here's a script that shows how to load an external API specification file, and an external YAML ruleset:
 
-```js
-// example-2.mjs
+```js title="example-2.mjs" lineNumbers
 import * as fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import * as path from "node:path";
@@ -126,13 +124,13 @@ spectral.run(myDocument).then(console.log);
 
 ### Load a JavaScript Ruleset
 
-Starting in Spectral v6.0, we added support for rulesets to be written using JavaScript. 
+Starting in Spectral v6.0, support was added for rulesets to be written using JavaScript. 
 
 You can find more information about it [here](./4-custom-rulesets.md#alternative-js-ruleset-format).
 
 To load a JavaScript ruleset, you have to import it similar to how you would import a module:
 
-```js
+```js  lineNumbers
 import { Spectral } from "@stoplight/spectral-core";
 import ruleset from "./my-javascript-ruleset";
 
@@ -144,7 +142,7 @@ spectral.setRuleset(ruleset);
 
 Here's an example script of how you could run Spectral in the browser:
 
-```js
+```js title="example-3.mjs" lineNumbers
 import { Spectral } from "@stoplight/spectral-core"
 import { bundleAndLoadRuleset } from "@stoplight/spectral-ruleset-bundler/with-loader";
 
@@ -169,13 +167,17 @@ const spectral = new Spectral();
 s.setRuleset(await bundleAndLoadRuleset("/.spectral.yaml", { fs, fetch }));
 ```
 
+### Load Multiple Rulesets
+
+If you'd like to use the `bundleAndLoadRuleset` method to load multiple rulesets, you'll have to create a new Spectral ruleset file, and use the [`extends`](https://meta.stoplight.io/docs/spectral/01baf06bdd05a-rulesets#extending-rulesets) functionality to extend the rulesets you'd like to use.
+
 ## Advanced
 
 ### How to Use a Proxy
 
 Spectral supports HTTP(S) proxies when fetching remote assets:
 
-```js
+```js title="example-4.mjs" lineNumbers
 import { Spectral } from "@stoplight/spectral-core";
 import ProxyAgent from "proxy-agent";
 import { createHttpAndFileResolver } from "@stoplight/spectral-ref-resolver";
@@ -193,11 +195,11 @@ const spectral = new Spectral({
 ### How to Use a Custom Resolver
 
 Spectral lets you provide any custom \$ref resolver. By default, HTTP(S) and file protocols are resolved, relatively to
-the document Spectral lints against. You can also add support for additional protocols, or adjust the resolution. In order to achieve that, you need to create a custom json-ref-resolver instance.
+the document Spectral lints against. You can also add support for additional protocols, or adjust the resolution. To achieve that, you need to create a custom json-ref-resolver instance.
 
 For example:
 
-```js
+```js title="example-5.mjs" lineNumbers
 import { join } from "path";
 import { readFile } from "fs";
 import { Spectral } from "@stoplight/spectral-cli";
@@ -230,7 +232,7 @@ const spectral = new Spectral({ resolver: customFileResolver });
 // ... lint document - $refs and rules will be requested using the proxy
 ```
 
-The custom resolver we've just created will resolve all remote file refs relatively to the current working directory.
+This custom resolver will resolve all remote file refs relatively to the current working directory.
 
 You can find more information about how to create custom resolvers in
 the [@stoplight/json-ref-resolver](https://github.com/stoplightio/json-ref-resolver) repository.


### PR DESCRIPTION
Fixes #2178, #2148.

**Checklist**

- [ ] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Additional context**

I tried to make this document a little bit more beginner-friendly as I tried to run some of these examples myself while learning Spectral:

- Replaced all `require` statements to `import`
- Moved the mentions of CommonJS to its own section
- Added a section explaining how to load multiple rulesets using the `bundleAndLoadRuleset` method
- Added an example showing how to load an external specification file
- Added link to JS ruleset section in Custom Rulesets page

Not sure if I tried to do too many changes here, would really appreciate some feedback!