### PR TITLE
fix(deps): bump spectral-core dependents

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@stoplight/json": "~3.21.0",
     "@stoplight/path": "1.3.2",
-    "@stoplight/spectral-core": "^1.19.2",
+    "@stoplight/spectral-core": "^1.19.4",
     "@stoplight/spectral-formatters": "^1.4.1",
     "@stoplight/spectral-parsers": "^1.0.4",
     "@stoplight/spectral-ref-resolver": "^1.0.4",

--- a/packages/formatters/package.json
+++ b/packages/formatters/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@stoplight/path": "^1.3.2",
-    "@stoplight/spectral-core": "^1.19.2",
+    "@stoplight/spectral-core": "^1.19.4",
     "@stoplight/spectral-runtime": "^1.1.2",
     "@stoplight/types": "^13.15.0",
     "@types/markdown-escape": "^1.1.3",

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@stoplight/better-ajv-errors": "1.0.3",
     "@stoplight/json": "^3.17.1",
-    "@stoplight/spectral-core": "^1.19.2",
+    "@stoplight/spectral-core": "^1.19.4",
     "@stoplight/spectral-formats": "^1.8.1",
     "@stoplight/spectral-runtime": "^1.1.2",
     "ajv": "^8.17.1",

--- a/packages/rulesets/package.json
+++ b/packages/rulesets/package.json
@@ -21,7 +21,7 @@
     "@asyncapi/specs": "^6.8.0",
     "@stoplight/better-ajv-errors": "1.0.3",
     "@stoplight/json": "^3.17.0",
-    "@stoplight/spectral-core": "^1.19.2",
+    "@stoplight/spectral-core": "^1.19.4",
     "@stoplight/spectral-formats": "^1.8.1",
     "@stoplight/spectral-functions": "^1.9.1",
     "@stoplight/spectral-runtime": "^1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2942,7 +2942,7 @@ __metadata:
   dependencies:
     "@stoplight/json": ~3.21.0
     "@stoplight/path": 1.3.2
-    "@stoplight/spectral-core": ^1.19.2
+    "@stoplight/spectral-core": ^1.19.4
     "@stoplight/spectral-formatters": ^1.4.1
     "@stoplight/spectral-parsers": ^1.0.4
     "@stoplight/spectral-ref-resolver": ^1.0.4
@@ -2971,7 +2971,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@stoplight/spectral-core@*, @stoplight/spectral-core@>=1, @stoplight/spectral-core@^1.19.2, @stoplight/spectral-core@workspace:packages/core":
+"@stoplight/spectral-core@*, @stoplight/spectral-core@>=1, @stoplight/spectral-core@^1.19.2, @stoplight/spectral-core@^1.19.4, @stoplight/spectral-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@stoplight/spectral-core@workspace:packages/core"
   dependencies:
@@ -3022,7 +3022,7 @@ __metadata:
   resolution: "@stoplight/spectral-formatters@workspace:packages/formatters"
   dependencies:
     "@stoplight/path": ^1.3.2
-    "@stoplight/spectral-core": ^1.19.2
+    "@stoplight/spectral-core": ^1.19.4
     "@stoplight/spectral-runtime": ^1.1.2
     "@stoplight/types": ^13.15.0
     "@types/markdown-escape": ^1.1.3
@@ -3048,7 +3048,7 @@ __metadata:
   dependencies:
     "@stoplight/better-ajv-errors": 1.0.3
     "@stoplight/json": ^3.17.1
-    "@stoplight/spectral-core": ^1.19.2
+    "@stoplight/spectral-core": ^1.19.4
     "@stoplight/spectral-formats": ^1.8.1
     "@stoplight/spectral-parsers": "*"
     "@stoplight/spectral-runtime": ^1.1.2
@@ -3146,7 +3146,7 @@ __metadata:
     "@stoplight/better-ajv-errors": 1.0.3
     "@stoplight/json": ^3.17.0
     "@stoplight/path": ^1.3.2
-    "@stoplight/spectral-core": ^1.19.2
+    "@stoplight/spectral-core": ^1.19.4
     "@stoplight/spectral-formats": ^1.8.1
     "@stoplight/spectral-functions": ^1.9.1
     "@stoplight/spectral-parsers": "*"


### PR DESCRIPTION
Fixes #2717

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

This PR bumps spectral packages that depend on spectral-core to leverage the latest version which includes jsonpath-plus 10.2.0 thus addressing CVE-2024-21534
