### PR TITLE
fix(rulesets): length.min said "must not be longer than"

### DIFF
--- a/packages/functions/src/__tests__/length.test.ts
+++ b/packages/functions/src/__tests__/length.test.ts
@@ -35,7 +35,7 @@ describe('Core Functions / Length', () => {
     async input => {
       expect(await runLength(input, { min: 4 })).toEqual([
         {
-          message: 'The document must not be longer than 4',
+          message: 'The document must be longer than 4',
           path: [],
         },
       ]);

--- a/packages/functions/src/length.ts
+++ b/packages/functions/src/length.ts
@@ -40,7 +40,7 @@ export default createRulesetFunction<unknown[] | Record<string, unknown> | strin
     if ('min' in opts && value < opts.min) {
       results = [
         {
-          message: `#{{print("property")}}must not be longer than ${printValue(opts.min)}`,
+          message: `#{{print("property")}}must be longer than ${printValue(opts.min)}`,
         },
       ];
     }


### PR DESCRIPTION
When the rule is minimum 20, if there is less than 20 characters it will say "must not be longer than 20". This removes the not, making minimum now correctly say "must be longer than 20".

**Checklist**

- [x] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [x] Yes
- [ ] No

Any change to a message could be considered breaking but this was broken already, so hopefully people arent programatically doing things on string responses.

