### PR TITLE
Fix off-by-one error in code-climate formatter

### DIFF
--- a/packages/formatters/src/__tests__/code-climate.jest.test.ts
+++ b/packages/formatters/src/__tests__/code-climate.jest.test.ts
@@ -63,7 +63,7 @@ describe('Code climate formatter', () => {
           path: '__tests__/fixtures/petstore.oas2.yaml',
           positions: {
             begin: {
-              line: 10,
+              line: 61,
               column: 8,
             },
             end: {

--- a/packages/formatters/src/__tests__/code-climate.jest.test.ts
+++ b/packages/formatters/src/__tests__/code-climate.jest.test.ts
@@ -48,11 +48,11 @@ describe('Code climate formatter', () => {
           path: '__tests__/fixtures/petstore.oas2.yaml',
           positions: {
             begin: {
-              line: 60,
+              line: 61,
               column: 8,
             },
             end: {
-              line: 71,
+              line: 72,
               column: 60,
             },
           },
@@ -63,11 +63,11 @@ describe('Code climate formatter', () => {
           path: '__tests__/fixtures/petstore.oas2.yaml',
           positions: {
             begin: {
-              line: 60,
+              line: 10,
               column: 8,
             },
             end: {
-              line: 71,
+              line: 72,
               column: 60,
             },
           },

--- a/packages/formatters/src/code-climate.ts
+++ b/packages/formatters/src/code-climate.ts
@@ -57,8 +57,8 @@ export const codeClimate: Formatter = results => {
       location: {
         path: relPath,
         positions: {
-          begin: { line: result.range.start.line, column: result.range.start.character },
-          end: { line: result.range.end.line, column: result.range.end.character },
+          begin: { line: result.range.start.line + 1, column: result.range.start.character },
+          end: { line: result.range.end.line + 1, column: result.range.end.character },
         },
       },
       severity: severityMap[result.severity],


### PR DESCRIPTION
**Checklist**

- [x] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [x] Yes
- [ ] No

> If indicated yes above, please describe the breaking change(s).
>
> The output of the code-climate formatter is changed. If someone has compensated for the off-by-one error using external tooling, that compensation will need to be removed.

**Additional context**

Since the line values are zero-indexed, the values in the report need to be offset by one to match the report format.
