### PR TITLE
fix(rulesets): remove step summary rule

### DIFF
--- a/docs/reference/arazzo-rules.md
+++ b/docs/reference/arazzo-rules.md
@@ -275,12 +275,6 @@ In order to improve consumer experience, Step `description` should be present an
 
 **Recommend:** Yes
 
-### arazzo-step-summary
-
-In order to improve consumer experience, Step `summary` should be present and a non-empty string.
-
-**Recommend:** Yes
-
 ### arazzo-step-operationPath
 
 It is recommended to use `operationId` rather than `operationPath` within a step to reference an API operation.

--- a/packages/rulesets/package.json
+++ b/packages/rulesets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/spectral-rulesets",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "homepage": "https://github.com/stoplightio/spectral",
   "bugs": "https://github.com/stoplightio/spectral/issues",
   "author": "Stoplight <support@stoplight.io>",

--- a/packages/rulesets/src/arazzo/index.ts
+++ b/packages/rulesets/src/arazzo/index.ts
@@ -202,15 +202,6 @@ export default {
         function: truthy,
       },
     },
-    'arazzo-step-summary': {
-      description: 'Step "summary" is recommended to be present and a non-empty string.',
-      severity: 'hint',
-      given: '$.workflows[*].steps[*]',
-      then: {
-        field: 'summary',
-        function: truthy,
-      },
-    },
     'arazzo-step-stepId': {
       description: 'Step "stepId" should follow the pattern "^[A-Za-z0-9_\\-]+$".',
       severity: 'warn',


### PR DESCRIPTION
Removes bad rule which was checking for step summary and giving a hint to include. 

Unfortunately, that makes no sense as it's not part of the schema, so if you follow the rule you'll get hit with a more serious rule failure