### PR TITLE
Fix unused percent encoded

### DIFF
--- a/packages/functions/src/unreferencedReusableObject.ts
+++ b/packages/functions/src/unreferencedReusableObject.ts
@@ -1,5 +1,6 @@
 import { createRulesetFunction } from '@stoplight/spectral-core';
 import { safePointerToPath } from '@stoplight/spectral-runtime';
+import { decodePointer } from '@stoplight/json';
 
 import { optionSchemas } from './optionSchemas';
 
@@ -24,7 +25,9 @@ export default createRulesetFunction<Record<string, unknown>, Options>(
 
     const defined = Object.keys(data).map(name => `${normalizedSource}${opts.reusableObjectsLocation}/${name}`);
 
-    const orphans = defined.filter(defPath => !graph.hasNode(defPath));
+    const decodedNodes = new Set(graph.overallOrder().map(n => decodePointer(n)));
+
+    const orphans = defined.filter(defPath => !decodedNodes.has(defPath));
 
     return orphans.map(orphanPath => {
       return {

--- a/packages/rulesets/src/oas/__tests__/oas2-unused-definition.test.ts
+++ b/packages/rulesets/src/oas/__tests__/oas2-unused-definition.test.ts
@@ -201,4 +201,32 @@ testRule('oas2-unused-definition', [
       [indirect2Document.source!]: indirect2Document.data,
     },
   },
+
+  {
+    name: 'all components are referenced with percent-encoded refs',
+    document: {
+      swagger: '2.0',
+      paths: {
+        '/path': {
+          post: {
+            parameters: [
+              {
+                name: '$body',
+                in: 'body',
+                schema: {
+                  $ref: '#/definitions/%24body',
+                },
+              },
+            ],
+          },
+        },
+      },
+      definitions: {
+        $body: {
+          type: 'string',
+        },
+      },
+    },
+    errors: [],
+  },
 ]);

--- a/packages/rulesets/src/oas/__tests__/oas3-unused-component.test.ts
+++ b/packages/rulesets/src/oas/__tests__/oas3-unused-component.test.ts
@@ -204,4 +204,54 @@ testRule('oas3-unused-component', [
       [indirect2Document.source!]: indirect2Document.data,
     },
   },
+  {
+    name: 'all components are referenced with percent-encoded refs',
+    document: {
+      openapi: '3.0.0',
+      paths: {
+        '/path': {
+          get: {
+            parameters: [
+              {
+                $ref: '#/components/parameters/%24top',
+              },
+            ],
+            responses: {
+              200: {
+                description: 'Success',
+                content: {
+                  'application/json': {
+                    $ref: '#/components/schemas/$resource',
+                  },
+                },
+              },
+              default: {
+                $ref: '#/components/responses/%24default',
+              },
+            },
+          },
+        },
+      },
+      components: {
+        parameters: {
+          $top: {
+            name: '$top',
+            in: 'query',
+            type: 'integer',
+          },
+        },
+        responses: {
+          $default: {
+            description: 'Ruh Roh',
+          },
+        },
+        schemas: {
+          $resource: {
+            type: 'string',
+          },
+        },
+      },
+    },
+    errors: [],
+  },
 ]);


### PR DESCRIPTION
This PR fixes the used component rules to handle percent-encoded refs to components.

**Checklist**

- [x] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
