### PR TITLE
build(cli): build nix binaries for both x64 and arm64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,7 @@ jobs:
       - checkout
       - install-and-build
       - build-binary:
-          targets: linux,macos,alpine
+          targets: linux-x64,linux-arm64,macos-x64,macos-arm64,alpine-x64,alpine-arm64
       - persist_to_workspace:
           root: ./packages/cli/
           paths:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build.binary": "pkg . --output ./binaries/spectral",
     "build.windows": "pkg . --targets windows --out-path ./binaries",
-    "build.nix": "pkg . --targets linux,macos,alpine --out-path ./binaries",
+    "build.nix": "pkg . --targets linux-x64,linux-arm64,macos-x64,macos-arm64,alpine-x64,alpine-arm64 --out-path ./binaries",
     "cli": "node -r ts-node/register/transpile-only -r tsconfig-paths/register src/index.ts",
     "cli:debug": "node -r ts-node/register/transpile-only -r tsconfig-paths/register --inspect-brk src/index.ts"
   },

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,26 +7,40 @@ install () {
 
 set -eu
 
-UNAME=$(uname)
-if [ "$UNAME" != "Linux" ] && [ "$UNAME" != "Darwin" ] ; then
-  echo "Sorry, OS/Architecture not supported: ${UNAME}/${ARCH}. Download binary from https://github.com/stoplightio/spectral/releases"
+KERNEL=$(uname -s)
+ARCH=$(uname -m)
+if [ "$KERNEL" != "Linux" ] && [ "$KERNEL" != "Darwin" ] ; then
+  echo "Sorry, KERNEL/Architecture not supported: ${KERNEL}/${ARCH}. Download binary from https://github.com/stoplightio/spectral/releases"
   exit 1
 fi
 
-if [ "$UNAME" = "Darwin" ] ; then
-  FILENAME="spectral-macos"
-elif [ "$UNAME" = "Linux" ] ; then
-  FILENAME="spectral-linux"
+if [ "$ARCH" != "aarch64" ] && [ "$ARCH" != "arm64" ] && [ "$ARCH" != "x86_64" ] ; then
+  echo "Sorry, KERNEL/Architecture not supported: ${KERNEL}/${ARCH}. Download binary from https://github.com/stoplightio/spectral/releases"
+  exit 1
+fi
+
+if [ "$ARCH" = "x86_64" ] ; then
+  ARCH="x64"
+fi
+
+if [ "$ARCH" = "aarch64" ] ; then
+  ARCH="arm64"
+fi
+
+OS="macos"
+if [ "$KERNEL" = "Linux" ] ; then
+  OS="linux"
   if [ -f /etc/os-release ]; then
     # extract the value for KEY named "NAME"
     DISTRO=$(sed -n -e 's/^NAME="\?\([^"]*\)"\?$/\1/p' /etc/os-release)
     if [ "$DISTRO" = "Alpine Linux" ]; then
       echo "Installing on Alpine Linux."
-      FILENAME="spectral-alpine"
+      OS="alpine"
     fi
   fi
 fi
 
+FILENAME="spectral-${OS}-${ARCH}"
 if [ "$VERSION" = "latest" ] ; then
   URL="https://github.com/stoplightio/spectral/releases/latest/download/${FILENAME}"
 else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -50,13 +50,13 @@ fi
 SRC="$(pwd)/${FILENAME}"
 DEST=/usr/local/bin/spectral
 
-STATUS=$(curl -sL -w %{http_code} -o $SRC $URL)
+STATUS=$(curl -sL -w %{http_code} -o "$SRC" "$URL")
 if [ $STATUS -ge 200 ] & [ $STATUS -le 308 ]; then
-  mv $SRC $DEST
-  chmod +x $DEST
+  mv "$SRC" "$DEST"
+  chmod +x "$DEST"
   echo "Spectral was installed to: ${DEST}"
 else
-  rm $SRC
+  rm "$SRC"
   echo "Error requesting. Download binary from ${URL}"
   exit 1
 fi


### PR DESCRIPTION
Fixes #2189.

**Checklist**

_Not applicable. Tests were run, and documentation was checked, but these changes don't require test or documentation changes._

- [ ] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [x] Yes
- [ ] No

> If indicated yes above, please describe the breaking change(s).

Release binaries for Linux, macOS, and Alpine now have their arch suffixed to their names. Prior to the change, release binaries were named:

- `spectral-linux`
- `spectral-macos`
- `spectral-alpine`

They are now: 

- `spectral-linux-x64`
- `spectral-linux-arm64`
- `spectral-macos-x64`
- `spectral-macos-arm64`
- `spectral-alpine-x64`
- `spectral-alpine-arm64`

The installation script has been updated to work with this change, but it breaks workflows for users or systems who depend on the original naming pattern.

I can copy the x64 binaries to files with their original name to prevent the BC break, but that could make the file list in the release look a little confusing.

**Additional context**

Unrelated to binary builds is a fix to the installation script that will prevent bugs when executing the script from a directory with a space in its name.

Thanks for checking this out! I'm open to commentary and suggestions.