### PR TITLE
fix(ruleset-bundler): defaults should be last one

### DIFF
--- a/packages/ruleset-bundler/package.json
+++ b/packages/ruleset-bundler/package.json
@@ -19,9 +19,9 @@
       "default": "./dist/index.js"
     },
     "./with-loader": {
-      "default": "./dist/loader/node.js",
       "node": "./dist/loader/node.js",
-      "browser": "./dist/loader/browser.js"
+      "browser": "./dist/loader/browser.js",
+      "default": "./dist/loader/node.js"
     },
     "./presets/*": {
       "default": "./dist/presets/*.js"


### PR DESCRIPTION
This fixes the Webpack error
```
Module not found: Default condition should be last one
```
when importing like
```
import { bundleAndLoadRuleset } from '@stoplight/spectral-ruleset-bundler/with-loader';
```

**Checklist**

- [X] Tests added / updated
- [X] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No