### PR TITLE
fix(rulesets): fixed array-items type property selector

### DIFF
--- a/packages/rulesets/src/oas/__tests__/array-items.test.ts
+++ b/packages/rulesets/src/oas/__tests__/array-items.test.ts
@@ -26,7 +26,41 @@ testRule('array-items', [
   },
 
   {
-    name: 'array items sibling is present',
+    name: 'array items sibling is present in a oas2 document',
+    document: {
+      swagger: '2.0',
+      securityDefinitions: {
+        apikey: {},
+        $ref: '#/securityDefinitions/apikey',
+      },
+      paths: {
+        $ref: '#/securityDefinitions/apikey',
+        '/path': {
+          get: {
+            '200': {
+              schema: {
+                type: 'array',
+                items: {},
+              },
+            },
+          },
+          post: {
+            '201': {
+              type: 'array',
+              items: {
+                type: 'array',
+                items: {},
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+
+  {
+    name: 'array items sibling is present in oas3 document',
     document: {
       $ref: '#/',
       responses: {
@@ -46,8 +80,85 @@ testRule('array-items', [
     },
     errors: [],
   },
+
   {
-    name: 'array items sibling is missing',
+    name: 'array items sibling is present in oas3.1 document',
+    document: {
+      openapi: '3.1.0',
+      paths: {
+        '/path': {
+          get: {
+            responses: {
+              '200': {
+                type: 'array',
+                items: {},
+              },
+            },
+          },
+          post: {
+            responses: {
+              '201': {
+                type: 'array',
+                items: {
+                  type: 'array',
+                  items: {},
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+
+  {
+    name: 'array items sibling is missing in a oas2 document',
+    document: {
+      swagger: '2.0',
+      securityDefinitions: {
+        apikey: {},
+        $ref: '#/securityDefinitions/apikey',
+      },
+      paths: {
+        $ref: '#/securityDefinitions/apikey',
+        '/path': {
+          get: {
+            '200': {
+              schema: {
+                type: 'array',
+              },
+            },
+          },
+          post: {
+            '201': {
+              type: 'array',
+              items: {
+                type: 'array',
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'array-items',
+        message: 'Schemas with "type: array", require a sibling "items" field',
+        path: ['paths', '/path', 'get', '200', 'schema'],
+        severity: DiagnosticSeverity.Error,
+      },
+      {
+        code: 'array-items',
+        message: 'Schemas with "type: array", require a sibling "items" field',
+        path: ['paths', '/path', 'post', '201', 'items'],
+        severity: DiagnosticSeverity.Error,
+      },
+    ],
+  },
+
+  {
+    name: 'array items sibling is missing in oas3 document',
     document: {
       $ref: '#/',
       responses: {
@@ -74,6 +185,48 @@ testRule('array-items', [
         code: 'array-items',
         message: 'Schemas with "type: array", require a sibling "items" field',
         path: ['responses', '201', 'items'],
+        severity: DiagnosticSeverity.Error,
+      },
+    ],
+  },
+
+  {
+    name: 'array items sibling is missing in oas3.1 document',
+    document: {
+      openapi: '3.1.0',
+      paths: {
+        '/path': {
+          get: {
+            responses: {
+              '200': {
+                type: 'array',
+              },
+            },
+          },
+          post: {
+            responses: {
+              '201': {
+                type: 'array',
+                items: {
+                  type: 'array',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'array-items',
+        message: 'Schemas with "type: array", require a sibling "items" field',
+        path: ['paths', '/path', 'get', 'responses', '200'],
+        severity: DiagnosticSeverity.Error,
+      },
+      {
+        code: 'array-items',
+        message: 'Schemas with "type: array", require a sibling "items" field',
+        path: ['paths', '/path', 'post', 'responses', '201', 'items'],
         severity: DiagnosticSeverity.Error,
       },
     ],

--- a/packages/rulesets/src/oas/index.ts
+++ b/packages/rulesets/src/oas/index.ts
@@ -57,6 +57,27 @@ const ruleset = {
         },
       ],
     },
+    ArrayProperties: {
+      targets: [
+        {
+          formats: [oas2, oas3_0],
+          given: [
+            // Check for type: 'array'
+            '$..[?(@ && @.type=="array")]',
+          ],
+        },
+        {
+          formats: [oas3_1],
+          given: [
+            // Still check for type: 'array'
+            '$..[?(@ && @.type=="array")]',
+
+            // also check for type: ['array', ...]
+            '$..[?(@ && @.type && @.type.constructor.name === "Array" && @.type.includes("array"))]',
+          ],
+        },
+      ],
+    },
   },
   rules: {
     'operation-success-response': {
@@ -362,12 +383,11 @@ const ruleset = {
       },
     },
     'array-items': {
-      formats: [oas3_0],
       message: 'Schemas with "type: array", require a sibling "items" field',
       severity: 0,
       recommended: true,
       resolved: false,
-      given: "$..[?(@.type === 'array')]",
+      given: '#ArrayProperties',
       then: {
         function: truthy,
         field: 'items',


### PR DESCRIPTION
Fixes #2637.

This PR fixes an issue that was introduced by #2632. New `array-items` rule selector which causes the following error:

```
ERROR] There was a problem with spectral.
[ERROR] Cannot read properties of null (reading 'type')
[ERROR] Additional error details:
[ERROR] TypeError: Cannot read properties of null (reading 'type')
at $..[?(@.type === 'array')] (eval at query (/data/node_modules/nimma/dist/legacy/cjs/core/index.js:66:71), <anonymous>:10:31)
at eval (eval at query (/data/node_modules/nimma/dist/legacy/cjs/core/index.js:66:71), <anonymous>:182:41)
at _traverseBody (/data/node_modules/nimma/dist/legacy/cjs/runtime/traverse.js:13:5)
at _traverse (/data/node_modules/nimma/dist/legacy/cjs/runtime/traverse.js:41:7)
at _traverseBody (/data/node_modules/nimma/dist/legacy/cjs/runtime/traverse.js:17:5)
at _traverse (/data/node_modules/nimma/dist/legacy/cjs/runtime/traverse.js:41:7)
at _traverseBody (/data/node_modules/nimma/dist/legacy/cjs/runtime/traverse.js:17:5)
at _traverse (/data/node_modules/nimma/dist/legacy/cjs/runtime/traverse.js:41:7)
at _traverseBody (/data/node_modules/nimma/dist/legacy/cjs/runtime/traverse.js:17:5)
at _traverse **(/data/node_modules/nimma/dist/legacy/cjs/runtime/traverse.js:41:7)
```

**Checklist**

- [x] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No