### PR TITLE
fix(formatters): Fix rendering of github actions documentationUrl

### DIFF
--- a/packages/formatters/src/__tests__/github-actions.jest.test.ts
+++ b/packages/formatters/src/__tests__/github-actions.jest.test.ts
@@ -37,6 +37,7 @@ const results: IRuleResult[] = [
         character: 60,
       },
     },
+    documentationUrl: 'https://example.com/pets',
   },
 ];
 
@@ -44,7 +45,7 @@ describe('GitHub Actions formatter', () => {
   test('should be formatted correctly', () => {
     expect(githubActions(results, { failSeverity: DiagnosticSeverity.Error }).split('\n')).toEqual([
       '::warning title=operation-description,file=__tests__/fixtures/petstore.oas2.yaml,col=9,endColumn=61,line=61,endLine=72::paths./pets.get.description is not truthy%0AMessage can have%0Amultiple lines',
-      '::warning title=operation-tags,file=__tests__/fixtures/petstore.oas2.yaml,col=9,endColumn=61,line=61,endLine=72::paths./pets.get.tags is not truthy',
+      '::warning title=operation-tags,file=__tests__/fixtures/petstore.oas2.yaml,col=9,endColumn=61,line=61,endLine=72::paths./pets.get.tags is not truthy%0ADocumentation: https://example.com/pets',
     ]);
   });
 });

--- a/packages/formatters/src/github-actions.ts
+++ b/packages/formatters/src/github-actions.ts
@@ -42,7 +42,7 @@ export const githubActions: Formatter = results => {
       const message = result.message.replace(/\n/g, '%0A');
 
       return `::${OUTPUT_TYPES[result.severity]} ${paramsString}::${message}${
-        result.documentationUrl ? `::${result.documentationUrl}` : ''
+        result.documentationUrl ? `%0ADocumentation: ${result.documentationUrl}` : ''
       }`;
     })
     .join('\n');

--- a/test-harness/scenarios/documentation-url/results-format-github-actions.scenario
+++ b/test-harness/scenarios/documentation-url/results-format-github-actions.scenario
@@ -54,6 +54,6 @@ info:
 ====command====
 {bin} lint {document} --format=github-actions --ruleset "{asset:ruleset.json}" --show-documentation-url
 ====stdout====
-::warning title=api-servers,file=document,col=1,endColumn=19,line=1,endLine=4::"servers" must be present and non-empty array.::https://www.example.com/docs/api-servers.md
+::warning title=api-servers,file=document,col=1,endColumn=19,line=1,endLine=4::"servers" must be present and non-empty array.%0ADocumentation: https://www.example.com/docs/api-servers.md
 ::warning title=info-contact,file=document,col=6,endColumn=19,line=2,endLine=4::Info object must have a "contact" object.
-::warning title=info-description,file=document,col=6,endColumn=19,line=2,endLine=4::Info "description" must be present and non-empty string.::https://www.example.com/docs/info-description.md
+::warning title=info-description,file=document,col=6,endColumn=19,line=2,endLine=4::Info "description" must be present and non-empty string.%0ADocumentation: https://www.example.com/docs/info-description.md


### PR DESCRIPTION
:: was rendered literally, which is not very useful. Instead print a descriptive string.

**Checklist**

- [x] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
