### PR TITLE
feat(rulesets): validate unresolved AsyncAPI document

### DIFF
--- a/docs/reference/asyncapi-rules.md
+++ b/docs/reference/asyncapi-rules.md
@@ -447,6 +447,12 @@ Validate structure of AsyncAPI v2 specification.
 
 **Recommended:** Yes
 
+### asyncapi-schema-unresolved
+
+Validate unresolved (all "$ref" have not been replaced with the objects they point to) structure of AsyncAPI v2 specification.
+
+**Recommended:** Yes
+
 ### asyncapi-server-no-empty-variable
 
 Server URL variable declarations cannot be empty, ex.`gigantic-server.com/{}` is invalid.

--- a/packages/functions/src/optionSchemas.ts
+++ b/packages/functions/src/optionSchemas.ts
@@ -172,6 +172,7 @@ export const optionSchemas: Record<string, CustomFunctionOptionsSchema> = {
         type: 'object',
         description:
           'Assigns a unique id (by reference to the JS object) to a schema. It is used to optimize the creation of a validation function for a given schema; a given function will be stored by given id and retrieved between execution of validation.',
+        'x-internal': true,
       },
       prepareResults: {
         'x-internal': true,

--- a/packages/functions/src/optionSchemas.ts
+++ b/packages/functions/src/optionSchemas.ts
@@ -168,6 +168,11 @@ export const optionSchemas: Record<string, CustomFunctionOptionsSchema> = {
         default: false,
         description: 'Returns all errors when true; otherwise only returns the first error.',
       },
+      uniqueId: {
+        type: 'object',
+        description:
+          'Assigns a unique id (by reference to the JS object) to a schema. It is used to optimize the creation of a validation function for a given schema; a given function will be stored by given id and retrieved between execution of validation.',
+      },
       prepareResults: {
         'x-internal': true,
       },

--- a/packages/functions/src/schema/index.ts
+++ b/packages/functions/src/schema/index.ts
@@ -12,10 +12,14 @@ export type Options = {
   schema: Record<string, unknown> | JSONSchema;
   allErrors?: boolean;
   dialect?: 'auto' | 'draft4' | 'draft6' | 'draft7' | 'draft2019-09' | 'draft2020-12';
+  uniqueId?: object;
   prepareResults?(errors: ErrorObject[]): void;
 };
 
-const instances = new WeakMap<RulesetFunctionContext['documentInventory'], ReturnType<typeof createAjvInstances>>();
+const instances = new WeakMap<
+  object | RulesetFunctionContext['documentInventory'],
+  ReturnType<typeof createAjvInstances>
+>();
 
 export default createRulesetFunction<unknown, Options>(
   {
@@ -32,10 +36,11 @@ export default createRulesetFunction<unknown, Options>(
       ];
     }
 
+    const uniqueId = opts.uniqueId ?? documentInventory;
     const assignAjvInstance =
-      instances.get(documentInventory) ??
+      instances.get(uniqueId) ??
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      instances.set(documentInventory, createAjvInstances()).get(documentInventory)!;
+      instances.set(uniqueId, createAjvInstances()).get(uniqueId)!;
 
     const results: IFunctionResult[] = [];
 

--- a/packages/rulesets/src/asyncapi/__tests__/asyncapi-schema-unresolved.test.ts
+++ b/packages/rulesets/src/asyncapi/__tests__/asyncapi-schema-unresolved.test.ts
@@ -1,0 +1,86 @@
+import { DiagnosticSeverity } from '@stoplight/types';
+import testRule from './__helpers__/tester';
+
+testRule('asyncapi-schema-unresolved', [
+  {
+    name: 'valid case',
+    document: {
+      asyncapi: '2.0.0',
+      info: {
+        title: 'Valid AsyncApi document',
+        version: '1.0',
+      },
+      channels: {
+        someChannel: {
+          publish: {
+            message: {
+              $ref: '#/components/messages/someMessage',
+            },
+          },
+        },
+      },
+      components: {
+        messages: {
+          someMessage: {},
+        },
+      },
+    },
+    errors: [],
+  },
+
+  {
+    name: 'invalid case (reference for operation object is not allowed)',
+    document: {
+      asyncapi: '2.0.0',
+      info: {
+        title: 'Valid AsyncApi document',
+        version: '1.0',
+      },
+      channels: {
+        someChannel: {
+          publish: {
+            $ref: '#/components/x-operations/someOperation',
+          },
+        },
+      },
+      components: {
+        'x-operations': {
+          someOperation: {},
+        },
+      },
+    },
+    errors: [
+      {
+        message: 'Referencing here is not allowed',
+        path: ['channels', 'someChannel', 'publish', '$ref'],
+        severity: DiagnosticSeverity.Error,
+      },
+    ],
+  },
+
+  {
+    name: 'invalid case (case when other errors should also occur but we filter them out - required info field is omitted)',
+    document: {
+      asyncapi: '2.0.0',
+      channels: {
+        someChannel: {
+          publish: {
+            $ref: '#/components/x-operations/someOperation',
+          },
+        },
+      },
+      components: {
+        'x-operations': {
+          someOperation: {},
+        },
+      },
+    },
+    errors: [
+      {
+        message: 'Referencing here is not allowed',
+        path: ['channels', 'someChannel', 'publish', '$ref'],
+        severity: DiagnosticSeverity.Error,
+      },
+    ],
+  },
+]);

--- a/packages/rulesets/src/asyncapi/__tests__/asyncapi-schema.test.ts
+++ b/packages/rulesets/src/asyncapi/__tests__/asyncapi-schema.test.ts
@@ -33,7 +33,7 @@ testRule('asyncapi-schema', [
   },
 
   {
-    name: 'valid case (case when other errors should also occur but we filter them out - operations cannot be references)',
+    name: 'valid case (case when other errors should also occur but we filter them out)',
     document: {
       asyncapi: '2.0.0',
       info: {

--- a/packages/rulesets/src/asyncapi/__tests__/asyncapi-schema.test.ts
+++ b/packages/rulesets/src/asyncapi/__tests__/asyncapi-schema.test.ts
@@ -14,8 +14,9 @@ testRule('asyncapi-schema', [
     },
     errors: [],
   },
+
   {
-    name: 'channels property is missing',
+    name: 'invalid case (channels property is missing)',
     document: {
       asyncapi: '2.0.0',
       info: {
@@ -23,6 +24,35 @@ testRule('asyncapi-schema', [
         version: '1.0',
       },
     },
-    errors: [{ message: 'Object must have required property "channels"', severity: DiagnosticSeverity.Error }],
+    errors: [
+      {
+        message: 'Object must have required property "channels"',
+        severity: DiagnosticSeverity.Error,
+      },
+    ],
+  },
+
+  {
+    name: 'valid case (case when other errors should also occur but we filter them out - operations cannot be references)',
+    document: {
+      asyncapi: '2.0.0',
+      info: {
+        title: 'Valid AsyncApi document',
+        version: '1.0',
+      },
+      channels: {
+        someChannel: {
+          publish: {
+            $ref: '#/components/x-operations/someOperation',
+          },
+        },
+      },
+      components: {
+        'x-operations': {
+          someOperation: {},
+        },
+      },
+    },
+    errors: [],
   },
 ]);

--- a/packages/rulesets/src/asyncapi/functions/asyncApi2DocumentSchema.ts
+++ b/packages/rulesets/src/asyncapi/functions/asyncApi2DocumentSchema.ts
@@ -104,7 +104,7 @@ function getSchema(formats: Set<Format>): Record<string, unknown> | void {
   }
 }
 
-// For optimizing the retrieving/creation of AJV's validation funcition for a given AsyncAPI version.
+// For optimizing the retrieving/creation of AJV's validation function for a given AsyncAPI version.
 // Currently each validation run creates a separate `documentInventory` (needed by `schemaFn`), which serves as an identifier for the weakMap's element of available AJV's validation functions.
 // This variable will always be the same for each validation run, regardless of the number of runs or Spectral instances.
 const CONST_DOCUMENT_INVENTORY: RulesetFunctionContext['documentInventory'] =

--- a/packages/rulesets/src/asyncapi/index.ts
+++ b/packages/rulesets/src/asyncapi/index.ts
@@ -385,6 +385,25 @@ export default {
       given: '$',
       then: {
         function: asyncApi2DocumentSchema,
+        functionOptions: {
+          resolved: true,
+        },
+      },
+    },
+    'asyncapi-schema-unresolved': {
+      description:
+        'Validate unresolved (all "$ref" have not been replaced with the objects they point to) structure of AsyncAPI v2 specification.',
+      message: '{{error}}',
+      severity: 'error',
+      recommended: true,
+      type: 'validation',
+      resolved: false,
+      given: '$',
+      then: {
+        function: asyncApi2DocumentSchema,
+        functionOptions: {
+          resolved: false,
+        },
       },
     },
     'asyncapi-server-variables': {


### PR DESCRIPTION
Fixes #2261.

**Checklist**

- [X] Tests added / updated
- [X] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

**Screenshots**

The following AsyncAPI document is invalid and Spectral should throw errors due to invalid defined references (in impossible places):

```yaml
asyncapi: '2.0.0'
channels: 
  someChannel:
    publish:
      $ref: '#/components/x-operations/someOperation'
components:
  'x-operations':
    someOperation: ...
```

and Spectral will return errors:

```yaml
[
  {
    message: 'Referencing here is not allowed',
    path: ['channels', 'someChannel', 'publish', '$ref'],
    severity: DiagnosticSeverity.Error,
  }
]
```