### PR TITLE
chore(repo): add Bank API to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,17 @@
 
 # Overview
 
-  - [🧰 Installation](#-installation)
-  - [💻 Usage](#-usage)
-    - [1. Create a local ruleset](#1-create-a-local-ruleset)
-    - [2. Lint](#2-lint)
-  - [📖 Documentation](#-documentation)
-  - [ℹ️ Support](#ℹ️-support)
-  - [🌎 Real-World Rulesets](#-real-world-rulesets)
-  - [⚙️ Integrations](#️-integrations)
-  - [🏁 Help Others Utilize Spectral](#-help-others-utilize-spectral)
-  - [👏 Contributing](#-contributing)
-  - [🎉 Thanks](#-thanks)
-  - [📜 License](#-license)
-  - [🌲 Sponsor Spectral by Planting a Tree](#-sponsor-spectral-by-planting-a-tree)
+- [🧰 Installation](#-installation)
+- [💻 Usage](#-usage)
+- [📖 Documentation](#-documentation)
+- [ℹ️ Support](#ℹ️-support)
+- [🌎 Real-World Rulesets](#-real-world-rulesets)
+- [⚙️ Integrations](#️-integrations)
+- [🏁 Help Others Utilize Spectral](#-help-others-utilize-spectral)
+- [👏 Contributing](#-contributing)
+- [🎉 Thanks](#-thanks)
+- [📜 License](#-license)
+- [🌲 Sponsor Spectral by Planting a Tree](#-sponsor-spectral-by-planting-a-tree)
 
 ## 🧰 Installation
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 
 # Overview
 
-- [Overview](#overview)
   - [🧰 Installation](#-installation)
   - [💻 Usage](#-usage)
     - [1. Create a local ruleset](#1-create-a-local-ruleset)

--- a/README.md
+++ b/README.md
@@ -9,14 +9,20 @@
 
 # Overview
 
-- [🧰 Installation](#-installation)
-- [💻 Usage](#-usage)
-- [📖 Documentation](#-documentation)
-- [ℹ️ Support](#ℹ️-support)
-- [🌎 Real-World Rulesets](#-real-world-rulesets)
-- [⚙️ Integrations](#️-integrations)
-- [👏 Contributing](#-contributing)
-- [🌲 Sponsor Spectral by Planting a Tree](#-sponsor-spectral-by-planting-a-tree)
+- [Overview](#overview)
+  - [🧰 Installation](#-installation)
+  - [💻 Usage](#-usage)
+    - [1. Create a local ruleset](#1-create-a-local-ruleset)
+    - [2. Lint](#2-lint)
+  - [📖 Documentation](#-documentation)
+  - [ℹ️ Support](#ℹ️-support)
+  - [🌎 Real-World Rulesets](#-real-world-rulesets)
+  - [⚙️ Integrations](#️-integrations)
+  - [🏁 Help Others Utilize Spectral](#-help-others-utilize-spectral)
+  - [👏 Contributing](#-contributing)
+  - [🎉 Thanks](#-thanks)
+  - [📜 License](#-license)
+  - [🌲 Sponsor Spectral by Planting a Tree](#-sponsor-spectral-by-planting-a-tree)
 
 ## 🧰 Installation
 
@@ -115,6 +121,8 @@ Check out some additional style guides here:
 ## 🏁 Help Others Utilize Spectral
 
 If you're using Spectral for an interesting use case, create an issue with details on how you're using it. We'll add it to a list here. Spread the goodness 🎉
+
+- [Bank API 🏦](https://github.com/erwinkramer/bank-api?tab=readme-ov-file#bank-api) - The Bank API is a design reference project suitable to bootstrap development for a compliant and modern API. Built in ASP.NET Core and fully complies to multiple Spectral rulesets, such as "OWASP Top 10", "Dutch Public Sector (NLGov) REST API Design Rules" and more. Built by [Erwin Kramer](https://github.com/erwinkramer).
 
 ## 👏 Contributing
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@
 - [ℹ️ Support](#ℹ️-support)
 - [🌎 Real-World Rulesets](#-real-world-rulesets)
 - [⚙️ Integrations](#️-integrations)
+- [🏁 Help Others Utilize Spectral](#-help-others-utilize-spectral)
 - [👏 Contributing](#-contributing)
+- [🎉 Thanks](#-thanks)
+- [📜 License](#-license)
 - [🌲 Sponsor Spectral by Planting a Tree](#-sponsor-spectral-by-planting-a-tree)
 
 ## 🧰 Installation
@@ -115,6 +118,8 @@ Check out some additional style guides here:
 ## 🏁 Help Others Utilize Spectral
 
 If you're using Spectral for an interesting use case, create an issue with details on how you're using it. We'll add it to a list here. Spread the goodness 🎉
+
+- [Bank API 🏦](https://github.com/erwinkramer/bank-api?tab=readme-ov-file#bank-api) - The Bank API is a design reference project suitable to bootstrap development for a compliant and modern API. Built in ASP.NET Core and fully complies to multiple Spectral rulesets, such as "OWASP Top 10", "Dutch Public Sector (NLGov) REST API Design Rules" and more. Built by [Erwin Kramer](https://github.com/erwinkramer).
 
 ## 👏 Contributing
 


### PR DESCRIPTION
As requested by https://github.com/stoplightio/spectral/issues/2763#issuecomment-2796681514, adding the Bank API as example into the readme.  The overview page was also a bit out of date, so i added the missing paragraphs. 