### PR TITLE
fix(oas): allow bearer scopes on operations in OpenAPI 3.1

### DIFF
--- a/packages/rulesets/src/oas/__tests__/oas3-operation-security-defined.test.ts
+++ b/packages/rulesets/src/oas/__tests__/oas3-operation-security-defined.test.ts
@@ -210,4 +210,33 @@ testRule('oas3-operation-security-defined', [
       },
     ],
   },
+
+  {
+    name: 'oas3.1: bearer http scopes on operation without scheme-level scopes',
+    document: {
+      openapi: '3.1.0',
+      info: { title: 'test', version: '1.0.0' },
+      paths: {
+        '/users': {
+          get: {
+            security: [
+              {
+                bearerAuth: ['read:users', 'public'],
+              },
+            ],
+          },
+        },
+      },
+      components: {
+        securitySchemes: {
+          bearerAuth: {
+            type: 'http',
+            scheme: 'bearer',
+            bearerFormat: 'jwt',
+          },
+        },
+      },
+    },
+    errors: [],
+  },
 ]);

--- a/packages/rulesets/src/oas/functions/oasSecurityDefined.ts
+++ b/packages/rulesets/src/oas/functions/oasSecurityDefined.ts
@@ -33,6 +33,8 @@ export default createRulesetFunction<Record<string, string[]>, Options>(
 
     if (!isPlainObject(document.data)) return;
 
+    const openapiVersion = typeof document.data.openapi === 'string' ? document.data.openapi : '';
+
     const allDefs =
       oasVersion === 2
         ? document.data.securityDefinitions
@@ -58,7 +60,7 @@ export default createRulesetFunction<Record<string, string[]>, Options>(
       const scope = input[schemeName];
       for (let i = 0; i < scope.length; i++) {
         const scopeName = scope[i];
-        if (!isScopeDefined(oasVersion, scopeName, allDefs[schemeName])) {
+        if (!isScopeDefined(oasVersion, scopeName, allDefs[schemeName], openapiVersion)) {
           results ??= [];
           results.push({
             message: `"${scopeName}" must be listed among scopes.`,
@@ -72,8 +74,18 @@ export default createRulesetFunction<Record<string, string[]>, Options>(
   },
 );
 
-function isScopeDefined(oasVersion: 2 | 3, scopeName: string, securityScheme: unknown): boolean {
+function isScopeDefined(oasVersion: 2 | 3, scopeName: string, securityScheme: unknown, openapiVersion = ''): boolean {
   if (!isPlainObject(securityScheme)) return false;
+
+  // OpenAPI 3.1 allows scope lists on http bearer requirements without scheme-level scope definitions
+  if (
+    oasVersion === 3 &&
+    openapiVersion.startsWith('3.1') &&
+    securityScheme.type === 'http' &&
+    securityScheme.scheme === 'bearer'
+  ) {
+    return true;
+  }
 
   if (oasVersion === 2) {
     return isPlainObject(securityScheme.scopes) && scopeName in securityScheme.scopes;


### PR DESCRIPTION
## Summary

Fixes false positives from `oas3-operation-security-defined` when OpenAPI **3.1** documents use `type: http` + `scheme: bearer` with operation-level scopes that are not declared on the security scheme (per OAS 3.1 security requirement semantics).

## Changes

- Skip scope validation for bearer HTTP schemes when `openapi` version is 3.1+
- Regression test from #2643 reproducer

## Test plan

- [x] `yarn jest packages/rulesets/src/oas/__tests__/oas3-operation-security-defined.test.ts`

Closes #2643

Made with [Cursor](https://cursor.com)