### PR TITLE
feat(rulesets): add rule to check if messageId is defined

### DIFF
--- a/docs/reference/asyncapi-rules.md
+++ b/docs/reference/asyncapi-rules.md
@@ -261,7 +261,7 @@ channels:
 
 ### asyncapi-message-messageId
 
-Each Message should have a "messageId" field defined. It is recommended, but still optional. Tools can use it to define function names, class method names and even URL passwords in documentation systems.
+Each Message should have a "messageId" field defined. It is recommended, but still optional. Tools can use it to define function names, class method names and even URL hashes in documentation systems.
 
 **Recommended:** Yes
 
@@ -303,7 +303,7 @@ channels:
 
 ### asyncapi-operation-operationId
 
-Each Operation should have a "operationId" field defined. It is recommended, but still optional. Tools can use it to define function names, class method names and even URL passwords in documentation systems.
+Each Operation must have an "operationId" field defined. Tools can use it to define function names, class method names and even URL hashes in documentation systems.
 
 **Recommended:** Yes
 

--- a/docs/reference/asyncapi-rules.md
+++ b/docs/reference/asyncapi-rules.md
@@ -259,6 +259,12 @@ channels:
         messageId: turnOffMessage
 ```
 
+### asyncapi-message-messageId
+
+Each Message should have a "messageId" field defined. It is recommended, but still optional. Tools can use it to define function names, class method names and even URL passwords in documentation systems.
+
+**Recommended:** Yes
+
 ### asyncapi-operation-description
 
 Operation objects should have a description.
@@ -297,7 +303,7 @@ channels:
 
 ### asyncapi-operation-operationId
 
-This operation ID is essentially a reference for the operation. Tools may use it for defining function names, class method names, and even URL hashes in documentation systems.
+Each Operation should have a "operationId" field defined. It is recommended, but still optional. Tools can use it to define function names, class method names and even URL passwords in documentation systems.
 
 **Recommended:** Yes
 

--- a/packages/formats/src/asyncapi.ts
+++ b/packages/formats/src/asyncapi.ts
@@ -39,3 +39,9 @@ aas2_3.displayName = 'AsyncAPI 2.3.x';
 export const aas2_4: Format = (document: unknown): boolean =>
   isAas2(document) && aas2_4Regex.test(String((document as MaybeAAS2).asyncapi));
 aas2_4.displayName = 'AsyncAPI 2.4.x';
+
+export const all_aas2: Format[] = [aas2_0, aas2_1, aas2_2, aas2_3, aas2_4];
+export const from_aas2_1: Format[] = [aas2_1, aas2_2, aas2_3, aas2_4];
+export const from_aas2_2: Format[] = [aas2_2, aas2_3, aas2_4];
+export const from_aas2_3: Format[] = [aas2_3, aas2_4];
+export const from_aas2_4: Format[] = [aas2_4];

--- a/packages/formats/src/asyncapi.ts
+++ b/packages/formats/src/asyncapi.ts
@@ -39,9 +39,3 @@ aas2_3.displayName = 'AsyncAPI 2.3.x';
 export const aas2_4: Format = (document: unknown): boolean =>
   isAas2(document) && aas2_4Regex.test(String((document as MaybeAAS2).asyncapi));
 aas2_4.displayName = 'AsyncAPI 2.4.x';
-
-export const all_aas2: Format[] = [aas2_0, aas2_1, aas2_2, aas2_3, aas2_4];
-export const from_aas2_1: Format[] = [aas2_1, aas2_2, aas2_3, aas2_4];
-export const from_aas2_2: Format[] = [aas2_2, aas2_3, aas2_4];
-export const from_aas2_3: Format[] = [aas2_3, aas2_4];
-export const from_aas2_4: Format[] = [aas2_4];

--- a/packages/rulesets/src/asyncapi/__tests__/asyncapi-message-messageId.test.ts
+++ b/packages/rulesets/src/asyncapi/__tests__/asyncapi-message-messageId.test.ts
@@ -43,6 +43,33 @@ testRule('asyncapi-message-messageId', [
   },
 
   {
+    name: 'valid case (with traits)',
+    document: {
+      asyncapi: '2.4.0',
+      channels: {
+        one: {
+          publish: {
+            message: {
+              traits: [
+                {},
+                {
+                  messageId: 'firstId',
+                },
+              ],
+            },
+          },
+          subscribe: {
+            message: {
+              messageId: 'secondId',
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+
+  {
     name: 'invalid case',
     document: {
       asyncapi: '2.4.0',
@@ -89,6 +116,14 @@ testRule('asyncapi-message-messageId', [
                   messageId: 'someId',
                 },
                 {},
+                {
+                  traits: [
+                    {},
+                    {
+                      messageId: 'anotherId',
+                    },
+                  ],
+                },
               ],
             },
           },
@@ -109,6 +144,34 @@ testRule('asyncapi-message-messageId', [
       {
         message: 'Message should have a "messageId" field defined.',
         path: ['channels', 'one', 'subscribe', 'message', 'oneOf', '2'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+
+  {
+    name: 'invalid case (with traits)',
+    document: {
+      asyncapi: '2.4.0',
+      channels: {
+        one: {
+          publish: {
+            message: {
+              traits: [{}, {}],
+            },
+          },
+          subscribe: {
+            message: {
+              messageId: 'secondId',
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        message: 'Message should have a "messageId" field defined.',
+        path: ['channels', 'one', 'publish', 'message'],
         severity: DiagnosticSeverity.Warning,
       },
     ],

--- a/packages/rulesets/src/asyncapi/__tests__/asyncapi-message-messageId.test.ts
+++ b/packages/rulesets/src/asyncapi/__tests__/asyncapi-message-messageId.test.ts
@@ -1,0 +1,116 @@
+import { DiagnosticSeverity } from '@stoplight/types';
+import testRule from './__helpers__/tester';
+
+testRule('asyncapi-message-messageId', [
+  {
+    name: 'valid case',
+    document: {
+      asyncapi: '2.4.0',
+      channels: {
+        one: {
+          publish: {
+            message: {
+              messageId: 'firstId',
+            },
+          },
+          subscribe: {
+            message: {
+              messageId: 'secondId',
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+
+  {
+    name: 'valid case (unsupported version)',
+    document: {
+      asyncapi: '2.3.0',
+      channels: {
+        one: {
+          publish: {
+            message: {},
+          },
+          subscribe: {
+            message: {},
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+
+  {
+    name: 'invalid case',
+    document: {
+      asyncapi: '2.4.0',
+      channels: {
+        one: {
+          publish: {
+            message: {},
+          },
+          subscribe: {
+            message: {},
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        message: 'Message should have a "messageId" field defined.',
+        path: ['channels', 'one', 'publish', 'message'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        message: 'Message should have a "messageId" field defined.',
+        path: ['channels', 'one', 'subscribe', 'message'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+
+  {
+    name: 'invalid case (oneOf case)',
+    document: {
+      asyncapi: '2.4.0',
+      channels: {
+        one: {
+          publish: {
+            message: {},
+            externalDocs: {},
+          },
+          subscribe: {
+            message: {
+              oneOf: [
+                {},
+                {
+                  messageId: 'someId',
+                },
+                {},
+              ],
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        message: 'Message should have a "messageId" field defined.',
+        path: ['channels', 'one', 'publish', 'message'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        message: 'Message should have a "messageId" field defined.',
+        path: ['channels', 'one', 'subscribe', 'message', 'oneOf', '0'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        message: 'Message should have a "messageId" field defined.',
+        path: ['channels', 'one', 'subscribe', 'message', 'oneOf', '2'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+]);

--- a/packages/rulesets/src/asyncapi/__tests__/asyncapi-operation-operationId.test.ts
+++ b/packages/rulesets/src/asyncapi/__tests__/asyncapi-operation-operationId.test.ts
@@ -56,14 +56,14 @@ testRule('asyncapi-operation-operationId', [
     },
     errors: [
       {
-        message: 'Operation should have a "operationId" field defined.',
+        message: 'Operation must have an "operationId" field defined.',
         path: ['channels', 'one', 'publish'],
-        severity: DiagnosticSeverity.Warning,
+        severity: DiagnosticSeverity.Error,
       },
       {
-        message: 'Operation should have a "operationId" field defined.',
+        message: 'Operation must have an "operationId" field defined.',
         path: ['channels', 'one', 'subscribe'],
-        severity: DiagnosticSeverity.Warning,
+        severity: DiagnosticSeverity.Error,
       },
     ],
   },
@@ -85,9 +85,9 @@ testRule('asyncapi-operation-operationId', [
     },
     errors: [
       {
-        message: 'Operation should have a "operationId" field defined.',
+        message: 'Operation must have an "operationId" field defined.',
         path: ['channels', 'one', 'publish'],
-        severity: DiagnosticSeverity.Warning,
+        severity: DiagnosticSeverity.Error,
       },
     ],
   },

--- a/packages/rulesets/src/asyncapi/__tests__/asyncapi-operation-operationId.test.ts
+++ b/packages/rulesets/src/asyncapi/__tests__/asyncapi-operation-operationId.test.ts
@@ -30,9 +30,9 @@ testRule('asyncapi-operation-operationId', [
     }),
     errors: [
       {
-        message: 'Operation must have "operationId".',
+        message: 'Operation should have a "operationId" field defined.',
         path: ['channels', 'one', property],
-        severity: DiagnosticSeverity.Error,
+        severity: DiagnosticSeverity.Warning,
       },
     ],
   })),

--- a/packages/rulesets/src/asyncapi/functions/asyncApi2CheckId.ts
+++ b/packages/rulesets/src/asyncapi/functions/asyncApi2CheckId.ts
@@ -1,0 +1,34 @@
+import { createRulesetFunction } from '@stoplight/spectral-core';
+import { truthy } from '@stoplight/spectral-functions';
+import { mergeTraits } from './utils/mergeTraits';
+
+import type { MaybeHaveTraits } from './utils/mergeTraits';
+
+export default createRulesetFunction<MaybeHaveTraits, { idField: 'operationId' | 'messageId' }>(
+  {
+    input: {
+      type: 'object',
+      properties: {
+        traits: {
+          type: 'array',
+          items: {
+            type: 'object',
+          },
+        },
+      },
+    },
+    options: {
+      type: 'object',
+      properties: {
+        idField: {
+          type: 'string',
+          enum: ['operationId', 'messageId'],
+        },
+      },
+    },
+  },
+  function asyncApi2CheckId(targetVal, options, ctx) {
+    const mergedValue = mergeTraits(targetVal);
+    return truthy(mergedValue[options.idField], null, ctx);
+  },
+);

--- a/packages/rulesets/src/asyncapi/functions/utils/__tests__/mergeTraits.test.ts
+++ b/packages/rulesets/src/asyncapi/functions/utils/__tests__/mergeTraits.test.ts
@@ -1,0 +1,32 @@
+import { mergeTraits } from '../mergeTraits';
+
+describe('mergeTraits', () => {
+  test('should merge one trait', () => {
+    const result = mergeTraits({ payload: {}, traits: [{ payload: { someKey: 'someValue' } }] });
+    expect(result.payload).toEqual({ someKey: 'someValue' });
+  });
+
+  test('should merge two or more traits', () => {
+    const result = mergeTraits({
+      payload: {},
+      traits: [
+        { payload: { someKey1: 'someValue1' } },
+        { payload: { someKey2: 'someValue2' } },
+        { payload: { someKey3: 'someValue3' } },
+      ],
+    });
+    expect(result.payload).toEqual({ someKey1: 'someValue1', someKey2: 'someValue2', someKey3: 'someValue3' });
+  });
+
+  test('should override fields', () => {
+    const result = mergeTraits({
+      payload: { someKey: 'someValue' },
+      traits: [
+        { payload: { someKey: 'someValue1' } },
+        { payload: { someKey: 'someValue2' } },
+        { payload: { someKey: 'someValue3' } },
+      ],
+    });
+    expect(result.payload).toEqual({ someKey: 'someValue3' });
+  });
+});

--- a/packages/rulesets/src/asyncapi/functions/utils/mergeTraits.ts
+++ b/packages/rulesets/src/asyncapi/functions/utils/mergeTraits.ts
@@ -1,0 +1,36 @@
+import { isPlainObject } from '@stoplight/json';
+
+export type MaybeHaveTraits = { traits?: any[] } & Record<string, any>;
+
+export function mergeTraits<T extends MaybeHaveTraits>(data: T): T {
+  if (Array.isArray(data.traits)) {
+    data = { ...data }; // shallow copy
+    for (const trait of data.traits as T[]) {
+      for (const key in trait) {
+        data[key] = merge(data[key], trait[key]);
+      }
+    }
+  }
+  return data;
+}
+
+function merge<T>(origin: unknown, patch: unknown): T {
+  // If the patch is not an object, it replaces the origin.
+  if (!isPlainObject(patch)) {
+    return patch as T;
+  }
+
+  const result = !isPlainObject(origin)
+    ? {} // Non objects are being replaced.
+    : Object.assign({}, origin); // Make sure we never modify the origin.
+
+  Object.keys(patch).forEach(key => {
+    const patchVal = patch[key];
+    if (patchVal === null) {
+      delete result[key];
+    } else {
+      result[key] = merge(result[key], patchVal);
+    }
+  });
+  return result as T;
+}

--- a/packages/rulesets/src/asyncapi/index.ts
+++ b/packages/rulesets/src/asyncapi/index.ts
@@ -1,4 +1,4 @@
-import { aas2_0, aas2_1, aas2_2, aas2_3, aas2_4 } from '@stoplight/spectral-formats';
+import { all_aas2, from_aas2_4 } from '@stoplight/spectral-formats';
 import {
   truthy,
   pattern,
@@ -22,7 +22,7 @@ import asyncApi2Security from './functions/asyncApi2Security';
 
 export default {
   documentationUrl: 'https://meta.stoplight.io/docs/spectral/docs/reference/asyncapi-rules.md',
-  formats: [aas2_0, aas2_1, aas2_2, aas2_3, aas2_4],
+  formats: all_aas2,
   rules: {
     'asyncapi-channel-no-empty-parameter': {
       description: 'Channel path must not have empty parameter substitution pattern.',
@@ -223,6 +223,23 @@ export default {
         function: asyncApi2MessageIdUniqueness,
       },
     },
+    'asyncapi-message-messageId': {
+      description: 'Message should have a "messageId" field defined.',
+      recommended: true,
+      formats: from_aas2_4,
+      type: 'style',
+      given: [
+        '$.channels.*.[publish,subscribe][?(@property === "message" && @.oneOf == void 0)]',
+        '$.channels.*.[publish,subscribe].message.oneOf.*',
+        '$.components.channels.*.[publish,subscribe][?(@property === "message" && @.oneOf == void 0)]',
+        '$.components.channels.*.[publish,subscribe].message.oneOf.*',
+        '$.components.messages.*',
+      ],
+      then: {
+        field: 'messageId',
+        function: truthy,
+      },
+    },
     'asyncapi-operation-description': {
       description: 'Operation "description" must be present and non-empty string.',
       recommended: true,
@@ -244,11 +261,10 @@ export default {
       },
     },
     'asyncapi-operation-operationId': {
-      description: 'Operation must have "operationId".',
-      severity: 'error',
+      description: 'Operation should have a "operationId" field defined.',
       recommended: true,
-      type: 'validation',
-      given: '$.channels[*][publish,subscribe]',
+      type: 'style',
+      given: ['$.channels[*][publish,subscribe]', '$.components.channels[*][publish,subscribe]'],
       then: {
         field: 'operationId',
         function: truthy,

--- a/packages/rulesets/src/asyncapi/index.ts
+++ b/packages/rulesets/src/asyncapi/index.ts
@@ -269,9 +269,10 @@ export default {
       },
     },
     'asyncapi-operation-operationId': {
-      description: 'Operation should have a "operationId" field defined.',
+      description: 'Operation must have an "operationId" field defined.',
+      severity: 'error',
       recommended: true,
-      type: 'style',
+      type: 'validation',
       given: ['$.channels[*][publish,subscribe]', '$.components.channels[*][publish,subscribe]'],
       then: {
         function: asyncApi2CheckId,

--- a/packages/rulesets/src/asyncapi/index.ts
+++ b/packages/rulesets/src/asyncapi/index.ts
@@ -1,4 +1,4 @@
-import { all_aas2, from_aas2_4 } from '@stoplight/spectral-formats';
+import { aas2_0, aas2_1, aas2_2, aas2_3, aas2_4 } from '@stoplight/spectral-formats';
 import {
   truthy,
   pattern,
@@ -10,6 +10,7 @@ import {
 
 import asyncApi2ChannelParameters from './functions/asyncApi2ChannelParameters';
 import asyncApi2ChannelServers from './functions/asyncApi2ChannelServers';
+import asyncApi2CheckId from './functions/asyncApi2CheckId';
 import asyncApi2DocumentSchema, { latestAsyncApiVersion } from './functions/asyncApi2DocumentSchema';
 import asyncApi2MessageExamplesValidation from './functions/asyncApi2MessageExamplesValidation';
 import asyncApi2MessageIdUniqueness from './functions/asyncApi2MessageIdUniqueness';
@@ -17,8 +18,13 @@ import asyncApi2OperationIdUniqueness from './functions/asyncApi2OperationIdUniq
 import asyncApi2SchemaValidation from './functions/asyncApi2SchemaValidation';
 import asyncApi2PayloadValidation from './functions/asyncApi2PayloadValidation';
 import asyncApi2ServerVariables from './functions/asyncApi2ServerVariables';
-import { uniquenessTags } from '../shared/functions';
 import asyncApi2Security from './functions/asyncApi2Security';
+import { uniquenessTags } from '../shared/functions';
+
+import type { Format } from '@stoplight/spectral-core';
+
+const all_aas2: Format[] = [aas2_0, aas2_1, aas2_2, aas2_3, aas2_4];
+const from_aas2_4: Format[] = [aas2_4];
 
 export default {
   documentationUrl: 'https://meta.stoplight.io/docs/spectral/docs/reference/asyncapi-rules.md',
@@ -236,8 +242,10 @@ export default {
         '$.components.messages.*',
       ],
       then: {
-        field: 'messageId',
-        function: truthy,
+        function: asyncApi2CheckId,
+        functionOptions: {
+          idField: 'messageId',
+        },
       },
     },
     'asyncapi-operation-description': {
@@ -266,8 +274,10 @@ export default {
       type: 'style',
       given: ['$.channels[*][publish,subscribe]', '$.components.channels[*][publish,subscribe]'],
       then: {
-        field: 'operationId',
-        function: truthy,
+        function: asyncApi2CheckId,
+        functionOptions: {
+          idField: 'operationId',
+        },
       },
     },
     'asyncapi-operation-security': {


### PR DESCRIPTION
**Checklist**

- [X] Tests added / updated
- [X] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

**Additional context**

- change severity of `asyncapi-operation-operationId` rule from error to warning
- add `asyncapi-message-messageId` rule, with similar functionality like `asyncapi-operation-operationId`
- add unit tests
- update docs
- add more formats (needed by new rule)
- merge traits before checking ids.

cc @jonaslagoni @smoya 
