### PR TITLE
feat(functions): add or function

### DIFF
--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -245,9 +245,34 @@ unused-definition:
       reusableObjectsLocation: "#/definitions"
 ```
 
+## or
+
+Communicate that one or more of these properties is required to be defined. `functionOptions` must contain at least two properties. **or** will require that _at least_ one of them is defined.
+
+<!-- title: functionOptions -->
+
+| name       | description             | type       | required? |
+| ---------- | ----------------------- | ---------- | --------- |
+| properties | the properties to check | `string[]` | yes       |
+
+<!-- title: example -->
+
+```yaml
+schemas-descriptive-text-exists:
+  description: Defined schemas must have one or more of `title`, `summary` and/or `description` fields.
+  given: "$.components.schemas.*"
+  then:
+    function: or
+    functionOptions:
+      properties:
+        - title
+        - summary
+        - description
+```
+
 ## xor
 
-Communicate that one of these properties is required, and no more than one is allowed to be defined.
+Communicate that one of these properties is required, and no more than one is allowed to be defined. `functionOptions` must contain at least two properties. **xor** will require that _exactly_ one of them is defined.
 
 <!-- title: functionOptions -->
 
@@ -259,7 +284,7 @@ Communicate that one of these properties is required, and no more than one is al
 
 ```yaml
 components-examples-value-or-externalValue:
-  description: Examples should have either a `value` or `externalValue` field.
+  description: Examples should have either a `value` or `externalValue` field, but not both.
   given: "$.components.examples.*"
   then:
     function: xor

--- a/packages/functions/src/__tests__/or.test.ts
+++ b/packages/functions/src/__tests__/or.test.ts
@@ -2,15 +2,15 @@ import '@stoplight/spectral-test-utils/matchers';
 
 import { RulesetValidationError } from '@stoplight/spectral-core';
 import testFunction from './__helpers__/tester';
-import xor from '../xor';
+import or from '../or';
 import AggregateError = require('es-aggregate-error');
 
-const runXor = testFunction.bind(null, xor);
+const runOr = testFunction.bind(null, or);
 
-describe('Core Functions / Xor', () => {
+describe('Core Functions / Or', () => {
   it('given no properties, should return an error message', async () => {
     expect(
-      await runXor(
+      await runOr(
         {
           version: '1.0.0',
           title: 'Swagger Petstore',
@@ -26,27 +26,9 @@ describe('Core Functions / Xor', () => {
     ]);
   });
 
-  it('given multiple properties that do not match, should return an error message', async () => {
+  it('given both properties, should return no error message', async () => {
     expect(
-      await runXor(
-        {
-          version: '1.0.0',
-          title: 'Swagger Petstore',
-          termsOfService: 'http://swagger.io/terms/',
-        },
-        { properties: ['yada-yada', 'whatever', 'foo'] },
-      ),
-    ).toEqual([
-      {
-        message: '"yada-yada", "whatever" and "foo" must not be both defined or both undefined',
-        path: [],
-      },
-    ]);
-  });
-
-  it('given both properties, should return an error message', async () => {
-    expect(
-      await runXor(
+      await runOr(
         {
           version: '1.0.0',
           title: 'Swagger Petstore',
@@ -54,21 +36,16 @@ describe('Core Functions / Xor', () => {
         },
         { properties: ['version', 'title'] },
       ),
-    ).toEqual([
-      {
-        message: 'Just one of "version" and "title" must be defined',
-        path: [],
-      },
-    ]);
+    ).toEqual([]);
   });
 
   it('given invalid input, should show no error message', async () => {
-    return expect(await runXor(null, { properties: ['version', 'title'] })).toEqual([]);
+    return expect(await runOr(null, { properties: ['version', 'title'] })).toEqual([]);
   });
 
   it('given only one of the properties, should return no error message', async () => {
     expect(
-      await runXor(
+      await runOr(
         {
           version: '1.0.0',
           title: 'Swagger Petstore',
@@ -79,9 +56,48 @@ describe('Core Functions / Xor', () => {
     ).toEqual([]);
   });
 
-  it('given multiple of 5 properties, should return an error message', async () => {
+  it('given one of 3 properties, should return no error message', async () => {
     expect(
-      await runXor(
+      await runOr(
+        {
+          type: 'string',
+          format: 'date',
+        },
+        { properties: ['default', 'pattern', 'format'] },
+      ),
+    ).toEqual([]);
+  });
+
+  it('given two of 3 properties, should return no error message', async () => {
+    expect(
+      await runOr(
+        {
+          type: 'string',
+          default: '2024-05-01',
+          format: 'date',
+        },
+        { properties: ['default', 'pattern', 'format'] },
+      ),
+    ).toEqual([]);
+  });
+
+  it('given three of 3 properties, should return no error message', async () => {
+    expect(
+      await runOr(
+        {
+          type: 'string',
+          default: '2024-05-01',
+          pattern: '\\d{4}-\\d{2}-\\d{2}',
+          format: 'date',
+        },
+        { properties: ['default', 'pattern', 'format'] },
+      ),
+    ).toEqual([]);
+  });
+
+  it('given multiple of 5 properties, should return no error message', async () => {
+    expect(
+      await runOr(
         {
           version: '1.0.0',
           title: 'Swagger Petstore',
@@ -89,17 +105,12 @@ describe('Core Functions / Xor', () => {
         },
         { properties: ['version', 'title', 'termsOfService', 'bar', 'five'] },
       ),
-    ).toEqual([
-      {
-        message: 'Just one of "version" and "title" and "termsOfService" must be defined',
-        path: [],
-      },
-    ]);
+    ).toEqual([]);
   });
 
   it('given none of 5 properties, should return an error message', async () => {
     expect(
-      await runXor(
+      await runOr(
         {
           version: '1.0.0',
           title: 'Swagger Petstore',
@@ -117,7 +128,7 @@ describe('Core Functions / Xor', () => {
 
   it('given only one of 4 properties, should return no error message', async () => {
     expect(
-      await runXor(
+      await runOr(
         {
           version: '1.0.0',
           title: 'Swagger Petstore',
@@ -130,11 +141,11 @@ describe('Core Functions / Xor', () => {
 
   describe('validation', () => {
     it.each([{ properties: ['foo', 'bar'] }])('given valid %p options, should not throw', async opts => {
-      expect(await runXor([], opts)).toEqual([]);
+      expect(await runOr([], opts)).toEqual([]);
     });
 
     it.each([{ properties: ['foo', 'bar', 'three'] }])('given valid %p options, should not throw', async opts => {
-      expect(await runXor([], opts)).toEqual([]);
+      expect(await runOr([], opts)).toEqual([]);
     });
 
     it.each<[unknown, RulesetValidationError[]]>([
@@ -143,7 +154,7 @@ describe('Core Functions / Xor', () => {
         [
           new RulesetValidationError(
             'invalid-function-options',
-            '"xor" function has invalid options specified. Example valid options: { "properties": ["country", "street"] }, { "properties": ["one", "two", "three"] }, etc.',
+            '"or" function has invalid options specified. Example valid options: { "properties": ["default", "example"] }, { "properties": ["title", "summary", "description"] }, etc.',
             ['rules', 'my-rule', 'then', 'functionOptions'],
           ),
         ],
@@ -153,7 +164,7 @@ describe('Core Functions / Xor', () => {
         [
           new RulesetValidationError(
             'invalid-function-options',
-            '"xor" function has invalid options specified. Example valid options: { "properties": ["country", "street"] }, { "properties": ["one", "two", "three"] }, etc.',
+            '"or" function has invalid options specified. Example valid options: { "properties": ["default", "example"] }, { "properties": ["title", "summary", "description"] }, etc.',
             ['rules', 'my-rule', 'then', 'functionOptions'],
           ),
         ],
@@ -161,7 +172,7 @@ describe('Core Functions / Xor', () => {
       [
         { properties: ['foo', 'bar'], foo: true },
         [
-          new RulesetValidationError('invalid-function-options', '"xor" function does not support "foo" option', [
+          new RulesetValidationError('invalid-function-options', '"or" function does not support "foo" option', [
             'rules',
             'my-rule',
             'then',
@@ -175,17 +186,7 @@ describe('Core Functions / Xor', () => {
         [
           new RulesetValidationError(
             'invalid-function-options',
-            '"xor" requires at least two enumerated "properties", i.e. ["country", "street"], ["one", "two", "three"], etc.',
-            ['rules', 'my-rule', 'then', 'functionOptions', 'properties'],
-          ),
-        ],
-      ],
-      [
-        { properties: ['foo'] },
-        [
-          new RulesetValidationError(
-            'invalid-function-options',
-            '"xor" requires at least two enumerated "properties", i.e. ["country", "street"], ["one", "two", "three"], etc.',
+            '"or" requires at least two enumerated "properties", i.e. ["default", "example"], ["title", "summary", "description"], etc.',
             ['rules', 'my-rule', 'then', 'functionOptions', 'properties'],
           ),
         ],
@@ -195,13 +196,13 @@ describe('Core Functions / Xor', () => {
         [
           new RulesetValidationError(
             'invalid-function-options',
-            '"xor" requires at least two enumerated "properties", i.e. ["country", "street"], ["one", "two", "three"], etc.',
+            '"or" requires at least two enumerated "properties", i.e. ["default", "example"], ["title", "summary", "description"], etc.',
             ['rules', 'my-rule', 'then', 'functionOptions', 'properties'],
           ),
         ],
       ],
     ])('given invalid %p options, should throw', async (opts, errors) => {
-      await expect(runXor({}, opts)).rejects.toThrowAggregateError(new AggregateError(errors));
+      await expect(runOr({}, opts)).rejects.toThrowAggregateError(new AggregateError(errors));
     });
   });
 });

--- a/packages/functions/src/__tests__/xor.test.ts
+++ b/packages/functions/src/__tests__/xor.test.ts
@@ -38,7 +38,7 @@ describe('Core Functions / Xor', () => {
       ),
     ).toEqual([
       {
-        message: '"yada-yada", "whatever" and "foo" must not be both defined or both undefined',
+        message: 'At least one of "yada-yada" or "whatever" or "foo" must be defined',
         path: [],
       },
     ]);

--- a/packages/functions/src/optionSchemas.ts
+++ b/packages/functions/src/optionSchemas.ts
@@ -96,6 +96,25 @@ export const optionSchemas: Record<string, CustomFunctionOptionsSchema> = {
       type: `"length" function has invalid options specified. Example valid options: { "min": 2 }, { "max": 5 }, { "min": 0, "max": 10 }`,
     },
   },
+  or: {
+    type: 'object',
+    properties: {
+      properties: {
+        type: 'array',
+        items: {
+          type: 'string',
+        },
+        minItems: 2,
+        errorMessage: `"or" requires at least two enumerated "properties", i.e. ["default", "example"], ["title", "summary", "description"], etc.`,
+        description: 'The properties to check.',
+      },
+    },
+    additionalProperties: false,
+    required: ['properties'],
+    errorMessage: {
+      type: `"or" function has invalid options specified. Example valid options: { "properties": ["default", "example"] }, { "properties": ["title", "summary", "description"] }, etc.`,
+    },
+  },
   pattern: {
     type: 'object',
     additionalProperties: false,
@@ -207,14 +226,14 @@ export const optionSchemas: Record<string, CustomFunctionOptionsSchema> = {
           type: 'string',
         },
         minItems: 2,
-        errorMessage: `"xor" and its "properties" option require at least 2-item tuples, i.e. ["id", "name"]`,
+        errorMessage: `"xor" requires at least two enumerated "properties", i.e. ["country", "street"], ["one", "two", "three"], etc.`,
         description: 'The properties to check.',
       },
     },
     additionalProperties: false,
     required: ['properties'],
     errorMessage: {
-      type: `"xor" function has invalid options specified. Example valid options: { "properties": ["id", "name"] }, { "properties": ["country", "street"] }`,
+      type: `"xor" function has invalid options specified. Example valid options: { "properties": ["country", "street"] }, { "properties": ["one", "two", "three"] }, etc.`,
     },
   },
 };

--- a/packages/functions/src/or.ts
+++ b/packages/functions/src/or.ts
@@ -2,7 +2,7 @@ import { createRulesetFunction, IFunctionResult } from '@stoplight/spectral-core
 import { optionSchemas } from './optionSchemas';
 
 export type Options = {
-  /** test to verify if exactly one of the provided keys are present in object */
+  /** test to verify at least one of the provided keys are present in object */
   properties: string[];
 };
 
@@ -11,9 +11,9 @@ export default createRulesetFunction<Record<string, unknown>, Options>(
     input: {
       type: 'object',
     },
-    options: optionSchemas.xor,
+    options: optionSchemas.or,
   },
-  function xor(targetVal, { properties }) {
+  function or(targetVal, { properties }) {
     if (properties.length < 2) return;
     // At least two but no maximum limit on number of properties
 
@@ -34,13 +34,6 @@ export default createRulesetFunction<Record<string, unknown>, Options>(
           message: 'At least one of "' + properties.join('" or "') + '" must be defined',
         });
       }
-    }
-
-    if (intersection.length > 1) {
-      // List all defined properties in error message
-      results.push({
-        message: 'Just one of "' + intersection.join('" and "') + '" must be defined',
-      });
     }
 
     return results;


### PR DESCRIPTION
This PR supersedes #2765 to provide a clean history with only the intended changes from CuttingClyde.

Changes:
- Added xor and or functions.
- Updated optionSchemas.ts and tests.

Original work credited to @cuttingclyde.

fixes #2396