### PR TITLE
fix(deps): fix CVE related to jsonpath-plus

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,7 @@
     "ajv-errors": "~3.0.0",
     "ajv-formats": "~2.1.0",
     "es-aggregate-error": "^1.0.7",
-    "jsonpath-plus": "10.1.0",
+    "jsonpath-plus": "10.2.0",
     "lodash": "~4.17.21",
     "lodash.topath": "^4.5.2",
     "minimatch": "3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2103,12 +2103,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jsep-plugin/assignment@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@jsep-plugin/assignment@npm:1.3.0"
+  peerDependencies:
+    jsep: ^0.4.0||^1.0.0
+  checksum: 5549497d403a6c00969d61202a6d3dafc5a349929d190a524363dcfacb3436dbda3d9f88b2ec1330247a594ad3c5f1c17b0997769d0b206802281bad6cf9a410
+  languageName: node
+  linkType: hard
+
 "@jsep-plugin/regex@npm:^1.0.1, @jsep-plugin/regex@npm:^1.0.3":
   version: 1.0.3
   resolution: "@jsep-plugin/regex@npm:1.0.3"
   peerDependencies:
     jsep: ^0.4.0||^1.0.0
   checksum: a57718ae5c86bd10ff5de51843a771b96a10a9c6b5c5f4e02aa5318257c3d5fdec96f8b389fcbe129c7a6ad6b0746d9a0fd934c949b80882230fbc14b548c922
+  languageName: node
+  linkType: hard
+
+"@jsep-plugin/regex@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "@jsep-plugin/regex@npm:1.0.4"
+  peerDependencies:
+    jsep: ^0.4.0||^1.0.0
+  checksum: 78ef01554535ac6c108851a2a6d86377bce10de01a263ad7b31f9b37c8aa9fc6c49f24b753e5da7d771c5921c913e43c1c33e0bc0fa5d02562d906c83a237836
   languageName: node
   linkType: hard
 
@@ -2975,7 +2993,7 @@ __metadata:
     ajv-errors: ~3.0.0
     ajv-formats: ~2.1.0
     es-aggregate-error: ^1.0.7
-    jsonpath-plus: 10.1.0
+    jsonpath-plus: 10.2.0
     lodash: ~4.17.21
     lodash.topath: ^4.5.2
     minimatch: 3.1.2
@@ -9263,7 +9281,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonpath-plus@npm:10.1.0, jsonpath-plus@npm:^6.0.1 || ^10.1.0":
+"jsonpath-plus@npm:10.2.0":
+  version: 10.2.0
+  resolution: "jsonpath-plus@npm:10.2.0"
+  dependencies:
+    "@jsep-plugin/assignment": ^1.3.0
+    "@jsep-plugin/regex": ^1.0.4
+    jsep: ^1.4.0
+  bin:
+    jsonpath: bin/jsonpath-cli.js
+    jsonpath-plus: bin/jsonpath-cli.js
+  checksum: 862a96a0179f342fa6c012065fa78458d4ae4835f18a6ef580d18807101d8c2c3509dc20c9857474503205bff8f06c309e17d7420b68196262d15ad1e4f22146
+  languageName: node
+  linkType: hard
+
+"jsonpath-plus@npm:^6.0.1 || ^10.1.0":
   version: 10.1.0
   resolution: "jsonpath-plus@npm:10.1.0"
   dependencies:


### PR DESCRIPTION
Refs #2717

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

This PR update the `jsonpath-plus` dependency in `spectral-core`.  After package release, I'll follow up with a bump on the depending packages as well as vscode-spectral
