### PR TITLE
docs(repo): fix custom function examples with targetVal

### DIFF
--- a/docs/guides/5-custom-functions.md
+++ b/docs/guides/5-custom-functions.md
@@ -98,7 +98,7 @@ export default createRulesetFunction(
       required: ["value"],
     },
   },
-  (input, options) => {
+  (targetVal, options) => {
     const { value } = options;
 
     if (targetVal !== value) {
@@ -129,7 +129,7 @@ export default createRulesetFunction(
       required: ["value"],
     },
   },
-  function customEquals(input, options) {
+  function customEquals(targetVal, options) {
     const { value } = options;
 
     if (targetVal !== value) {
@@ -237,7 +237,7 @@ export default createRulesetFunction(
     },
     options: null,
   },
-  (input, options, { path }) => {
+  (targetVal, options, { path }) => {
     const seen = [];
     const results = [];
 


### PR DESCRIPTION
Based on [Slack conversation](https://stoplight-internal.slack.com/archives/CEUN2664A/p1667217489662359).

Some of the examples in the Custom Functions docs page were using the `targetVal` variable, but it wasn't declared anywhere.