### PR TITLE
chore: updated ws package based on vulnerability scan

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
   "resolutions": {
     "jsep": "1.4.0",
     "sha.js": "2.4.12",
-    "pbkdf2": "3.1.3"
+    "pbkdf2": "3.1.3",
+    "ws": "8.17.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^14.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14477,22 +14477,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:~8.11.0":
-  version: 8.11.0
-  resolution: "ws@npm:8.11.0"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ^5.0.2
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 316b33aba32f317cd217df66dbfc5b281a2f09ff36815de222bc859e3424d83766d9eb2bd4d667de658b6ab7be151f258318fb1da812416b30be13103e5b5c67
-  languageName: node
-  linkType: hard
-
-"ws@npm:~8.17.1":
+"ws@npm:8.17.1":
   version: 8.17.1
   resolution: "ws@npm:8.17.1"
   peerDependencies:


### PR DESCRIPTION
updates ws to 8.17.1 due to vulnerability scans