### PR TITLE
feat(rulesets): add scope validation to oas{2,3}-operation-security-defined rules

### DIFF
--- a/packages/rulesets/src/oas/__tests__/oas3-operation-security-defined.test.ts
+++ b/packages/rulesets/src/oas/__tests__/oas3-operation-security-defined.test.ts
@@ -3,82 +3,18 @@ import testRule from './__helpers__/tester';
 
 testRule('oas3-operation-security-defined', [
   {
-    name: 'validate a correct object (just in body)',
+    name: 'valid case',
     document: {
       openapi: '3.0.2',
       components: {
         securitySchemes: {
-          apikey: {},
-        },
-      },
-      paths: {
-        '/path': {
-          get: {
-            security: [
-              {
-                apikey: [],
-              },
-            ],
+          apikey: {
+            type: 'apiKey',
+            name: 'api_key',
+            in: 'header',
           },
         },
       },
-    },
-    errors: [],
-  },
-  {
-    name: 'validate a correct object (API-level security)',
-    document: {
-      openapi: '3.0.2',
-      components: {
-        securitySchemes: {
-          apikey: {},
-        },
-        security: [
-          {
-            apikey: [],
-          },
-        ],
-      },
-      paths: {
-        '/path': {
-          get: {},
-        },
-      },
-    },
-    errors: [],
-  },
-
-  {
-    name: 'return errors on invalid object',
-    document: {
-      openapi: '3.0.2',
-      components: {},
-      paths: {
-        '/path': {
-          get: {
-            security: [
-              {
-                apikey: [],
-              },
-            ],
-          },
-        },
-      },
-    },
-    errors: [
-      {
-        message: 'Operation "security" values must match a scheme defined in the "components.securitySchemes" object.',
-        path: ['paths', '/path', 'get', 'security', '0', 'apikey'],
-        severity: DiagnosticSeverity.Warning,
-      },
-    ],
-  },
-
-  {
-    name: 'return errors on invalid object (API-level)',
-    document: {
-      openapi: '3.0.2',
-      components: {},
       security: [
         {
           apikey: [],
@@ -86,28 +22,97 @@ testRule('oas3-operation-security-defined', [
       ],
       paths: {
         '/path': {
-          get: {},
+          get: {
+            security: [
+              {
+                apikey: [],
+              },
+            ],
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+
+  {
+    name: 'valid and invalid object',
+    document: {
+      openapi: '3.0.2',
+      components: {
+        securitySchemes: {
+          apikey: {
+            type: 'apiKey',
+            name: 'api_key',
+            in: 'header',
+          },
+          oauth2: {
+            type: 'oauth2',
+            flows: {
+              authorizationCode: {
+                authorizationUrl: 'https://example.com/api/oauth/dialog',
+                tokenUrl: 'https://example.com/api/oauth/token',
+                scopes: {
+                  'write:pets': 'modify pets in your account',
+                  'read:pets': 'read your pets',
+                },
+              },
+            },
+          },
+        },
+      },
+      security: [
+        {
+          apikey: [],
+          basic: [],
+          oauth2: ['write:pets'],
+        },
+        {},
+        {
+          oauth2: ['write:users', 'read:users'],
+        },
+      ],
+      paths: {
+        '/users': {
+          get: {
+            security: [
+              {
+                bearer: [],
+                oauth2: [],
+              },
+            ],
+          },
         },
       },
     },
     errors: [
       {
         message: 'API "security" values must match a scheme defined in the "components.securitySchemes" object.',
-        path: ['security', '0', 'apikey'],
+        path: ['security', '0', 'basic'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        message: '"write:users" must be listed among scopes.',
+        path: ['security', '2', 'oauth2', '0'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        message: '"read:users" must be listed among scopes.',
+        path: ['security', '2', 'oauth2', '1'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        message: 'Operation "security" values must match a scheme defined in the "components.securitySchemes" object.',
+        path: ['paths', '/users', 'get', 'security', '0', 'bearer'],
         severity: DiagnosticSeverity.Warning,
       },
     ],
   },
 
   {
-    name: 'return errors on valid and invalid object',
+    name: 'missing securitySchemes',
     document: {
-      openapi: '3.0.2',
-      components: {
-        securitySchemes: {
-          apikey: {},
-        },
-      },
+      openapi: '3.1.0',
       paths: {
         '/path': {
           get: {
@@ -125,6 +130,11 @@ testRule('oas3-operation-security-defined', [
     errors: [
       {
         message: 'Operation "security" values must match a scheme defined in the "components.securitySchemes" object.',
+        path: ['paths', '/path', 'get', 'security', '0', 'apikey'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        message: 'Operation "security" values must match a scheme defined in the "components.securitySchemes" object.',
         path: ['paths', '/path', 'get', 'security', '0', 'basic'],
         severity: DiagnosticSeverity.Warning,
       },
@@ -132,30 +142,70 @@ testRule('oas3-operation-security-defined', [
   },
 
   {
-    name: 'valid and invalid object (API-level security)',
+    name: 'invalid scopes in Security Scheme object',
     document: {
-      openapi: '3.0.2',
+      openapi: '3.1.0',
       components: {
         securitySchemes: {
-          apikey: {},
+          authorizationCode: {
+            type: 'oauth2',
+            flows: {
+              authorizationCode: {
+                authorizationUrl: 'https://example.com/api/oauth/dialog',
+                tokenUrl: 'https://example.com/api/oauth/token',
+                scopes: null,
+              },
+            },
+          },
+          noFlows: {
+            type: 'oauth2',
+          },
+          client: {
+            type: 'oauth2',
+            flows: {
+              clientCredentials: null,
+            },
+          },
+          broken: null,
         },
       },
-      security: [
-        {
-          apikey: [],
-          basic: [],
-        },
-      ],
       paths: {
         '/path': {
-          get: {},
+          get: {
+            security: [
+              {
+                noFlows: ['read:users'],
+                authorizationCode: ['write:users'],
+                broken: ['delete:users'],
+              },
+              {
+                noFlows: [],
+                client: ['read:users'],
+              },
+            ],
+          },
         },
       },
     },
     errors: [
       {
-        message: 'API "security" values must match a scheme defined in the "components.securitySchemes" object.',
-        path: ['security', '0', 'basic'],
+        message: '"read:users" must be listed among scopes.',
+        path: ['paths', '/path', 'get', 'security', '0', 'noFlows', '0'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        message: '"write:users" must be listed among scopes.',
+        path: ['paths', '/path', 'get', 'security', '0', 'authorizationCode', '0'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        message: '"delete:users" must be listed among scopes.',
+        path: ['paths', '/path', 'get', 'security', '0', 'broken', '0'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        message: '"read:users" must be listed among scopes.',
+        path: ['paths', '/path', 'get', 'security', '1', 'client', '0'],
         severity: DiagnosticSeverity.Warning,
       },
     ],


### PR DESCRIPTION

Closes #2529 

TBH we should probably rename that rule since it also validates top-level securities.

**Checklist**

- [x] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
