### PR TITLE
feat(formatters): add GitHub Actions formatter

### DIFF
--- a/docs/guides/2-cli.md
+++ b/docs/guides/2-cli.md
@@ -33,7 +33,8 @@ Other options include:
           [string] [choices: "utf8", "ascii", "utf-8", "utf16le", "ucs2", "ucs-2", "base64", "latin1"] [default: "utf8"]
   -f, --format                   formatters to use for outputting results, more than one can be given joining them with
                                  a comma
-               [string] [choices: "json", "stylish", "junit", "html", "text", "teamcity", "pretty"] [default: "stylish"]
+        [string] [choices: "json", "stylish", "junit", "html", "text", "teamcity", "pretty", "github-actions"] [default:
+                                                                                                              "stylish"]
   -o, --output                   where to output results, can be a single file name, multiple "output.<format>" or
                                  missing to print to stdout                                                     [string]
       --stdin-filepath           path to a file to pretend that stdin comes from                                [string]

--- a/packages/cli/src/services/config.ts
+++ b/packages/cli/src/services/config.ts
@@ -11,6 +11,7 @@ export enum OutputFormat {
   TEXT = 'text',
   TEAMCITY = 'teamcity',
   PRETTY = 'pretty',
+  GITHUB_ACTIONS = 'github-actions',
 }
 
 export interface ILintConfig {

--- a/packages/cli/src/services/output.ts
+++ b/packages/cli/src/services/output.ts
@@ -1,7 +1,7 @@
 import * as process from 'process';
 import { IRuleResult } from '@stoplight/spectral-core';
 import { promises as fs } from 'fs';
-import { html, json, junit, stylish, teamcity, text, pretty } from '@stoplight/spectral-formatters';
+import { html, json, junit, stylish, teamcity, text, pretty, githubActions } from '@stoplight/spectral-formatters';
 import type { Formatter, FormatterOptions } from '@stoplight/spectral-formatters';
 import type { OutputFormat } from './config';
 
@@ -13,6 +13,7 @@ const formatters: Record<OutputFormat, Formatter> = {
   html,
   text,
   teamcity,
+  'github-actions': githubActions,
 };
 
 export function formatOutput(results: IRuleResult[], format: OutputFormat, formatOptions: FormatterOptions): string {

--- a/packages/formatters/README.md
+++ b/packages/formatters/README.md
@@ -32,3 +32,4 @@ console.error(output);
 ### Node.js only
 
 - pretty
+- github-actions

--- a/packages/formatters/src/__tests__/github-actions.test.ts
+++ b/packages/formatters/src/__tests__/github-actions.test.ts
@@ -6,7 +6,7 @@ const cwd = process.cwd();
 const results: IRuleResult[] = [
   {
     code: 'operation-description',
-    message: 'paths./pets.get.description is not truthy',
+    message: 'paths./pets.get.description is not truthy\nMessage can have\nmultiple lines',
     path: ['paths', '/pets', 'get', 'description'],
     severity: 1,
     source: `${cwd}/__tests__/fixtures/petstore.oas2.yaml`,
@@ -43,7 +43,7 @@ const results: IRuleResult[] = [
 describe('GitHub Actions formatter', () => {
   test('should be formatted correctly', () => {
     expect(githubActions(results, { failSeverity: DiagnosticSeverity.Error }).split('\n')).toEqual([
-      '::warning title=operation-description,file=__tests__/fixtures/petstore.oas2.yaml,col=9,endColumn=61,line=61,endLine=72::paths./pets.get.description is not truthy',
+      '::warning title=operation-description,file=__tests__/fixtures/petstore.oas2.yaml,col=9,endColumn=61,line=61,endLine=72::paths./pets.get.description is not truthy%0AMessage can have%0Amultiple lines',
       '::warning title=operation-tags,file=__tests__/fixtures/petstore.oas2.yaml,col=9,endColumn=61,line=61,endLine=72::paths./pets.get.tags is not truthy',
     ]);
   });

--- a/packages/formatters/src/__tests__/github-actions.test.ts
+++ b/packages/formatters/src/__tests__/github-actions.test.ts
@@ -1,0 +1,50 @@
+import { DiagnosticSeverity } from '@stoplight/types';
+import type { IRuleResult } from '@stoplight/spectral-core';
+import { githubActions } from '../github-actions';
+
+const cwd = process.cwd();
+const results: IRuleResult[] = [
+  {
+    code: 'operation-description',
+    message: 'paths./pets.get.description is not truthy',
+    path: ['paths', '/pets', 'get', 'description'],
+    severity: 1,
+    source: `${cwd}/__tests__/fixtures/petstore.oas2.yaml`,
+    range: {
+      start: {
+        line: 60,
+        character: 8,
+      },
+      end: {
+        line: 71,
+        character: 60,
+      },
+    },
+  },
+  {
+    code: 'operation-tags',
+    message: 'paths./pets.get.tags is not truthy',
+    path: ['paths', '/pets', 'get', 'tags'],
+    severity: 1,
+    source: `${cwd}/__tests__/fixtures/petstore.oas2.yaml`,
+    range: {
+      start: {
+        line: 60,
+        character: 8,
+      },
+      end: {
+        line: 71,
+        character: 60,
+      },
+    },
+  },
+];
+
+describe('GitHub Actions formatter', () => {
+  test('should be formatted correctly', () => {
+    expect(githubActions(results, { failSeverity: DiagnosticSeverity.Error }).split('\n')).toEqual([
+      '::warning title=operation-description,file=__tests__/fixtures/petstore.oas2.yaml,col=8,endColumn=60,line=60,endLine=71::paths./pets.get.description is not truthy',
+      '::warning title=operation-tags,file=__tests__/fixtures/petstore.oas2.yaml,col=8,endColumn=60,line=60,endLine=71::paths./pets.get.tags is not truthy',
+    ]);
+  });
+});

--- a/packages/formatters/src/__tests__/github-actions.test.ts
+++ b/packages/formatters/src/__tests__/github-actions.test.ts
@@ -43,8 +43,8 @@ const results: IRuleResult[] = [
 describe('GitHub Actions formatter', () => {
   test('should be formatted correctly', () => {
     expect(githubActions(results, { failSeverity: DiagnosticSeverity.Error }).split('\n')).toEqual([
-      '::warning title=operation-description,file=__tests__/fixtures/petstore.oas2.yaml,col=8,endColumn=60,line=60,endLine=71::paths./pets.get.description is not truthy',
-      '::warning title=operation-tags,file=__tests__/fixtures/petstore.oas2.yaml,col=8,endColumn=60,line=60,endLine=71::paths./pets.get.tags is not truthy',
+      '::warning title=operation-description,file=__tests__/fixtures/petstore.oas2.yaml,col=9,endColumn=61,line=61,endLine=72::paths./pets.get.description is not truthy',
+      '::warning title=operation-tags,file=__tests__/fixtures/petstore.oas2.yaml,col=9,endColumn=61,line=61,endLine=72::paths./pets.get.tags is not truthy',
     ]);
   });
 });

--- a/packages/formatters/src/github-actions.ts
+++ b/packages/formatters/src/github-actions.ts
@@ -36,7 +36,7 @@ export const githubActions: Formatter = results => {
         .map(p => p.join('='))
         .join(',');
 
-      return `::${OUTPUT_TYPES[result.severity]} ${paramsString}::${result.message}`;
+      return `::${OUTPUT_TYPES[result.severity]} ${paramsString}::${result.message.replaceAll('\n', '%0A')}`;
     })
     .join('\n');
 };

--- a/packages/formatters/src/github-actions.ts
+++ b/packages/formatters/src/github-actions.ts
@@ -36,7 +36,12 @@ export const githubActions: Formatter = results => {
         .map(p => p.join('='))
         .join(',');
 
-      return `::${OUTPUT_TYPES[result.severity]} ${paramsString}::${result.message.replaceAll('\n', '%0A')}`;
+      // As annotated messages must be one-line due to GitHub's limitation, replacing all LF to %0A here.
+      // see: https://github.com/actions/toolkit/issues/193
+      // FIXME: Use replaceAll instead after removing Node.js 14 support.
+      const message = result.message.replace(/\n/g, '%0A');
+
+      return `::${OUTPUT_TYPES[result.severity]} ${paramsString}::${message}`;
     })
     .join('\n');
 };

--- a/packages/formatters/src/github-actions.ts
+++ b/packages/formatters/src/github-actions.ts
@@ -18,11 +18,13 @@ type OutputParams = {
 };
 
 export const githubActions: Formatter = results => {
+  const path = require('path') as { relative: (from: string, to: string) => string };
+
   return results
     .map(result => {
       const params: OutputParams = {
         title: result.code.toString(),
-        file: require('path').relative(process.cwd(), result.source ?? ''),
+        file: path.relative(process.cwd(), result.source ?? ''),
         col: result.range.start.character,
         endColumn: result.range.end.character,
         line: result.range.start.line,

--- a/packages/formatters/src/github-actions.ts
+++ b/packages/formatters/src/github-actions.ts
@@ -1,3 +1,4 @@
+import { relative } from '@stoplight/path';
 import { DiagnosticSeverity, Dictionary } from '@stoplight/types';
 import { Formatter } from './types';
 
@@ -18,13 +19,13 @@ type OutputParams = {
 };
 
 export const githubActions: Formatter = results => {
-  const path = require('path') as { relative: (from: string, to: string) => string };
-
   return results
     .map(result => {
+      // GitHub Actions requires relative path for annotations, determining from working directory here
+      const file = relative(process.cwd(), result.source ?? '');
       const params: OutputParams = {
         title: result.code.toString(),
-        file: path.relative(process.cwd(), result.source ?? ''),
+        file,
         col: result.range.start.character,
         endColumn: result.range.end.character,
         line: result.range.start.line,

--- a/packages/formatters/src/github-actions.ts
+++ b/packages/formatters/src/github-actions.ts
@@ -26,10 +26,10 @@ export const githubActions: Formatter = results => {
       const params: OutputParams = {
         title: result.code.toString(),
         file,
-        col: result.range.start.character,
-        endColumn: result.range.end.character,
-        line: result.range.start.line,
-        endLine: result.range.end.line,
+        col: result.range.start.character + 1,
+        endColumn: result.range.end.character + 1,
+        line: result.range.start.line + 1,
+        endLine: result.range.end.line + 1,
       };
 
       const paramsString = Object.entries(params)

--- a/packages/formatters/src/github-actions.ts
+++ b/packages/formatters/src/github-actions.ts
@@ -1,0 +1,39 @@
+import { DiagnosticSeverity, Dictionary } from '@stoplight/types';
+import { Formatter } from './types';
+
+const OUTPUT_TYPES: Dictionary<string, DiagnosticSeverity> = {
+  [DiagnosticSeverity.Error]: 'error',
+  [DiagnosticSeverity.Warning]: 'warning',
+  [DiagnosticSeverity.Information]: 'notice',
+  [DiagnosticSeverity.Hint]: 'notice',
+};
+
+type OutputParams = {
+  title?: string;
+  file: string;
+  col?: number;
+  endColumn?: number;
+  line?: number;
+  endLine?: number;
+};
+
+export const githubActions: Formatter = results => {
+  return results
+    .map(result => {
+      const params: OutputParams = {
+        title: result.code.toString(),
+        file: require('path').relative(process.cwd(), result.source ?? ''),
+        col: result.range.start.character,
+        endColumn: result.range.end.character,
+        line: result.range.start.line,
+        endLine: result.range.end.line,
+      };
+
+      const paramsString = Object.entries(params)
+        .map(p => p.join('='))
+        .join(',');
+
+      return `::${OUTPUT_TYPES[result.severity]} ${paramsString}::${result.message}`;
+    })
+    .join('\n');
+};

--- a/packages/formatters/src/index.node.ts
+++ b/packages/formatters/src/index.node.ts
@@ -1,3 +1,3 @@
-export { html, json, junit, text, stylish, teamcity } from './index';
+export { githubActions, html, json, junit, text, stylish, teamcity } from './index';
 export type { Formatter, FormatterOptions } from './index';
 export { pretty } from './pretty';

--- a/packages/formatters/src/index.node.ts
+++ b/packages/formatters/src/index.node.ts
@@ -1,3 +1,4 @@
-export { githubActions, html, json, junit, text, stylish, teamcity } from './index';
+export { html, json, junit, text, stylish, teamcity } from './index';
 export type { Formatter, FormatterOptions } from './index';
 export { pretty } from './pretty';
+export { githubActions } from './github-actions';

--- a/packages/formatters/src/index.ts
+++ b/packages/formatters/src/index.ts
@@ -4,6 +4,7 @@ export * from './junit';
 export * from './html';
 export * from './text';
 export * from './teamcity';
+export * from './github-actions';
 import type { Formatter } from './types';
 export type { Formatter, FormatterOptions } from './types';
 

--- a/packages/formatters/src/index.ts
+++ b/packages/formatters/src/index.ts
@@ -4,10 +4,13 @@ export * from './junit';
 export * from './html';
 export * from './text';
 export * from './teamcity';
-export * from './github-actions';
 import type { Formatter } from './types';
 export type { Formatter, FormatterOptions } from './types';
 
 export const pretty: Formatter = () => {
   throw Error('pretty formatter is available only in Node.js');
+};
+
+export const githubActions: Formatter = () => {
+  throw Error('github-actions formatter is available only in Node.js');
 };

--- a/test-harness/scenarios/help-no-document.scenario
+++ b/test-harness/scenarios/help-no-document.scenario
@@ -20,7 +20,7 @@ Options:
       --version                  Show version number  [boolean]
       --help                     Show help  [boolean]
   -e, --encoding                 text encoding to use  [string] [choices: "utf8", "ascii", "utf-8", "utf16le", "ucs2", "ucs-2", "base64", "latin1"] [default: "utf8"]
-  -f, --format                   formatters to use for outputting results, more than one can be given joining them with a comma  [string] [choices: "json", "stylish", "junit", "html", "text", "teamcity", "pretty"] [default: "stylish"]
+  -f, --format                   formatters to use for outputting results, more than one can be given joining them with a comma  [string] [choices: "json", "stylish", "junit", "html", "text", "teamcity", "pretty", "github-actions"] [default: "stylish"]
   -o, --output                   where to output results, can be a single file name, multiple "output.<format>" or missing to print to stdout  [string]
       --stdin-filepath           path to a file to pretend that stdin comes from  [string]
       --resolver                 path to custom json-ref-resolver instance  [string]

--- a/test-harness/scenarios/strict-options.scenario
+++ b/test-harness/scenarios/strict-options.scenario
@@ -20,7 +20,7 @@ Options:
       --version                  Show version number  [boolean]
       --help                     Show help  [boolean]
   -e, --encoding                 text encoding to use  [string] [choices: "utf8", "ascii", "utf-8", "utf16le", "ucs2", "ucs-2", "base64", "latin1"] [default: "utf8"]
-  -f, --format                   formatters to use for outputting results, more than one can be given joining them with a comma  [string] [choices: "json", "stylish", "junit", "html", "text", "teamcity", "pretty"] [default: "stylish"]
+  -f, --format                   formatters to use for outputting results, more than one can be given joining them with a comma  [string] [choices: "json", "stylish", "junit", "html", "text", "teamcity", "pretty", "github-actions"] [default: "stylish"]
   -o, --output                   where to output results, can be a single file name, multiple "output.<format>" or missing to print to stdout  [string]
       --stdin-filepath           path to a file to pretend that stdin comes from  [string]
       --resolver                 path to custom json-ref-resolver instance  [string]


### PR DESCRIPTION
This pull requests add a built-in formatter for annotating errors in GitHub Actions.

Spectral already have spectral-action for running Spectral and annotating errors in the workflow. The action creates a new check entry to annotate, but sometimes the annotation is incorrectly attached to another job due to GitHub's bug. To avoid that, it would be great if the Spectral CLI support formatting errors to GitHub Actions format [^1] as a built-in formatter, as same as TeamCity formatter does.

[^1]: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message

**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Screenshots**

N/A

**Additional context**

N/A
