### PR TITLE
fix(ruleset-migrator): url loaded rulesets fail to resolve npm installed rulesets

### DIFF
--- a/packages/ruleset-migrator/src/tree/index.ts
+++ b/packages/ruleset-migrator/src/tree/index.ts
@@ -137,6 +137,9 @@ export class Tree {
       // <origin>/<pkg-name>
       // <origin>/<pkg-name>/<asset> where asset can be a custom fn, etc.
       resolved = path.join(ctx.filepath, identifier);
+    } else if (kind === 'ruleset' && requireResolve?.(identifier, { paths: [ctx.cwd] })) {
+      // this is an npm installed ruleset
+      resolved = requireResolve?.(identifier, { paths: [ctx.cwd] });
     } else if (kind === 'ruleset' && !path.isURL(ctx.filepath) && isPackageImport(identifier)) {
       resolved =
         ctx.npmRegistry !== null


### PR DESCRIPTION
**Checklist**

- [ ] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Summary:**
A remotely loaded ruleset will fail to load if it `extends` an npm/yarn installed ruleset such as:
- `"@stoplight/spectral-owasp-ruleset"`
- `"spectral-aws-apigateway-ruleset"`

This is **NOT** an issue if the remote ruleset extends core rulesets "spectral:oas" and "spectral:asyncapi" because of the check [here](https://github.com/stoplightio/spectral/blob/develop/packages/ruleset-migrator/src/transformers/extends.ts#L9-L12).

**Cause:**
In the `resolveModule()` method, the `path.isURL(ctx.filepath)` check will return true for a remote ruleset and not bother to check if the module/identifier is an npm installed module via the `requireResolve()` method. This causes the npm installed module to wrongly resolve to a relative URL path and 404.

**Notes:**
The `isPackageImport()` method will wrongly return true if my remote ruleset extends another ruleset in the same remote path. So, I'm testing the identifier if it is in fact installed via `requireResolve()`.

We also can't assume all module names will be prefixed `@`, because it would fail to find `spectral-aws-apigateway-ruleset`.

**Steps to reproduce:**
1. NPM install the [owasp ruleset](https://github.com/stoplightio/spectral-owasp-ruleset).
`npm install --save -D @stoplight/spectral-owasp-ruleset`
2. Lint with a remote ruleset file that extends that npm installed owasp ruleset.
`spectral lint -r https://raw.githubusercontent.com/jquick-axway/spectral-test-rulesets/main/api-linting/owasp.yaml https://raw.githubusercontent.com/jquick-axway/spectral-test-rulesets/main/api-linting/tests/openapi-v3.json`
3. The following error gets outputted. Note that the `@stoplight/spectral-owasp-ruleset` is resolving to a URL instead of the npm locally installed module.
`Could not load https://raw.githubusercontent.com/jquick-axway/spectral-test-rulesets/main/api-linting/@stoplight/spectral-owasp-ruleset (imported by https://raw.githubusercontent.com/jquick-axway/spectral-test-rulesets/main/api-linting/.spectral.js): Error fetching https://raw.githubusercontent.com/jquick-axway/spectral-test-rulesets/main/api-linting/@stoplight/spectral-owasp-ruleset: Not Found`
