### PR TITLE
docs(repo): update js ruleset with working example

### DIFF
--- a/docs/getting-started/3-rulesets.md
+++ b/docs/getting-started/3-rulesets.md
@@ -1,6 +1,6 @@
 # Rulesets
 
-Rulesets are collections of rules written in JSON or YAML, which can be used to power powerful linting of other JSON or YAML files. Meta, we know! 😎
+Rulesets are collections of rules written in JSON, YAML, or [JavaScript](../guides/4-custom-rulesets.md#alternative-js-ruleset-format), which can be used to power powerful linting of other JSON or YAML files. Meta, we know! 😎
 
 These rules are taking parameters, and calling functions on certain parts of another YAML or JSON object being linted.
 

--- a/docs/getting-started/3-rulesets.md
+++ b/docs/getting-started/3-rulesets.md
@@ -6,7 +6,7 @@ These rules are taking parameters, and calling functions on certain parts of ano
 
 ## Anatomy of a Ruleset
 
-A ruleset is a JSON or YAML file ([often the file will be called `.spectral.yaml`](../guides/2-cli.md#using-a-ruleset-file)), and there are two main parts.
+A ruleset is a JSON, YAML, or JavaScript file ([often the file will be called `.spectral.yaml`](../guides/2-cli.md#using-a-ruleset-file)), and there are two main parts.
 
 ### Rules
 

--- a/docs/guides/4-custom-rulesets.md
+++ b/docs/guides/4-custom-rulesets.md
@@ -635,7 +635,7 @@ Or using unpkg:
 
 ```
 extends:
-  - https://unpkg.com/@your-js-ruleset@1.0/ruleset.js
+  - https://unpkg.com/@your-js-ruleset
 ```
 
 For a more detailed example of creating a JavaScript ruleset and publishing it to npm, check out [Distribute Spectral Style Guides with npm](https://apisyouwonthate.com/blog/distribute-spectral-style-guides-with-npm) at APIs You Won't Hate.

--- a/docs/guides/4-custom-rulesets.md
+++ b/docs/guides/4-custom-rulesets.md
@@ -291,9 +291,9 @@ If none of the [core functions](../reference/functions.md) do what you want, you
 
 ## Alternative JS Ruleset Format
 
-Spectral v6.0 added support for an alternative ruleset format, similar to the JSON and YAML formats, but now entirely in Javascript.
+Spectral v6.0 added support for a JavaScript ruleset format, similar to the JSON and YAML formats.
 
-This has a few benefits: it lets you explicitly load formats or rulesets to get control over versioning, you can load common functions from popular JS libraries like normal, and in general feels a lot more welcoming to developers experienced with JavaScript, especially when it comes to working with custom functions.
+This has a few benefits: it lets you explicitly load formats or rulesets to get control over versioning, you can load common functions from popular JS libraries, and in general feels a lot more welcoming to developers experienced with JavaScript, especially when it comes to working with custom functions.
 
 **Example**
 
@@ -336,8 +336,6 @@ export default {
 This code example adds two rules: `valid-rule` and `only-new-json-schema`, things should look fairly familiar for anyone who has used the JSON or YAML formats.
 
 For those of you using custom functions, the keywords `functions` & `functionOptions` have been removed, as they were designed to help Spectral find your functions. Now functions are passed as a variable, instead of using a string that contains the name like the JSON/YAML formats.
-
-For now the JSON, YAML, and JS formats are all being maintained, and there are no current plans to drop support for any of them.
 
 ## Aliases
 

--- a/docs/guides/4-custom-rulesets.md
+++ b/docs/guides/4-custom-rulesets.md
@@ -289,117 +289,6 @@ Several functions [are provided by default](../reference/functions.md) for your 
 
 If none of the [core functions](../reference/functions.md) do what you want, you can [write your own custom functions](./5-custom-functions.md).
 
-## Alternative JS Ruleset Format
-
-Spectral v6.0 added support for a JavaScript ruleset format, similar to the JSON and YAML formats.
-
-This has a few benefits: it lets you explicitly load formats or rulesets to get control over versioning, you can load common functions from popular JS libraries, and in general feels a lot more welcoming to developers experienced with JavaScript, especially when it comes to working with custom functions.
-
-**Example**
-
-To create a JavaScript ruleset, the first step is creating a folder. In your terminal, run the following commands:
-
-```
-mkdir style-guide
-cd style-guide
-```
-
-Next, install two dependencies using [npm](https://www.npmjs.com/):
-
-```
-npm install --save @stoplight/spectral-functions
-npm install --save @stoplight/spectral-formats
-```
-
-Installing these packages is not required for creating a JavaScript ruleset, but we'll use them in our example to create some common rules used with Spectral and to target a specific OpenAPI format.
-
-Next, let's create a JavaScript file to hold our ruleset:
-
-```
-touch spectral.js
-```
-
-And inside the file, let's create a couple rules:
-
-```js
-import { truthy, undefined as pattern, schema } from "@stoplight/spectral-functions";
-import { oas3 } from "@stoplight/spectral-formats";
-
-export default {
-  rules: {
-    'api-home-get': {
-      description: 'APIs root path (`/`) MUST have a GET operation.',
-      message: "Otherwise people won't know how to get it.",
-      given: "$.paths[/]",
-      then: {
-        field: "get",
-        function: truthy,
-      },
-      severity: 'warn',
-    },
-
-    // Author: Phil Sturgeon (https://github.com/philsturgeon)
-    'no-numeric-ids': {
-      description: 'Avoid exposing IDs as an integer, UUIDs are preferred.',
-      given: '$.paths..parameters[*].[?(@property === "name" && (@ === "id" || @.match(/(_id|Id)$/)))]^.schema',
-      then: {
-        function: schema,
-        functionOptions: {
-          schema: {
-            type: "object",
-            not: {
-              properties: {
-                type: {
-                  const: "integer"
-                }
-              }
-            },
-            properties: {
-              format: {
-                const: 'uuid'
-              }
-            }
-          }
-        }
-      },
-      severity: 'error',
-    },
-
-    // Author: Nauman Ali (https://github.com/naumanali-stoplight)
-    'no-global-versioning': {
-      description: 'Using global versions just forces all your clients to do a lot more work for each upgrade. Please consider using API Evolution instead.',
-      message: 'Server URL should not contain global versions',
-      given: "$.servers[*].url",
-      then: {
-        function: pattern,
-        functionOptions: {
-          notMatch: '/v[1-9]'
-        }
-      },
-      formats: [oas3],
-      severity: 'warn',
-    }
-  }
-};
-```
-
-For those of you using custom functions, the keywords `functions` & `functionOptions` have been removed, as they were designed to help Spectral find your functions. Now functions are passed as a variable, instead of using a string that contains the name like the JSON/YAML formats.
-
-This code example should look fairly familiar for anyone who has used the JSON or YAML formats. The next steps for using this ruleset would be publishing it as an npm package, and then installing that package as part of your API project and referencing in your Spectral ruleset as:
-
-```
-extends: ["@your-js-ruleset"]
-```
-
-Or using unpkg:
-
-```
-extends:
-  - https://unpkg.com/@your-js-ruleset@1.0/ruleset.js
-```
-
-For a more detailed example of creating a JavaScript ruleset and publishing it to npm, check out [Distribute Spectral Style Guides with npm](https://apisyouwonthate.com/blog/distribute-spectral-style-guides-with-npm) at APIs You Won't Hate.
-
 ## Aliases
 
 Targeting certain parts of an OpenAPI spec is powerful but it can become cumbersome to write and repeat complex JSONPath expressions across various rules.
@@ -639,3 +528,114 @@ While executing `spectral lint User.yaml` will output:
 ```
 No results with a severity of 'error' or higher found!
 ```
+
+## Alternative JS Ruleset Format
+
+Spectral v6.0 added support for a JavaScript ruleset format, similar to the JSON and YAML formats.
+
+This has a few benefits: it lets you explicitly load formats or rulesets to get control over versioning, you can load common functions from popular JS libraries, and in general feels a lot more welcoming to developers experienced with JavaScript, especially when it comes to working with custom functions.
+
+**Example**
+
+To create a JavaScript ruleset, the first step is creating a folder. In your terminal, run the following commands:
+
+```
+mkdir style-guide
+cd style-guide
+```
+
+Next, install two dependencies using [npm](https://www.npmjs.com/):
+
+```
+npm install --save @stoplight/spectral-functions
+npm install --save @stoplight/spectral-formats
+```
+
+Installing these packages is not required for creating a JavaScript ruleset, but we'll use them in our example to create some common rules used with Spectral and to target a specific OpenAPI format.
+
+Next, let's create a JavaScript file to hold our ruleset:
+
+```
+touch spectral.js
+```
+
+And inside the file, let's create a couple rules:
+
+```js
+import { truthy, undefined as pattern, schema } from "@stoplight/spectral-functions";
+import { oas3 } from "@stoplight/spectral-formats";
+
+export default {
+  rules: {
+    'api-home-get': {
+      description: 'APIs root path (`/`) MUST have a GET operation.',
+      message: "Otherwise people won't know how to get it.",
+      given: "$.paths[/]",
+      then: {
+        field: "get",
+        function: truthy,
+      },
+      severity: 'warn',
+    },
+
+    // Author: Phil Sturgeon (https://github.com/philsturgeon)
+    'no-numeric-ids': {
+      description: 'Avoid exposing IDs as an integer, UUIDs are preferred.',
+      given: '$.paths..parameters[*].[?(@property === "name" && (@ === "id" || @.match(/(_id|Id)$/)))]^.schema',
+      then: {
+        function: schema,
+        functionOptions: {
+          schema: {
+            type: "object",
+            not: {
+              properties: {
+                type: {
+                  const: "integer"
+                }
+              }
+            },
+            properties: {
+              format: {
+                const: 'uuid'
+              }
+            }
+          }
+        }
+      },
+      severity: 'error',
+    },
+
+    // Author: Nauman Ali (https://github.com/naumanali-stoplight)
+    'no-global-versioning': {
+      description: 'Using global versions just forces all your clients to do a lot more work for each upgrade. Please consider using API Evolution instead.',
+      message: 'Server URL should not contain global versions',
+      given: "$.servers[*].url",
+      then: {
+        function: pattern,
+        functionOptions: {
+          notMatch: '/v[1-9]'
+        }
+      },
+      formats: [oas3],
+      severity: 'warn',
+    }
+  }
+};
+```
+
+For those of you using custom functions, the keywords `functions` & `functionOptions` have been removed, as they were designed to help Spectral find your functions. Now functions are passed as a variable, instead of using a string that contains the name like the JSON/YAML formats.
+
+This code example should look fairly familiar for anyone who has used the JSON or YAML formats. The next steps for using this ruleset would be publishing it as an npm package, and then installing that package as part of your API project and referencing in your Spectral ruleset as:
+
+```
+extends: ["@your-js-ruleset"]
+```
+
+Or using unpkg:
+
+```
+extends:
+  - https://unpkg.com/@your-js-ruleset@1.0/ruleset.js
+```
+
+For a more detailed example of creating a JavaScript ruleset and publishing it to npm, check out [Distribute Spectral Style Guides with npm](https://apisyouwonthate.com/blog/distribute-spectral-style-guides-with-npm) at APIs You Won't Hate.

--- a/docs/guides/4-custom-rulesets.md
+++ b/docs/guides/4-custom-rulesets.md
@@ -567,20 +567,20 @@ import { oas3 } from "@stoplight/spectral-formats";
 
 export default {
   rules: {
-    'api-home-get': {
-      description: 'APIs root path (`/`) MUST have a GET operation.',
+    "api-home-get": {
+      description: "APIs root path (`/`) MUST have a GET operation.",
       message: "Otherwise people won't know how to get it.",
       given: "$.paths[/]",
       then: {
         field: "get",
         function: truthy,
       },
-      severity: 'warn',
+      severity: "warn",
     },
 
     // Author: Phil Sturgeon (https://github.com/philsturgeon)
-    'no-numeric-ids': {
-      description: 'Avoid exposing IDs as an integer, UUIDs are preferred.',
+    "no-numeric-ids": {
+      description: "Avoid exposing IDs as an integer, UUIDs are preferred.",
       given: '$.paths..parameters[*].[?(@property === "name" && (@ === "id" || @.match(/(_id|Id)$/)))]^.schema',
       then: {
         function: schema,
@@ -590,36 +590,36 @@ export default {
             not: {
               properties: {
                 type: {
-                  const: "integer"
-                }
-              }
+                  const: "integer",
+                },
+              },
             },
             properties: {
               format: {
-                const: 'uuid'
-              }
-            }
-          }
-        }
+                const: "uuid",
+              },
+            },
+          },
+        },
       },
-      severity: 'error',
+      severity: "error",
     },
 
     // Author: Nauman Ali (https://github.com/naumanali-stoplight)
-    'no-global-versioning': {
-      description: 'Using global versions just forces all your clients to do a lot more work for each upgrade. Please consider using API Evolution instead.',
-      message: 'Server URL should not contain global versions',
+    "no-global-versioning": {
+      description: "Using global versions just forces all your clients to do a lot more work for each upgrade. Please consider using API Evolution instead.",
+      message: "Server URL should not contain global versions",
       given: "$.servers[*].url",
       then: {
         function: pattern,
         functionOptions: {
-          notMatch: '/v[1-9]'
-        }
+          notMatch: "/v[1-9]",
+        },
       },
       formats: [oas3],
-      severity: 'warn',
-    }
-  }
+      severity: "warn",
+    },
+  },
 };
 ```
 


### PR DESCRIPTION
Fixes #2233.

Update JS ruleset format section with a working example based on https://apisyouwonthate.com/blog/distribute-spectral-style-guides-with-npm.

**Checklist**

- [ ] Tests added / updated
- [x] Docs added / updated
