### PR TITLE
feat(rulesets): add support for 2.5.0 AsyncAPI

### DIFF
--- a/docs/getting-started/3-rulesets.md
+++ b/docs/getting-started/3-rulesets.md
@@ -83,6 +83,7 @@ Formats are an optional way to specify which API description formats a rule, or 
 - `aas2_2` (AsyncAPI v2.2.0)
 - `aas2_3` (AsyncAPI v2.3.0)
 - `aas2_4` (AsyncAPI v2.4.0)
+- `aas2_5` (AsyncAPI v2.5.0)
 - `oas2` (OpenAPI v2.0)
 - `oas3` (OpenAPI v3.x)
 - `oas3_0` (OpenAPI v3.0.x)

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test": "yarn pretest && yarn test.karma && yarn test.jest",
     "pretest.harness": "ts-node -T test-harness/scripts/generate-tests.ts",
     "test.harness": "yarn pretest.harness && jest -c test-harness/jest.config.mjs",
-    "test.jest": "jest --silent --cacheDirectory=.cache/.jest",
+    "test.jest": "jest --cacheDirectory=.cache/.jest",
     "test.karma": "karma start",
     "prepare": "husky install",
     "prerelease": "patch-package",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test": "yarn pretest && yarn test.karma && yarn test.jest",
     "pretest.harness": "ts-node -T test-harness/scripts/generate-tests.ts",
     "test.harness": "yarn pretest.harness && jest -c test-harness/jest.config.mjs",
-    "test.jest": "jest --cacheDirectory=.cache/.jest",
+    "test.jest": "jest --silent --cacheDirectory=.cache/.jest",
     "test.karma": "karma start",
     "prepare": "husky install",
     "prerelease": "patch-package",

--- a/packages/formats/src/__tests__/asyncapi.test.ts
+++ b/packages/formats/src/__tests__/asyncapi.test.ts
@@ -1,4 +1,4 @@
-import { aas2, aas2_0, aas2_1, aas2_2, aas2_3, aas2_4 } from '../asyncapi';
+import { aas2, aas2_0, aas2_1, aas2_2, aas2_3, aas2_4, aas2_5 } from '../asyncapi';
 
 describe('AsyncAPI format', () => {
   describe('AsyncAPI 2.x', () => {
@@ -85,6 +85,19 @@ describe('AsyncAPI format', () => {
       'does not recognize %s version',
       version => {
         expect(aas2_4({ asyncapi: version }, null)).toBe(false);
+      },
+    );
+  });
+
+  describe('AsyncAPI 2.5', () => {
+    it.each(['2.5.0', '2.5.2'])('recognizes %s version correctly', version => {
+      expect(aas2_5({ asyncapi: version }, null)).toBe(true);
+    });
+
+    it.each(['2', '2.3', '2.0.0', '2.1.0', '2.1.37', '2.2.0', '2.3.0', '2.4.0', '2.4.3', '2.6.0', '2.6.4'])(
+      'does not recognize %s version',
+      version => {
+        expect(aas2_5({ asyncapi: version }, null)).toBe(false);
       },
     );
   });

--- a/packages/formats/src/asyncapi.ts
+++ b/packages/formats/src/asyncapi.ts
@@ -9,6 +9,7 @@ const aas2_1Regex = /^2\.1(?:\.[0-9]*)?$/;
 const aas2_2Regex = /^2\.2(?:\.[0-9]*)?$/;
 const aas2_3Regex = /^2\.3(?:\.[0-9]*)?$/;
 const aas2_4Regex = /^2\.4(?:\.[0-9]*)?$/;
+const aas2_5Regex = /^2\.5(?:\.[0-9]*)?$/;
 
 const isAas2 = (document: unknown): document is { asyncapi: string } & Record<string, unknown> =>
   isPlainObject(document) && 'asyncapi' in document && aas2Regex.test(String((document as MaybeAAS2).asyncapi));
@@ -39,3 +40,7 @@ aas2_3.displayName = 'AsyncAPI 2.3.x';
 export const aas2_4: Format = (document: unknown): boolean =>
   isAas2(document) && aas2_4Regex.test(String((document as MaybeAAS2).asyncapi));
 aas2_4.displayName = 'AsyncAPI 2.4.x';
+
+export const aas2_5: Format = (document: unknown): boolean =>
+  isAas2(document) && aas2_5Regex.test(String((document as MaybeAAS2).asyncapi));
+aas2_5.displayName = 'AsyncAPI 2.5.x';

--- a/packages/rulesets/package.json
+++ b/packages/rulesets/package.json
@@ -21,7 +21,7 @@
     "release": "semantic-release -e semantic-release-monorepo"
   },
   "dependencies": {
-    "@asyncapi/specs": "2.15.0-next-spec.2",
+    "@asyncapi/specs": "^3.2.0",
     "@stoplight/better-ajv-errors": "1.0.3",
     "@stoplight/json": "^3.17.0",
     "@stoplight/spectral-core": "^1.8.1",

--- a/packages/rulesets/package.json
+++ b/packages/rulesets/package.json
@@ -21,7 +21,7 @@
     "release": "semantic-release -e semantic-release-monorepo"
   },
   "dependencies": {
-    "@asyncapi/specs": "^2.14.0",
+    "@asyncapi/specs": "2.15.0-next-spec.2",
     "@stoplight/better-ajv-errors": "1.0.3",
     "@stoplight/json": "^3.17.0",
     "@stoplight/spectral-core": "^1.8.1",

--- a/packages/rulesets/src/asyncapi/__tests__/asyncapi-payload.test.ts
+++ b/packages/rulesets/src/asyncapi/__tests__/asyncapi-payload.test.ts
@@ -51,6 +51,14 @@ testRule('asyncapi-payload', [
   },
 
   {
+    name: 'valid case (2.5.0 version)',
+    document: produce(document, (draft: any) => {
+      draft.asyncapi = '2.5.0';
+    }),
+    errors: [],
+  },
+
+  {
     name: 'components.messages.{message}.payload is not valid against the AsyncApi2 schema object',
     document: produce(document, (draft: any) => {
       draft.components.messages.aMessage.payload.deprecated = 17;

--- a/packages/rulesets/src/asyncapi/__tests__/asyncapi-tags-uniqueness.test.ts
+++ b/packages/rulesets/src/asyncapi/__tests__/asyncapi-tags-uniqueness.test.ts
@@ -27,6 +27,28 @@ testRule('asyncapi-tags-uniqueness', [
   },
 
   {
+    name: 'tags has duplicated names (server)',
+    document: {
+      asyncapi: '2.5.0',
+      servers: {
+        someServer: {
+          tags: [{ name: 'one' }, { name: 'one' }],
+        },
+        anotherServer: {
+          tags: [{ name: 'one' }, { name: 'two' }],
+        },
+      },
+    },
+    errors: [
+      {
+        message: '"tags" object contains duplicate tag name "one".',
+        path: ['servers', 'someServer', 'tags', '1', 'name'],
+        severity: DiagnosticSeverity.Error,
+      },
+    ],
+  },
+
+  {
     name: 'tags has duplicated names (operation)',
     document: {
       asyncapi: '2.0.0',

--- a/packages/rulesets/src/asyncapi/functions/__tests__/asyncApi2DocumentSchema.test.ts
+++ b/packages/rulesets/src/asyncapi/functions/__tests__/asyncApi2DocumentSchema.test.ts
@@ -204,13 +204,6 @@ describe('asyncApi2DocumentSchema', () => {
           message: 'must be string',
         },
         {
-          keyword: 'required',
-          instancePath: '/paths/test/post/parameters/0/schema',
-          schemaPath: '#/definitions/Reference/required',
-          params: { missingProperty: '$ref' },
-          message: "must have required property '$ref'",
-        },
-        {
           keyword: 'oneOf',
           instancePath: '/paths/test/post/parameters/0/schema',
           schemaPath: '#/properties/schema/oneOf',
@@ -324,15 +317,6 @@ describe('asyncApi2DocumentSchema', () => {
             type: 'string',
           },
           schemaPath: '#/properties/type/type',
-        },
-        {
-          instancePath: '/paths/foo/post/parameters/0/schema',
-          keyword: 'required',
-          message: "must have required property '$ref'",
-          params: {
-            missingProperty: '$ref',
-          },
-          schemaPath: '#/definitions/Reference/required',
         },
         {
           instancePath: '/paths/baz/post/parameters/0/schema',

--- a/packages/rulesets/src/asyncapi/functions/__tests__/asyncApi2PayloadValidation.test.ts
+++ b/packages/rulesets/src/asyncapi/functions/__tests__/asyncApi2PayloadValidation.test.ts
@@ -1,7 +1,11 @@
+import { aas2_0 } from '@stoplight/spectral-formats';
 import asyncApi2PayloadValidation from '../asyncApi2PayloadValidation';
 
 function runPayloadValidation(targetVal: any) {
-  return asyncApi2PayloadValidation(targetVal, null, { path: ['components', 'messages', 'aMessage'] } as any);
+  return asyncApi2PayloadValidation(targetVal, null, {
+    path: ['components', 'messages', 'aMessage'],
+    document: { formats: new Set([aas2_0]) },
+  } as any);
 }
 
 describe('asyncApi2PayloadValidation', () => {

--- a/packages/rulesets/src/asyncapi/functions/asyncApi2DocumentSchema.ts
+++ b/packages/rulesets/src/asyncapi/functions/asyncApi2DocumentSchema.ts
@@ -37,9 +37,14 @@ const ERROR_MAP = [
 // That being said, we always strip both oneOf and $ref, since we are always interested in the first error.
 export function prepareResults(errors: ErrorObject[]): void {
   // Update additionalProperties errors to make them more precise and prevent them from being treated as duplicates
-  for (const error of errors) {
+  for (let i = 0; i < errors.length; i++) {
+    const error = errors[i];
+
     if (error.keyword === 'additionalProperties') {
       error.instancePath = `${error.instancePath}/${String(error.params['additionalProperty'])}`;
+    } else if (error.keyword === 'required' && error.params.missingProperty === '$ref') {
+      errors.splice(i, 1);
+      i--;
     }
   }
 

--- a/packages/rulesets/src/asyncapi/functions/asyncApi2DocumentSchema.ts
+++ b/packages/rulesets/src/asyncapi/functions/asyncApi2DocumentSchema.ts
@@ -71,15 +71,15 @@ function applyManualReplacements(errors: IFunctionResult[]): void {
   }
 }
 
-const serializedSchemas = new Map<AsyncAPISpecVersion, Record<string, any>>();
-function getSerializedSchema(version: AsyncAPISpecVersion): Record<string, any> {
+const serializedSchemas = new Map<AsyncAPISpecVersion, Record<string, unknown>>();
+function getSerializedSchema(version: AsyncAPISpecVersion): Record<string, unknown> {
   const schema = serializedSchemas.get(version);
   if (schema) {
     return schema;
   }
 
   // Copy to not operate on the original json schema - between imports (in different modules) we operate on this same schema.
-  const copied = getCopyOfSchema(version);
+  const copied = getCopyOfSchema(version) as { definitions: Record<string, unknown> };
   // Remove the meta schemas because they are already present within Ajv, and it's not possible to add duplicated schemas.
   delete copied.definitions['http://json-schema.org/draft-07/schema'];
   delete copied.definitions['http://json-schema.org/draft-04/schema'];

--- a/packages/rulesets/src/asyncapi/functions/asyncApi2DocumentSchema.ts
+++ b/packages/rulesets/src/asyncapi/functions/asyncApi2DocumentSchema.ts
@@ -113,7 +113,7 @@ export default createRulesetFunction<unknown, null>(
     options: null,
   },
   function asyncApi2DocumentSchema(targetVal, _, context) {
-    const formats = context.document.formats;
+    const formats = context.document?.formats;
     if (formats === null || formats === void 0) return;
 
     const schema = getSchema(formats);

--- a/packages/rulesets/src/asyncapi/functions/asyncApi2DocumentSchema.ts
+++ b/packages/rulesets/src/asyncapi/functions/asyncApi2DocumentSchema.ts
@@ -71,8 +71,8 @@ function applyManualReplacements(errors: IFunctionResult[]): void {
   }
 }
 
-const serializedSchemas = new Map<AsyncAPISpecVersion, Record<string, unknown>>();
-function getSerializedSchema(version: AsyncAPISpecVersion): Record<string, unknown> {
+const serializedSchemas = new Map<AsyncAPISpecVersion, Record<string, any>>();
+function getSerializedSchema(version: AsyncAPISpecVersion): Record<string, any> {
   const schema = serializedSchemas.get(version);
   if (schema) {
     return schema;
@@ -81,14 +81,14 @@ function getSerializedSchema(version: AsyncAPISpecVersion): Record<string, unkno
   // Copy to not operate on the original json schema - between imports (in different modules) we operate on this same schema.
   const copied = getCopyOfSchema(version);
   // Remove the meta schemas because they are already present within Ajv, and it's not possible to add duplicated schemas.
-  delete copied!.definitions!['http://json-schema.org/draft-07/schema'];
-  delete copied!.definitions!['http://json-schema.org/draft-04/schema'];
+  delete copied.definitions['http://json-schema.org/draft-07/schema'];
+  delete copied.definitions['http://json-schema.org/draft-04/schema'];
 
   serializedSchemas.set(version, copied);
   return copied;
 }
 
-function getSchema(formats: Set<Format>): Record<string, unknown> | void {
+function getSchema(formats: Set<Format>): Record<string, any> | void {
   switch (true) {
     case formats.has(aas2_5):
       return getSerializedSchema('2.5.0');

--- a/packages/rulesets/src/asyncapi/functions/asyncApi2DocumentSchema.ts
+++ b/packages/rulesets/src/asyncapi/functions/asyncApi2DocumentSchema.ts
@@ -81,8 +81,8 @@ function getSerializedSchema(version: AsyncAPISpecVersion): Record<string, unkno
   // Copy to not operate on the original json schema - between imports (in different modules) we operate on this same schema.
   const copied = getCopyOfSchema(version);
   // Remove the meta schemas because they are already present within Ajv, and it's not possible to add duplicated schemas.
-  delete copied.definitions!['http://json-schema.org/draft-07/schema'];
-  delete copied.definitions!['http://json-schema.org/draft-04/schema'];
+  delete copied!.definitions!['http://json-schema.org/draft-07/schema'];
+  delete copied!.definitions!['http://json-schema.org/draft-04/schema'];
 
   serializedSchemas.set(version, copied);
   return copied;

--- a/packages/rulesets/src/asyncapi/functions/asyncApi2PayloadValidation.ts
+++ b/packages/rulesets/src/asyncapi/functions/asyncApi2PayloadValidation.ts
@@ -75,7 +75,7 @@ export default createRulesetFunction<unknown, null>(
     options: null,
   },
   function asyncApi2PayloadValidation(targetVal, _, context) {
-    const formats = context.document.formats;
+    const formats = context.document?.formats;
     if (formats === null || formats === void 0) return;
 
     const validator = getSchemaValidator(formats);

--- a/packages/rulesets/src/asyncapi/functions/asyncApi2PayloadValidation.ts
+++ b/packages/rulesets/src/asyncapi/functions/asyncApi2PayloadValidation.ts
@@ -23,9 +23,9 @@ addFormats(ajv);
  * To validate the schema of the payload we just need a small portion of official AsyncAPI spec JSON Schema, the Schema Object in particular. The definition of Schema Object must be
  * included in the returned JSON Schema.
  */
-function preparePayloadSchema(version: AsyncAPISpecVersion): Record<string, any> {
+function preparePayloadSchema(version: AsyncAPISpecVersion): Record<string, unknown> {
   // Copy to not operate on the original json schema - between imports (in different modules) we operate on this same schema.
-  const copied = getCopyOfSchema(version);
+  const copied = getCopyOfSchema(version) as { definitions: Record<string, unknown> };
   // Remove the meta schemas because they are already present within Ajv, and it's not possible to add duplicated schemas.
   delete copied.definitions['http://json-schema.org/draft-07/schema'];
   delete copied.definitions['http://json-schema.org/draft-04/schema'];

--- a/packages/rulesets/src/asyncapi/functions/asyncApi2PayloadValidation.ts
+++ b/packages/rulesets/src/asyncapi/functions/asyncApi2PayloadValidation.ts
@@ -23,12 +23,12 @@ addFormats(ajv);
  * To validate the schema of the payload we just need a small portion of official AsyncAPI spec JSON Schema, the Schema Object in particular. The definition of Schema Object must be
  * included in the returned JSON Schema.
  */
-function preparePayloadSchema(version: AsyncAPISpecVersion): Record<string, unknown> {
+function preparePayloadSchema(version: AsyncAPISpecVersion): Record<string, any> {
   // Copy to not operate on the original json schema - between imports (in different modules) we operate on this same schema.
   const copied = getCopyOfSchema(version);
   // Remove the meta schemas because they are already present within Ajv, and it's not possible to add duplicated schemas.
-  delete copied!.definitions!['http://json-schema.org/draft-07/schema'];
-  delete copied!.definitions!['http://json-schema.org/draft-04/schema'];
+  delete copied.definitions['http://json-schema.org/draft-07/schema'];
+  delete copied.definitions['http://json-schema.org/draft-04/schema'];
 
   const payloadSchema = `http://asyncapi.com/definitions/${version}/schema.json`;
 

--- a/packages/rulesets/src/asyncapi/functions/asyncApi2PayloadValidation.ts
+++ b/packages/rulesets/src/asyncapi/functions/asyncApi2PayloadValidation.ts
@@ -1,33 +1,88 @@
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import { createRulesetFunction } from '@stoplight/spectral-core';
+import { aas2_0, aas2_1, aas2_2, aas2_3, aas2_4, aas2_5 } from '@stoplight/spectral-formats';
 import betterAjvErrors from '@stoplight/better-ajv-errors';
 
-// use latest AsyncAPI JSON Schema because there are no differences of Schema Object definitions between the 2.X.X.
-import * as asyncApi2Schema from '@asyncapi/specs/schemas/2.3.0.json';
+import { getCopyOfSchema } from './utils/specs';
+
+import type { ValidateFunction } from 'ajv';
+import type { Format } from '@stoplight/spectral-core';
+import type { AsyncAPISpecVersion } from './utils/specs';
 
 const asyncApi2SchemaObject = { $ref: 'asyncapi2#/definitions/schema' };
 
 const ajv = new Ajv({
   allErrors: true,
   strict: false,
+  logger: false,
 });
-
 addFormats(ajv);
 
-ajv.addSchema(asyncApi2Schema, 'asyncapi2');
+/**
+ * To validate the schema of the payload we just need a small portion of official AsyncAPI spec JSON Schema, the Schema Object in particular. The definition of Schema Object must be
+ * included in the returned JSON Schema.
+ */
+function preparePayloadSchema(version: AsyncAPISpecVersion): Record<string, unknown> {
+  // Copy to not operate on the original json schema - between imports (in different modules) we operate on this same schema.
+  const copied = getCopyOfSchema(version);
+  // Remove the meta schemas because they are already present within Ajv, and it's not possible to add duplicated schemas.
+  delete copied.definitions!['http://json-schema.org/draft-07/schema'];
+  delete copied.definitions!['http://json-schema.org/draft-04/schema'];
 
-const ajvValidationFn = ajv.compile(asyncApi2SchemaObject);
+  const payloadSchema = `http://asyncapi.com/definitions/${version}/schema.json`;
+
+  return {
+    $ref: payloadSchema,
+    definitions: copied.definitions,
+  };
+}
+
+function getValidator(version: AsyncAPISpecVersion): ValidateFunction {
+  let validator = ajv.getSchema(version);
+  if (!validator) {
+    const schema = preparePayloadSchema(version);
+
+    ajv.addSchema(schema, version);
+    validator = ajv.getSchema(version);
+  }
+
+  return validator as ValidateFunction;
+}
+
+function getSchemaValidator(formats: Set<Format>): ValidateFunction | void {
+  switch (true) {
+    case formats.has(aas2_5):
+      return getValidator('2.5.0');
+    case formats.has(aas2_4):
+      return getValidator('2.4.0');
+    case formats.has(aas2_3):
+      return getValidator('2.3.0');
+    case formats.has(aas2_2):
+      return getValidator('2.2.0');
+    case formats.has(aas2_1):
+      return getValidator('2.1.0');
+    case formats.has(aas2_0):
+      return getValidator('2.0.0');
+    default:
+      return;
+  }
+}
 
 export default createRulesetFunction<unknown, null>(
   {
     input: null,
     options: null,
   },
-  function asyncApi2PayloadValidation(targetVal, _opts, context) {
-    ajvValidationFn(targetVal);
+  function asyncApi2PayloadValidation(targetVal, _, context) {
+    const formats = context.document.formats;
+    if (formats === null || formats === void 0) return;
 
-    return betterAjvErrors(asyncApi2SchemaObject, ajvValidationFn.errors, {
+    const validator = getSchemaValidator(formats);
+    if (validator === void 0) return;
+
+    validator(targetVal);
+    return betterAjvErrors(asyncApi2SchemaObject, validator.errors, {
       propertyPath: context.path,
       targetValue: targetVal,
     }).map(({ suggestion, error, path: errorPath }) => ({

--- a/packages/rulesets/src/asyncapi/functions/asyncApi2PayloadValidation.ts
+++ b/packages/rulesets/src/asyncapi/functions/asyncApi2PayloadValidation.ts
@@ -27,8 +27,8 @@ function preparePayloadSchema(version: AsyncAPISpecVersion): Record<string, unkn
   // Copy to not operate on the original json schema - between imports (in different modules) we operate on this same schema.
   const copied = getCopyOfSchema(version);
   // Remove the meta schemas because they are already present within Ajv, and it's not possible to add duplicated schemas.
-  delete copied.definitions!['http://json-schema.org/draft-07/schema'];
-  delete copied.definitions!['http://json-schema.org/draft-04/schema'];
+  delete copied!.definitions!['http://json-schema.org/draft-07/schema'];
+  delete copied!.definitions!['http://json-schema.org/draft-04/schema'];
 
   const payloadSchema = `http://asyncapi.com/definitions/${version}/schema.json`;
 

--- a/packages/rulesets/src/asyncapi/functions/utils/specs.ts
+++ b/packages/rulesets/src/asyncapi/functions/utils/specs.ts
@@ -17,6 +17,6 @@ export const specs = {
   '2.5.0': asyncAPI2_5_0Schema,
 };
 
-export function getCopyOfSchema(version: AsyncAPISpecVersion): Record<string, unknown> {
-  return JSON.parse(JSON.stringify(specs[version])) as Record<string, unknown>;
+export function getCopyOfSchema(version: AsyncAPISpecVersion): Record<string, any> {
+  return JSON.parse(JSON.stringify(specs[version])) as Record<string, any>;
 }

--- a/packages/rulesets/src/asyncapi/functions/utils/specs.ts
+++ b/packages/rulesets/src/asyncapi/functions/utils/specs.ts
@@ -1,0 +1,22 @@
+// import only 2.X.X AsyncAPI JSON Schemas for better treeshaking
+import * as asyncAPI2_0_0Schema from '@asyncapi/specs/schemas/2.0.0.json';
+import * as asyncAPI2_1_0Schema from '@asyncapi/specs/schemas/2.1.0.json';
+import * as asyncAPI2_2_0Schema from '@asyncapi/specs/schemas/2.2.0.json';
+import * as asyncAPI2_3_0Schema from '@asyncapi/specs/schemas/2.3.0.json';
+import * as asyncAPI2_4_0Schema from '@asyncapi/specs/schemas/2.4.0.json';
+import * as asyncAPI2_5_0Schema from '@asyncapi/specs/schemas/2.5.0.json';
+
+export type AsyncAPISpecVersion = keyof typeof specs;
+
+export const specs = {
+  '2.0.0': asyncAPI2_0_0Schema,
+  '2.1.0': asyncAPI2_1_0Schema,
+  '2.2.0': asyncAPI2_2_0Schema,
+  '2.3.0': asyncAPI2_3_0Schema,
+  '2.4.0': asyncAPI2_4_0Schema,
+  '2.5.0': asyncAPI2_5_0Schema,
+};
+
+export function getCopyOfSchema(version: AsyncAPISpecVersion): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(specs[version])) as Record<string, unknown>;
+}

--- a/packages/rulesets/src/asyncapi/functions/utils/specs.ts
+++ b/packages/rulesets/src/asyncapi/functions/utils/specs.ts
@@ -17,6 +17,6 @@ export const specs = {
   '2.5.0': asyncAPI2_5_0Schema,
 };
 
-export function getCopyOfSchema(version: AsyncAPISpecVersion): Record<string, any> {
-  return JSON.parse(JSON.stringify(specs[version])) as Record<string, any>;
+export function getCopyOfSchema(version: AsyncAPISpecVersion): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(specs[version])) as Record<string, unknown>;
 }

--- a/packages/rulesets/src/asyncapi/index.ts
+++ b/packages/rulesets/src/asyncapi/index.ts
@@ -1,4 +1,4 @@
-import { aas2_0, aas2_1, aas2_2, aas2_3, aas2_4 } from '@stoplight/spectral-formats';
+import { aas2_0, aas2_1, aas2_2, aas2_3, aas2_4, aas2_5 } from '@stoplight/spectral-formats';
 import {
   truthy,
   pattern,
@@ -22,7 +22,7 @@ import asyncApi2Security from './functions/asyncApi2Security';
 
 export default {
   documentationUrl: 'https://meta.stoplight.io/docs/spectral/docs/reference/asyncapi-rules.md',
-  formats: [aas2_0, aas2_1, aas2_2, aas2_3, aas2_4],
+  formats: [aas2_0, aas2_1, aas2_2, aas2_3, aas2_4, aas2_5],
   rules: {
     'asyncapi-channel-no-empty-parameter': {
       description: 'Channel path must not have empty parameter substitution pattern.',
@@ -497,6 +497,9 @@ export default {
       given: [
         // root
         '$.tags',
+        // root
+        '$.servers.*.tags',
+        '$.components.servers.*.tags',
         // operations
         '$.channels.*.[publish,subscribe].tags',
         '$.components.channels.*.[publish,subscribe].tags',

--- a/packages/rulesets/src/asyncapi/index.ts
+++ b/packages/rulesets/src/asyncapi/index.ts
@@ -497,7 +497,7 @@ export default {
       given: [
         // root
         '$.tags',
-        // root
+        // servers
         '$.servers.*.tags',
         '$.components.servers.*.tags',
         // operations

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,10 +27,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@asyncapi/specs@npm:^2.14.0":
-  version: 2.14.0
-  resolution: "@asyncapi/specs@npm:2.14.0"
-  checksum: 066c23c493df54c44c319433bdcf8482a3acd584e32c0073e6a9f5b167d61bde23a252621be2b28bbaf1466636f6cafaab570795de403f0c671358784d4b12ed
+"@asyncapi/specs@npm:2.15.0-next-spec.2":
+  version: 2.15.0-next-spec.2
+  resolution: "@asyncapi/specs@npm:2.15.0-next-spec.2"
+  checksum: 767331458e9bd75498857cd4d7db8b6e23d6c552179026c3ab9507f23e5d6457cffcd9f812ea6f88c6896f69c68ae5be720b0d66ce9bde76790231f41fcbaea4
   languageName: node
   linkType: hard
 
@@ -2703,7 +2703,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@stoplight/spectral-rulesets@workspace:packages/rulesets"
   dependencies:
-    "@asyncapi/specs": ^2.14.0
+    "@asyncapi/specs": 2.15.0-next-spec.2
     "@stoplight/better-ajv-errors": 1.0.3
     "@stoplight/json": ^3.17.0
     "@stoplight/path": ^1.3.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,10 +27,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@asyncapi/specs@npm:2.15.0-next-spec.2":
-  version: 2.15.0-next-spec.2
-  resolution: "@asyncapi/specs@npm:2.15.0-next-spec.2"
-  checksum: 767331458e9bd75498857cd4d7db8b6e23d6c552179026c3ab9507f23e5d6457cffcd9f812ea6f88c6896f69c68ae5be720b0d66ce9bde76790231f41fcbaea4
+"@asyncapi/specs@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "@asyncapi/specs@npm:3.2.0"
+  checksum: 09971262aefc8844ab3e7c0c3652711862ac562dd5d614f23b496185690430a81df8e50eddba657f4141e0fd9548ef622fe6c20f4e3dec8054be23f774798335
   languageName: node
   linkType: hard
 
@@ -2703,7 +2703,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@stoplight/spectral-rulesets@workspace:packages/rulesets"
   dependencies:
-    "@asyncapi/specs": 2.15.0-next-spec.2
+    "@asyncapi/specs": ^3.2.0
     "@stoplight/better-ajv-errors": 1.0.3
     "@stoplight/json": ^3.17.0
     "@stoplight/path": ^1.3.2


### PR DESCRIPTION
**Checklist**

- [X] Tests added / updated
- [X] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

PR adds support for `2.5.0` AsyncAPI.

cc @smoya @jonaslagoni 