### PR TITLE
fix(ruleset-bundler): remove extraneous 'external dependency' warnings

### DIFF
--- a/packages/ruleset-bundler/src/index.ts
+++ b/packages/ruleset-bundler/src/index.ts
@@ -35,6 +35,14 @@ export async function bundleRuleset(
       if (e.code === 'MISSING_NAME_OPTION_FOR_IIFE_EXPORT') {
         return;
       }
+      // The Spectral packages themselves are not included in the bundle.
+      if (
+        e.code === 'UNRESOLVED_IMPORT' &&
+        typeof e.source === 'string' &&
+        e.source.startsWith('@stoplight/spectral')
+      ) {
+        return;
+      }
 
       fn(e);
     },


### PR DESCRIPTION
Fixes https://github.com/stoplightio/platform-internal/issues/16525

**Checklist**

- [ ] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Screenshots**

Before:
![239012037-c8539711-0ebd-4293-baa6-04f604a4f3d5](https://github.com/stoplightio/spectral/assets/587740/df3c4bfd-919e-4a98-b4e1-efc88a00032a)


After:
![239021842-ef4fcd3b-f6db-4c56-af6a-5fbd4e408c04](https://github.com/stoplightio/spectral/assets/587740/92dbdcef-87c4-4ab4-b9c9-d24f36c74987)


**Additional context**

These warnings create noise in our DataDog logs for the `api-design` service.
