### PR TITLE
chore(deps): bump ajv to 8.17.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,7 @@
     "@stoplight/types": "~13.6.0",
     "@types/es-aggregate-error": "^1.0.2",
     "@types/json-schema": "^7.0.11",
-    "ajv": "^8.6.0",
+    "ajv": "^8.17.1",
     "ajv-errors": "~3.0.0",
     "ajv-formats": "~2.1.0",
     "es-aggregate-error": "^1.0.7",

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -24,7 +24,7 @@
     "@stoplight/spectral-core": "^1.7.0",
     "@stoplight/spectral-formats": "^1.0.0",
     "@stoplight/spectral-runtime": "^1.1.0",
-    "ajv": "^8.6.3",
+    "ajv": "^8.17.1",
     "ajv-draft-04": "~1.0.0",
     "ajv-errors": "~3.0.0",
     "ajv-formats": "~2.1.0",

--- a/packages/ruleset-migrator/package.json
+++ b/packages/ruleset-migrator/package.json
@@ -29,7 +29,7 @@
     "@stoplight/types": "^13.6.0",
     "@stoplight/yaml": "~4.2.3",
     "@types/node": "*",
-    "ajv": "^8.6.0",
+    "ajv": "^8.17.1",
     "ast-types": "0.14.2",
     "astring": "^1.7.5",
     "reserved": "0.1.2",

--- a/packages/rulesets/package.json
+++ b/packages/rulesets/package.json
@@ -27,7 +27,7 @@
     "@stoplight/spectral-runtime": "^1.1.1",
     "@stoplight/types": "^13.6.0",
     "@types/json-schema": "^7.0.7",
-    "ajv": "^8.12.0",
+    "ajv": "^8.17.1",
     "ajv-formats": "~2.1.0",
     "json-schema-traverse": "^1.0.0",
     "leven": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2692,7 +2692,7 @@ __metadata:
     "@types/json-schema": ^7.0.11
     "@types/minimatch": ^3.0.5
     "@types/treeify": ^1.0.0
-    ajv: ^8.6.0
+    ajv: ^8.17.1
     ajv-errors: ~3.0.0
     ajv-formats: ~2.1.0
     es-aggregate-error: ^1.0.7
@@ -2753,7 +2753,7 @@ __metadata:
     "@stoplight/spectral-formats": ^1.0.0
     "@stoplight/spectral-parsers": "*"
     "@stoplight/spectral-runtime": ^1.1.0
-    ajv: ^8.6.3
+    ajv: ^8.17.1
     ajv-draft-04: ~1.0.0
     ajv-errors: ~3.0.0
     ajv-formats: ~2.1.0
@@ -2826,7 +2826,7 @@ __metadata:
     "@stoplight/types": ^13.6.0
     "@stoplight/yaml": ~4.2.3
     "@types/node": "*"
-    ajv: ^8.6.0
+    ajv: ^8.17.1
     ast-types: 0.14.2
     astring: ^1.7.5
     fetch-mock: ^9.11.0
@@ -2855,7 +2855,7 @@ __metadata:
     "@stoplight/spectral-runtime": ^1.1.1
     "@stoplight/types": ^13.6.0
     "@types/json-schema": ^7.0.7
-    ajv: ^8.12.0
+    ajv: ^8.17.1
     ajv-formats: ~2.1.0
     gzip-size: ^6.0.0
     immer: ^9.0.6
@@ -3764,7 +3764,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.0.0, ajv@npm:^8.12.0, ajv@npm:^8.6.0, ajv@npm:^8.6.3":
+"ajv@npm:^8.0.0":
   version: 8.12.0
   resolution: "ajv@npm:8.12.0"
   dependencies:
@@ -3773,6 +3773,18 @@ __metadata:
     require-from-string: ^2.0.2
     uri-js: ^4.2.2
   checksum: 4dc13714e316e67537c8b31bc063f99a1d9d9a497eb4bbd55191ac0dcd5e4985bbb71570352ad6f1e76684fb6d790928f96ba3b2d4fd6e10024be9612fe3f001
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^8.17.1":
+  version: 8.17.1
+  resolution: "ajv@npm:8.17.1"
+  dependencies:
+    fast-deep-equal: ^3.1.3
+    fast-uri: ^3.0.1
+    json-schema-traverse: ^1.0.0
+    require-from-string: ^2.0.2
+  checksum: 1797bf242cfffbaf3b870d13565bd1716b73f214bb7ada9a497063aada210200da36e3ed40237285f3255acc4feeae91b1fb183625331bad27da95973f7253d9
   languageName: node
   linkType: hard
 
@@ -6431,6 +6443,13 @@ __metadata:
   version: 2.5.2
   resolution: "fast-memoize@npm:2.5.2"
   checksum: 79fa759719ba4eac7e8c22fb3b0eb3f18f4a31e218c00b1eb4a5b53c5781921133a6b84472d59ec5a6ea8f26ad57b43cd99a350c0547ccce51489bc9a5f0b28d
+  languageName: node
+  linkType: hard
+
+"fast-uri@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "fast-uri@npm:3.0.1"
+  checksum: 106143ff83705995225dcc559411288f3337e732bb2e264e79788f1914b6bd8f8bc3683102de60b15ba00e6ebb443633cabac77d4ebc5cb228c47cf955e199ff
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR updates `ajv` to version `8.17.1` in all packages to [lay the foundation](https://github.com/asyncapi/parser-js/issues/980#issuecomment-2227599634) for fixing https://github.com/asyncapi/parser-js/issues/980.

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No
