### PR TITLE
fix(ref-resolver): bump @stoplight/json-ref-resolver from ~3.1.4 to ~3.1.5

### DIFF
--- a/packages/ref-resolver/package.json
+++ b/packages/ref-resolver/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@stoplight/json-ref-readers": "1.2.2",
-    "@stoplight/json-ref-resolver": "~3.1.4",
+    "@stoplight/json-ref-resolver": "~3.1.5",
     "@stoplight/spectral-runtime": "^1.1.2",
     "dependency-graph": "0.11.0",
     "tslib": "^2.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2427,9 +2427,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stoplight/json-ref-resolver@npm:~3.1.4":
-  version: 3.1.4
-  resolution: "@stoplight/json-ref-resolver@npm:3.1.4"
+"@stoplight/json-ref-resolver@npm:~3.1.5":
+  version: 3.1.5
+  resolution: "@stoplight/json-ref-resolver@npm:3.1.5"
   dependencies:
     "@stoplight/json": ^3.17.0
     "@stoplight/path": ^1.3.2
@@ -2441,7 +2441,7 @@ __metadata:
     lodash: ^4.17.21
     tslib: ^2.3.1
     urijs: ^1.19.11
-  checksum: 9da64dc9209420d335d00487c1a50094debb2511ca8ab2c755baea275a7fc4d70695cedbbf1b2d72f05034be395fde47e1b42957b1a7a21325850d5ccc5e60e4
+  checksum: b2df82e899717ffa7bab9ec4c380f206511b3971d242724afd34e8b964e5aa7be2a52e32ba48d435548a9ac13a63a2271ca69182abec8506fc3bb3cc129f6380
   languageName: node
   linkType: hard
 
@@ -2594,7 +2594,7 @@ __metadata:
   resolution: "@stoplight/spectral-ref-resolver@workspace:packages/ref-resolver"
   dependencies:
     "@stoplight/json-ref-readers": 1.2.2
-    "@stoplight/json-ref-resolver": ~3.1.4
+    "@stoplight/json-ref-resolver": ~3.1.5
     "@stoplight/spectral-runtime": ^1.1.2
     dependency-graph: 0.11.0
     tslib: ^2.3.1


### PR DESCRIPTION
Fixed https://github.com/stoplightio/spectral/issues/2337

**Checklist**

- [x] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

