### PR TITLE
docs(rulesets): link to spectral-rulesets

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
 * @stoplightio/oss-spectral
+
+/docs @stoplightio/documentation
+
 /packages/rulesets/src/asyncapi @magicmatatjahu @smoya @jonaslagoni


### PR DESCRIPTION
No issue, just updating docs as requested by marc and jason, to help folks find more examples of Spectral being used in the wild for more than just "is my OpenAPI valid or not".

**Checklist**

- [ ] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
