### PR TITLE
fix(formatters): markdown formatter with invalid-ref crashes spectral

### DIFF
--- a/packages/formatters/src/__tests__/markdown.test.ts
+++ b/packages/formatters/src/__tests__/markdown.test.ts
@@ -55,6 +55,23 @@ const results: IRuleResult[] = [
       },
     },
   },
+  {
+    code: 'invalid-ref',
+    message: 'i should not have any documentation url link',
+    path: ['paths'],
+    severity: DiagnosticSeverity.Error,
+    source: './src/__tests__/fixtures/petstore.oas2.yaml',
+    range: {
+      start: {
+        line: 21,
+        character: 0,
+      },
+      end: {
+        line: 30,
+        character: 1,
+      },
+    },
+  },
 ];
 
 const context = {
@@ -94,6 +111,7 @@ const expectedMd = String.raw`
 | [operation-description](https://rule-documentation-url.com)            | paths.\/pets.get.description | paths.\/pets.get.description is not truthy   | Error    | 1:0   | 10:1 | .\/src\/\_\_tests\_\_\/fixtures\/petstore.oas2.yaml |
 | [operation-tags](https://ruleset-documentation-url.com#operation-tags) | paths.\/pets.get.tags        | paths.\/pets.get.tags is not truthy          | Warning  | 11:0  | 20:1 | .\/src\/\_\_tests\_\_\/fixtures\/petstore.oas2.yaml |
 | rule-from-other-ruleset                                                | paths                        | i should not have any documentation url link | Warning  | 21:0  | 30:1 | .\/src\/\_\_tests\_\_\/fixtures\/petstore.oas2.yaml |
+| invalid-ref                                                            | paths                        | i should not have any documentation url link | Error    | 21:0  | 30:1 | .\/src\/\_\_tests\_\_\/fixtures\/petstore.oas2.yaml |
 `;
 
 describe('Markdown formatter', () => {

--- a/packages/formatters/src/utils/getDocumentationUrl.ts
+++ b/packages/formatters/src/utils/getDocumentationUrl.ts
@@ -8,12 +8,12 @@ export function getRuleDocumentationUrl(ruleCode: string | number, ctx?: Formatt
 
   const rule = ctx.ruleset.rules[ruleCode.toString()];
   //if rule.documentationUrl is not null and not empty and not undefined, return it
-  if (rule.documentationUrl != null && rule.documentationUrl) {
+  if (rule?.documentationUrl != null && rule.documentationUrl) {
     return rule.documentationUrl;
   }
 
   //otherwise use the ruleset documentationUrl and append the rulecode as an anchor
-  const rulesetDocumentationUrl = rule.owner?.definition.documentationUrl;
+  const rulesetDocumentationUrl = rule?.owner?.definition.documentationUrl;
   if (rulesetDocumentationUrl != null && rulesetDocumentationUrl) {
     return `${rulesetDocumentationUrl}#${ruleCode}`;
   }


### PR DESCRIPTION
If there is an "invalid-ref" error, spectral crashes when using the markdown formatter, with error:

```

Error #1: Cannot read properties of undefined (reading 'documentationUrl')
          at getRuleDocumentatio…  …umentationUrl.ts:11  if (rule.documentat…
          at markdown              …/src/markdown.ts:19  const ruleDocumenta…
          at formatOutput          …rvices/output.ts:42  return formatters[f…
          at                       …ommands/lint.ts:215  linterResult.result…
          at map
```

This happens because Spectral tries to load the documentationUrl from the rule related to the error, but "invalid-ref" is not an actual rule, so rule is null, causing "cannot read properties of undefined". Fix bug by using optional chaining.
**Checklist**

- [x] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No