### PR TITLE
fix(rulesets): make rule `oas2-operation-formData-consume-check` consistent with Swagger Editor similar rule

### DIFF
--- a/packages/rulesets/src/oas/__tests__/oas2-operation-formData-consume-check.test.ts
+++ b/packages/rulesets/src/oas/__tests__/oas2-operation-formData-consume-check.test.ts
@@ -40,4 +40,26 @@ testRule('oas2-operation-formData-consume-check', [
       },
     ],
   },
+
+  {
+    name: 'return error when consumes is missing',
+    document: {
+      swagger: '2.0',
+      paths: {
+        '/path1': {
+          get: {
+            parameters: [{ in: 'formData', name: 'test' }],
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        message:
+          'Operations with "in: formData" parameter must include "application/x-www-form-urlencoded" or "multipart/form-data" in their "consumes" property.',
+        path: ['paths', '/path1', 'get'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
 ]);

--- a/packages/rulesets/src/oas/functions/oasOpFormDataConsumeCheck.ts
+++ b/packages/rulesets/src/oas/functions/oasOpFormDataConsumeCheck.ts
@@ -4,7 +4,7 @@ import { isObject } from './utils/isObject';
 const validConsumeValue = /(application\/x-www-form-urlencoded|multipart\/form-data)/;
 
 type Input = {
-  consumes: unknown[];
+  consumes?: unknown[];
   parameters: unknown[];
 };
 
@@ -20,12 +20,15 @@ export default createRulesetFunction<Input, null>(
           type: 'array',
         },
       },
-      required: ['consumes', 'parameters'],
+      required: ['parameters'],
     },
     options: null,
   },
   function oasOpFormDataConsumeCheck({ parameters, consumes }) {
-    if (parameters.some(p => isObject(p) && p.in === 'formData') && !validConsumeValue.test(consumes?.join(','))) {
+    if (
+      !consumes ||
+      (parameters.some(p => isObject(p) && p.in === 'formData') && !validConsumeValue.test(consumes?.join(',')))
+    ) {
       return [
         {
           message:


### PR DESCRIPTION
Swagger Editor has a similar rule to check values of `consumes` array:
https://github.com/swagger-api/swagger-editor/blob/249d4f0044d2104fdbe582cf53f27f3538b361d7/src/plugins/validate-semantic/validators/form-data.js#L50-L96

The difference is that Spectral rule does not fail if `consumes` array is completely missing which seems to be a mistake.

**Checklist**

- [x] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [x] Yes
- [ ] No

Potentially, it might be a breaking change for those who use this rule as it will though an additional validation issue in this edge case.