### PR TITLE
chore: updated fetch-mock package based on vulnerability scan

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "jsep": "1.4.0",
     "sha.js": "2.4.12",
     "pbkdf2": "3.1.3",
-    "ws": "8.17.1"
+    "ws": "8.17.1",
+    "path-to-regexp": "3.3.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^14.1.0",
@@ -112,7 +113,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "expect": "^27.5.1",
     "fast-glob": "^3.3.3",
-    "fetch-mock": "^9.11.0",
+    "fetch-mock": "^12.6.0",
     "file-entry-cache": "^6.0.1",
     "husky": "^7.0.4",
     "jest": "^29.7.0",

--- a/packages/ruleset-bundler/package.json
+++ b/packages/ruleset-bundler/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@types/validate-npm-package-name": "^3.0.3",
-    "fetch-mock": "^12",
+    "fetch-mock": "^12.6.0",
     "memfs": "^3.5.3",
     "prettier": "^2.4.1"
   }

--- a/packages/ruleset-bundler/package.json
+++ b/packages/ruleset-bundler/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@types/validate-npm-package-name": "^3.0.3",
-    "fetch-mock": "^9.11.0",
+    "fetch-mock": "^12",
     "memfs": "^3.5.3",
     "prettier": "^2.4.1"
   }

--- a/packages/ruleset-migrator/package.json
+++ b/packages/ruleset-migrator/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@stoplight/spectral-core": "*",
     "@stoplight/spectral-rulesets": "*",
-    "fetch-mock": "^9.11.0",
+    "fetch-mock": "^12",
     "json-schema-to-typescript": "^10.1.5",
     "memfs": "^3.5.3",
     "prettier": "^2.4.1"

--- a/packages/ruleset-migrator/package.json
+++ b/packages/ruleset-migrator/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@stoplight/spectral-core": "*",
     "@stoplight/spectral-rulesets": "*",
-    "fetch-mock": "^12",
+    "fetch-mock": "^12.6.0",
     "json-schema-to-typescript": "^10.1.5",
     "memfs": "^3.5.3",
     "prettier": "^2.4.1"

--- a/packages/ruleset-migrator/src/__tests__/ruleset.test.ts
+++ b/packages/ruleset-migrator/src/__tests__/ruleset.test.ts
@@ -28,7 +28,8 @@ type FetchMockSandbox = FetchMockInstance & FetchFn;
 function createFetchMockSandbox(): FetchMockSandbox {
   const instance = fetchMockLib.createInstance();
   const sandbox = instance.fetchHandler as FetchMockSandbox;
-  return Object.assign(sandbox, instance);
+  Object.setPrototypeOf(sandbox, instance);
+  return sandbox;
 }
 
 const scenarios = Object.keys(fixtures)

--- a/packages/ruleset-migrator/src/__tests__/ruleset.test.ts
+++ b/packages/ruleset-migrator/src/__tests__/ruleset.test.ts
@@ -4,7 +4,7 @@ import * as prettier from 'prettier/standalone';
 import * as parserBabel from 'prettier/parser-babel';
 import { Ruleset } from '@stoplight/spectral-core';
 import { DiagnosticSeverity } from '@stoplight/types';
-import { createSandbox } from 'fetch-mock';
+import fetchMockLib, { FetchMock as FetchMockInstance } from 'fetch-mock';
 import { serveAssets } from '@stoplight/spectral-test-utils';
 
 import { migrateRuleset } from '..';
@@ -18,8 +18,17 @@ afterAll(() => {
   vol.reset();
 });
 
-function createFetchMockSandbox() {
-  return createSandbox();
+type FetchFn = (
+  input: Parameters<typeof globalThis.fetch>[0],
+  init?: Parameters<typeof globalThis.fetch>[1],
+) => ReturnType<typeof globalThis.fetch>;
+
+type FetchMockSandbox = FetchMockInstance & FetchFn;
+
+function createFetchMockSandbox(): FetchMockSandbox {
+  const instance = fetchMockLib.createInstance();
+  const sandbox = instance.fetchHandler as FetchMockSandbox;
+  return Object.assign(sandbox, instance);
 }
 
 const scenarios = Object.keys(fixtures)

--- a/packages/ruleset-migrator/src/__tests__/ruleset.test.ts
+++ b/packages/ruleset-migrator/src/__tests__/ruleset.test.ts
@@ -4,7 +4,7 @@ import * as prettier from 'prettier/standalone';
 import * as parserBabel from 'prettier/parser-babel';
 import { Ruleset } from '@stoplight/spectral-core';
 import { DiagnosticSeverity } from '@stoplight/types';
-import * as fetchMock from 'fetch-mock';
+import { createSandbox } from 'fetch-mock';
 import { serveAssets } from '@stoplight/spectral-test-utils';
 
 import { migrateRuleset } from '..';
@@ -19,8 +19,7 @@ afterAll(() => {
 });
 
 function createFetchMockSandbox() {
-  // something is off with default module interop in Karma :man_shrugging:
-  return ((fetchMock as { default?: typeof import('fetch-mock') }).default ?? fetchMock).sandbox();
+  return createSandbox();
 }
 
 const scenarios = Object.keys(fixtures)

--- a/test-utils/browser/index.js
+++ b/test-utils/browser/index.js
@@ -1,11 +1,12 @@
 import { dirname, isURL } from '@stoplight/path';
 import * as fs from 'fs';
+import { createSandbox } from 'fetch-mock';
 
 let fetchMock;
 let fetchDesc;
 
 beforeEach(() => {
-  fetchMock = require('fetch-mock').default.sandbox();
+  fetchMock = createSandbox();
   // fetchMock.config.fetch = fetch;
   fetchMock.config.fallbackToNetwork = false;
   fetchDesc = Object.getOwnPropertyDescriptor(global, 'fetch');

--- a/test-utils/browser/index.js
+++ b/test-utils/browser/index.js
@@ -1,20 +1,19 @@
 import { dirname, isURL } from '@stoplight/path';
 import * as fs from 'fs';
-import { createSandbox } from 'fetch-mock';
+import fetchMockLib from 'fetch-mock';
 
 let fetchMock;
 let fetchDesc;
 
 beforeEach(() => {
-  fetchMock = createSandbox();
-  // fetchMock.config.fetch = fetch;
-  fetchMock.config.fallbackToNetwork = false;
+  fetchMock = fetchMockLib.createInstance();
+  fetchMock.config.fetch = global.fetch;
   fetchDesc = Object.getOwnPropertyDescriptor(global, 'fetch');
-  window.fetch = fetchMock;
+  window.fetch = fetchMock.fetchHandler;
 });
 
 afterEach(() => {
-  fetchMock.restore();
+  fetchMock.hardReset();
   Object.defineProperty(window, 'fetch', fetchDesc);
 });
 
@@ -27,7 +26,7 @@ export function serveAssets(mocks) {
     }
 
     for (const actualUrl of new Set([uri.replace(/([^/])\?/, '$1/?'), uri.replace(/([^/])\?/, '$1?')])) {
-      fetchMock.mock(actualUrl, {
+      fetchMock.route(actualUrl, {
         status: 200,
         body,
       });
@@ -39,7 +38,7 @@ export function mockResponses(mocks) {
   for (const [uri, responses] of Object.entries(mocks)) {
     for (const [code, body] of Object.entries(responses)) {
       for (const actualUrl of new Set([uri.replace(/([^/])\?/, '$1/?'), uri.replace(/([^/])\?/, '$1?')])) {
-        fetchMock.mock(actualUrl, {
+        fetchMock.route(actualUrl, {
           status: Number(code),
           body,
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3092,7 +3092,7 @@ __metadata:
     "@stoplight/types": ^13.6.0
     "@types/node": "*"
     "@types/validate-npm-package-name": ^3.0.3
-    fetch-mock: ^12
+    fetch-mock: ^12.6.0
     memfs: ^3.5.3
     pony-cause: 1.1.1
     prettier: ^2.4.1
@@ -3119,7 +3119,7 @@ __metadata:
     ajv: ^8.17.1
     ast-types: 0.14.2
     astring: ^1.9.0
-    fetch-mock: ^12
+    fetch-mock: ^12.6.0
     json-schema-to-typescript: ^10.1.5
     memfs: ^3.5.3
     prettier: ^2.4.1
@@ -7095,7 +7095,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fetch-mock@npm:^12, fetch-mock@npm:^12.6.0":
+"fetch-mock@npm:^12.6.0":
   version: 12.6.0
   resolution: "fetch-mock@npm:12.6.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,7 +80,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.0.0, @babel/core@npm:^7.11.1, @babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.7.5":
+"@babel/core@npm:^7.11.1, @babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.7.5":
   version: 7.18.9
   resolution: "@babel/core@npm:7.18.9"
   dependencies:
@@ -1331,7 +1331,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.4":
+"@babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.4":
   version: 7.22.5
   resolution: "@babel/runtime@npm:7.22.5"
   dependencies:
@@ -3092,7 +3092,7 @@ __metadata:
     "@stoplight/types": ^13.6.0
     "@types/node": "*"
     "@types/validate-npm-package-name": ^3.0.3
-    fetch-mock: ^9.11.0
+    fetch-mock: ^12
     memfs: ^3.5.3
     pony-cause: 1.1.1
     prettier: ^2.4.1
@@ -3119,7 +3119,7 @@ __metadata:
     ajv: ^8.17.1
     ast-types: 0.14.2
     astring: ^1.9.0
-    fetch-mock: ^9.11.0
+    fetch-mock: ^12
     json-schema-to-typescript: ^10.1.5
     memfs: ^3.5.3
     prettier: ^2.4.1
@@ -3516,6 +3516,13 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: 4d0b5f13de2dfece7ad03ce2be6314cea0dd98488202568493c5c3cd0c6f5d7c618beb0c03f4251dbb6d846f60c5a2b04cdca9f23583c47953bbcaedd88f043e
+  languageName: node
+  linkType: hard
+
+"@types/glob-to-regexp@npm:^0.4.4":
+  version: 0.4.4
+  resolution: "@types/glob-to-regexp@npm:0.4.4"
+  checksum: be9c924d664592a16129c825aa392365335ce455c34e1c9d3f6dd8b45371088bb5d4a45bbb576559f2b63d4f8bcf464cbd5baafb08cdf89b71d3b6a79356b747
   languageName: node
   linkType: hard
 
@@ -5569,13 +5576,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js@npm:^3.0.0":
-  version: 3.8.1
-  resolution: "core-js@npm:3.8.1"
-  checksum: 0212b6d2d113d2ed50d5cfed467e1b64fa25b53f0d5c38eba4ac591a7d6d05bd74bab544fa982c07acaf781daab5f468e8b7d3f5a774bccdf6059bf0ce54b3d5
-  languageName: node
-  linkType: hard
-
 "core-util-is@npm:~1.0.0":
   version: 1.0.2
   resolution: "core-util-is@npm:1.0.2"
@@ -5993,6 +5993,13 @@ __metadata:
   version: 2.3.1
   resolution: "deprecation@npm:2.3.1"
   checksum: f56a05e182c2c195071385455956b0c4106fe14e36245b00c689ceef8e8ab639235176a96977ba7c74afb173317fac2e0ec6ec7a1c6d1e6eaa401c586c714132
+  languageName: node
+  linkType: hard
+
+"dequal@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "dequal@npm:2.0.3"
+  checksum: 8679b850e1a3d0ebbc46ee780d5df7b478c23f335887464023a631d1b9af051ad4a6595a44220f9ff8ff95a8ddccf019b5ad778a976fd7bbf77383d36f412f90
   languageName: node
   linkType: hard
 
@@ -7088,26 +7095,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fetch-mock@npm:^9.11.0":
-  version: 9.11.0
-  resolution: "fetch-mock@npm:9.11.0"
+"fetch-mock@npm:^12":
+  version: 12.6.0
+  resolution: "fetch-mock@npm:12.6.0"
   dependencies:
-    "@babel/core": ^7.0.0
-    "@babel/runtime": ^7.0.0
-    core-js: ^3.0.0
-    debug: ^4.1.1
-    glob-to-regexp: ^0.4.0
-    is-subset: ^0.1.1
-    lodash.isequal: ^4.5.0
-    path-to-regexp: ^2.2.1
-    querystring: ^0.2.0
-    whatwg-url: ^6.5.0
-  peerDependencies:
-    node-fetch: "*"
-  peerDependenciesMeta:
-    node-fetch:
-      optional: true
-  checksum: debc4dd83bcda79b0aa71c38d08da6036906cdc49393343eb3426112314a7e57557255664f745d2e3f0b9b2a6e852bd3a564ae3f08332c27e422d3441bb865bd
+    "@types/glob-to-regexp": ^0.4.4
+    dequal: ^2.0.3
+    glob-to-regexp: ^0.4.1
+    regexparam: ^3.0.0
+  checksum: 7705aaa6ab149f59e10e9e0794175e31c3b6c52eb0aab22522a4d7689a1ff0e3a85b9f76a2079adfd23d515e4db228e9ab7d4293f5c4cfee157cd9f858e14ae1
   languageName: node
   linkType: hard
 
@@ -7647,7 +7643,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-to-regexp@npm:^0.4.0":
+"glob-to-regexp@npm:^0.4.1":
   version: 0.4.1
   resolution: "glob-to-regexp@npm:0.4.1"
   checksum: e795f4e8f06d2a15e86f76e4d92751cf8bbfcf0157cea5c2f0f35678a8195a750b34096b1256e436f0cebc1883b5ff0888c47348443e69546a5a87f9e1eb1167
@@ -8603,13 +8599,6 @@ __metadata:
   dependencies:
     has-tostringtag: ^1.0.0
   checksum: 323b3d04622f78d45077cf89aab783b2f49d24dc641aa89b5ad1a72114cfeff2585efc8c12ef42466dff32bde93d839ad321b26884cf75e5a7892a938b089989
-  languageName: node
-  linkType: hard
-
-"is-subset@npm:^0.1.1":
-  version: 0.1.1
-  resolution: "is-subset@npm:0.1.1"
-  checksum: 97b8d7852af165269b7495095691a6ce6cf20bdfa1f846f97b4560ee190069686107af4e277fbd93aa0845c4d5db704391460ff6e9014aeb73264ba87893df44
   languageName: node
   linkType: hard
 
@@ -9954,13 +9943,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.isequal@npm:^4.5.0":
-  version: 4.5.0
-  resolution: "lodash.isequal@npm:4.5.0"
-  checksum: da27515dc5230eb1140ba65ff8de3613649620e8656b19a6270afe4866b7bd461d9ba2ac8a48dcc57f7adac4ee80e1de9f965d89d4d81a0ad52bb3eec2609644
-  languageName: node
-  linkType: hard
-
 "lodash.ismatch@npm:^4.4.0":
   version: 4.4.0
   resolution: "lodash.ismatch@npm:4.4.0"
@@ -10000,13 +9982,6 @@ __metadata:
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
   checksum: ad580b4bdbb7ca1f7abf7e1bce63a9a0b98e370cf40194b03380a46b4ed799c9573029599caebc1b14e3f24b111aef72b96674a56cfa105e0f5ac70546cdc005
-  languageName: node
-  linkType: hard
-
-"lodash.sortby@npm:^4.7.0":
-  version: 4.7.0
-  resolution: "lodash.sortby@npm:4.7.0"
-  checksum: db170c9396d29d11fe9a9f25668c4993e0c1331bcb941ddbd48fb76f492e732add7f2a47cfdf8e9d740fa59ac41bbfaf931d268bc72aab3ab49e9f89354d718c
   languageName: node
   linkType: hard
 
@@ -11653,13 +11628,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:^2.2.1":
-  version: 2.4.0
-  resolution: "path-to-regexp@npm:2.4.0"
-  checksum: 581175bf2968e51452f2b8c71f10e75c995693668b4ecf7d0b48962fbe0c56830661ca5dd5fd6d8e2f0cc9a045ce07e89af504ab133e1d21887c2712df85b1f4
-  languageName: node
-  linkType: hard
-
 "path-type@npm:^4.0.0":
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
@@ -12041,7 +12009,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"querystring@npm:0.2.0, querystring@npm:^0.2.0":
+"querystring@npm:0.2.0":
   version: 0.2.0
   resolution: "querystring@npm:0.2.0"
   checksum: 8258d6734f19be27e93f601758858c299bdebe71147909e367101ba459b95446fbe5b975bf9beb76390156a592b6f4ac3a68b6087cea165c259705b8b4e56a69
@@ -12289,6 +12257,13 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.8.4
   checksum: a467a3b652b4ec26ff964e9c5f1817523a73fc44cb928b8d21ff11aebeac5d10a84d297fe02cea9f282bcec81a0b0d562237da69ef0f40a0160b30a4fa98bc94
+  languageName: node
+  linkType: hard
+
+"regexparam@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "regexparam@npm:3.0.0"
+  checksum: c8649af1538ccc12b5c5d250525f61bd370227dce41f4fb908433a9651e18b7be21dd8f8518c322dd9ebd75f7caaaea4921e374c39a469c11d4f9d0c738043e0
   languageName: node
   linkType: hard
 
@@ -12558,7 +12533,7 @@ __metadata:
     eslint-plugin-prettier: ^4.2.1
     expect: ^27.5.1
     fast-glob: ^3.3.3
-    fetch-mock: ^9.11.0
+    fetch-mock: ^12
     file-entry-cache: ^6.0.1
     husky: ^7.0.4
     jest: ^29.7.0
@@ -13678,15 +13653,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tr46@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "tr46@npm:1.0.1"
-  dependencies:
-    punycode: ^2.1.0
-  checksum: 96d4ed46bc161db75dbf9247a236ea0bfcaf5758baae6749e92afab0bc5a09cb59af21788ede7e55080f2bf02dce3e4a8f2a484cc45164e29f4b5e68f7cbcc1a
-  languageName: node
-  linkType: hard
-
 "tr46@npm:~0.0.3":
   version: 0.0.3
   resolution: "tr46@npm:0.0.3"
@@ -14337,13 +14303,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webidl-conversions@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "webidl-conversions@npm:4.0.2"
-  checksum: c93d8dfe908a0140a4ae9c0ebc87a33805b416a33ee638a605b551523eec94a9632165e54632f6d57a39c5f948c4bab10e0e066525e9a4b87a79f0d04fbca374
-  languageName: node
-  linkType: hard
-
 "whatwg-url@npm:^5.0.0":
   version: 5.0.0
   resolution: "whatwg-url@npm:5.0.0"
@@ -14351,17 +14310,6 @@ __metadata:
     tr46: ~0.0.3
     webidl-conversions: ^3.0.0
   checksum: b8daed4ad3356cc4899048a15b2c143a9aed0dfae1f611ebd55073310c7b910f522ad75d727346ad64203d7e6c79ef25eafd465f4d12775ca44b90fa82ed9e2c
-  languageName: node
-  linkType: hard
-
-"whatwg-url@npm:^6.5.0":
-  version: 6.5.0
-  resolution: "whatwg-url@npm:6.5.0"
-  dependencies:
-    lodash.sortby: ^4.7.0
-    tr46: ^1.0.1
-    webidl-conversions: ^4.0.2
-  checksum: a10bd5e29f4382cd19789c2a7bbce25416e606b6fefc241c7fe34a2449de5bc5709c165bd13634eda433942d917ca7386a52841780b82dc37afa8141c31a8ebd
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7095,7 +7095,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fetch-mock@npm:^12":
+"fetch-mock@npm:^12, fetch-mock@npm:^12.6.0":
   version: 12.6.0
   resolution: "fetch-mock@npm:12.6.0"
   dependencies:
@@ -12533,7 +12533,7 @@ __metadata:
     eslint-plugin-prettier: ^4.2.1
     expect: ^27.5.1
     fast-glob: ^3.3.3
-    fetch-mock: ^12
+    fetch-mock: ^12.6.0
     file-entry-cache: ^6.0.1
     husky: ^7.0.4
     jest: ^29.7.0


### PR DESCRIPTION
updating `fetch-mock` due to the vulnerabilities found in `path-to-regexp` library