### PR TITLE
fix(deps): update dependency jsonpath-plus to 10.0.0 due to vulnerability

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,7 @@
     "ajv-errors": "~3.0.0",
     "ajv-formats": "~2.1.0",
     "es-aggregate-error": "^1.0.7",
-    "jsonpath-plus": "7.1.0",
+    "jsonpath-plus": "^10.0.0",
     "lodash": "~4.17.21",
     "lodash.topath": "^4.5.2",
     "minimatch": "3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2094,12 +2094,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jsep-plugin/assignment@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@jsep-plugin/assignment@npm:1.2.1"
+  peerDependencies:
+    jsep: ^0.4.0||^1.0.0
+  checksum: d56fd7423c59dd269c50b0a9c22ec05f099a789ec8e8980f2307782f496ab3f0740151f1bdc7a1f3a8ee9085cdeb6f5b4def0d6b312e6b93ab160e6489b400f2
+  languageName: node
+  linkType: hard
+
 "@jsep-plugin/regex@npm:^1.0.1":
   version: 1.0.2
   resolution: "@jsep-plugin/regex@npm:1.0.2"
   peerDependencies:
     jsep: ^0.4.0||^1.0.0
   checksum: b19f1cb160d5b026f93aeaf586cf506288c4ce588dc7e7b794f1da3ea950e969bdd6b2cfc7e31ad4b9b7860d15db116f7bb0a0cee9d0db59109869312f2fbf92
+  languageName: node
+  linkType: hard
+
+"@jsep-plugin/regex@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@jsep-plugin/regex@npm:1.0.3"
+  peerDependencies:
+    jsep: ^0.4.0||^1.0.0
+  checksum: a57718ae5c86bd10ff5de51843a771b96a10a9c6b5c5f4e02aa5318257c3d5fdec96f8b389fcbe129c7a6ad6b0746d9a0fd934c949b80882230fbc14b548c922
   languageName: node
   linkType: hard
 
@@ -2966,7 +2984,7 @@ __metadata:
     ajv-errors: ~3.0.0
     ajv-formats: ~2.1.0
     es-aggregate-error: ^1.0.7
-    jsonpath-plus: 7.1.0
+    jsonpath-plus: ^10.0.0
     lodash: ~4.17.21
     lodash.topath: ^4.5.2
     minimatch: 3.1.2
@@ -9069,6 +9087,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsep@npm:^1.3.9":
+  version: 1.3.9
+  resolution: "jsep@npm:1.3.9"
+  checksum: d1f3e2cc00209f67a989b73c2a89d2ccbea908d950ec959e2448c6449b134c6367b47eef4e1292767cb490f0b5b72e7309080b93ee4c7398684df2514dbd33a3
+  languageName: node
+  linkType: hard
+
 "jsesc@npm:^2.5.1":
   version: 2.5.2
   resolution: "jsesc@npm:2.5.2"
@@ -9254,10 +9279,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonpath-plus@npm:7.1.0":
-  version: 7.1.0
-  resolution: "jsonpath-plus@npm:7.1.0"
-  checksum: a4005dc860c6b7e339229842537ceb6eb839d87a3447f989792b9c64f2564bbbd40663515f9481fb5a1b6cb0f988afba5b0b150e0285c463b794a45ed1aaf555
+"jsonpath-plus@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "jsonpath-plus@npm:10.0.0"
+  dependencies:
+    "@jsep-plugin/assignment": ^1.2.1
+    "@jsep-plugin/regex": ^1.0.3
+    jsep: ^1.3.9
+  bin:
+    jsonpath: bin/jsonpath-cli.js
+    jsonpath-plus: bin/jsonpath-cli.js
+  checksum: 992a62a0a5d2b96b40389de0608943840db39b466f9d3c1d71b4801e34b8d397c74811213e24e33c833b74aa83d9ce7860c1e7e0bc29980161489ea4a3962ecf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is a simple dependency bump in `core` of the jsonpath-plus dependency.

This dependency is vulnerable according to Snyk: https://security.snyk.io/vuln/SNYK-JS-JSONPATHPLUS-7945884
As this is a non-major upgrade and I have not seen the vulnerability being mentioned anywhere in the repository I thought I'd open a PR for it.

**Checklist**

- [ ] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
