### PR TITLE
fix(core): fix 'resolved vs unresolved' json path mapping

### DIFF
--- a/packages/cli/src/services/__tests__/linter.test.ts
+++ b/packages/cli/src/services/__tests__/linter.test.ts
@@ -472,9 +472,10 @@ describe('Linter service', () => {
         {
           code: 'info-matches-stoplight',
           message: 'Info must contain Stoplight',
-          path: ['info', 'title'],
+          path: [],
           range: expect.any(Object),
           severity: DiagnosticSeverity.Warning,
+          source: expect.stringContaining('__fixtures__/resolver/document.json'),
         },
       ]);
     });

--- a/packages/core/src/__tests__/__fixtures__/gh-658/URIError.yaml
+++ b/packages/core/src/__tests__/__fixtures__/gh-658/URIError.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "404":
+          $ref: './lib.yaml#/components/responses/NotFoundResponse'
         "500":
           description: No Bueno.
           content:

--- a/packages/core/src/__tests__/__fixtures__/gh-658/lib.yaml
+++ b/packages/core/src/__tests__/__fixtures__/gh-658/lib.yaml
@@ -22,3 +22,26 @@ components:
           type: string
         test:
           $ref: ./URIError.yaml#/components/schemas/Foo
+    NotFound:
+      oneOf:
+        - $ref: '#/components/schemas/DoesntExist'
+        - $ref: '#/components/schemas/JustCantFindIt'
+    DoesntExist:
+      type: object
+      properties:
+        id:
+          type: string
+    JustCantFindIt:
+      type: object
+      properties:
+        name:
+          type: string
+
+  responses:
+    NotFoundResponse:
+      description: Not Found.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/NotFound'
+      

--- a/packages/core/src/__tests__/spectral.jest.test.ts
+++ b/packages/core/src/__tests__/spectral.jest.test.ts
@@ -190,7 +190,7 @@ describe('Spectral', () => {
 
     const results = await s.run(new Document(fs.readFileSync(documentUri, 'utf8'), Parsers.Yaml, documentUri));
 
-    expect(results.length).toEqual(3);
+    expect(results.length).toEqual(5);
 
     return expect(results).toEqual([
       expect.objectContaining({
@@ -204,6 +204,36 @@ describe('Spectral', () => {
           start: {
             character: 20,
             line: 20,
+          },
+        },
+      }),
+
+      expect.objectContaining({
+        path: ['components', 'schemas', 'DoesntExist', 'properties', 'id'],
+        source: expect.stringContaining('/src/__tests__/__fixtures__/gh-658/lib.yaml'),
+        range: {
+          end: {
+            character: 22,
+            line: 32,
+          },
+          start: {
+            character: 11,
+            line: 31,
+          },
+        },
+      }),
+
+      expect.objectContaining({
+        path: ['components', 'schemas', 'JustCantFindIt', 'properties', 'name'],
+        source: expect.stringContaining('/src/__tests__/__fixtures__/gh-658/lib.yaml'),
+        range: {
+          end: {
+            character: 22,
+            line: 37,
+          },
+          start: {
+            character: 13,
+            line: 36,
           },
         },
       }),
@@ -229,11 +259,11 @@ describe('Spectral', () => {
         range: {
           end: {
             character: 18,
-            line: 43,
+            line: 45,
           },
           start: {
             character: 8,
-            line: 42,
+            line: 44,
           },
         },
       }),


### PR DESCRIPTION
This PR improves the DocumentInventory.findAssociatedItemForPath() function
by slightly changing the approach used to map a path from the resolved document
back to the corresponding path within the original unresolved document.
The result is a more accurate mapping due to the fact that the updated code
now more closely mimics the steps performed by the resolver when processing
the $refs, but just in reverse. 

Fixes #2059
Fixes #2043

**Checklist**

- [x] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
