### PR TITLE
fix(cli): choose proxy agent based on requester protocol

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,12 +6,12 @@ import { DEFAULT_REQUEST_OPTIONS } from '@stoplight/spectral-runtime';
 import lintCommand from './commands/lint';
 
 if (typeof process.env.PROXY === 'string') {
-  const { protocol } = new URL(process.env.PROXY);
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { HttpProxyAgent, HttpsProxyAgent } = require('hpagent') as typeof import('hpagent');
-  DEFAULT_REQUEST_OPTIONS.agent = new (protocol === 'https:' ? HttpsProxyAgent : HttpProxyAgent)({
-    proxy: process.env.PROXY,
-  });
+  const httpAgent = new HttpProxyAgent({ proxy: process.env.PROXY });
+  const httpsAgent = new HttpsProxyAgent({ proxy: process.env.PROXY });
+
+  DEFAULT_REQUEST_OPTIONS.agent = url => (url.protocol === 'http:' ? httpAgent : httpsAgent);
 }
 
 export default yargs


### PR DESCRIPTION
**Checklist**

- [x] Tests added / updated
- [x] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

Side note - in the next major release, we should prob align Spectral (and the rest of our tooling) with a more common implementation that relies on `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY`.