### PR TITLE
feat(functions): add support unicode to regexp pattern

### DIFF
--- a/packages/functions/src/__tests__/pattern.test.ts
+++ b/packages/functions/src/__tests__/pattern.test.ts
@@ -36,6 +36,11 @@ describe('Core Functions / Pattern', () => {
     it('should return empty array when given value does not match the given notMatch string regex with slashes and modifier', async () => {
       expect(await runPattern('def', { notMatch: '/[abc]+/i' })).toEqual([]);
     });
+
+    it('should support unicode', async () => {
+      expect(await runPattern('DüsseldorfKölnМосква北京市إسرائيل', { match: '^\\p{Letter}+$' })).toEqual([]);
+      expect(await runPattern('DüsseldorfKölnМосква北京市إسرائيل', { match: '/^\\p{Letter}+$/u' })).toEqual([]);
+    });
   });
 
   describe('given match and notMatch regexes', () => {

--- a/packages/functions/src/pattern.ts
+++ b/packages/functions/src/pattern.ts
@@ -42,7 +42,7 @@ function createRegex(pattern: string): RegExp {
     return new RegExp(splitRegex[1], splitRegex[2]);
   } else {
     // without slashes like [a-b]+
-    return new RegExp(pattern);
+    return new RegExp(pattern, 'u');
   }
 }
 


### PR DESCRIPTION
**Checklist**

- [x] Tests added / updated
- [-] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Additional context**

Fix unicode issue:
https://stackoverflow.com/questions/68840457/can-i-use-the-unicode-flag-within-a-json-schema-pattern-regular-expression
