### PR TITLE
build: Bump Up Spectral-core in Spectral-rulesets, functions & f…

### DIFF
--- a/packages/formats/package.json
+++ b/packages/formats/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/spectral-formats",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "sideEffects": false,
   "homepage": "https://github.com/stoplightio/spectral",
   "bugs": "https://github.com/stoplightio/spectral/issues",
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@stoplight/json": "^3.17.0",
-    "@stoplight/spectral-core": "^1.19.2",
+    "@stoplight/spectral-core": "1.23.0",
     "@types/json-schema": "^7.0.7",
     "tslib": "^2.8.1"
   }

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/spectral-functions",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "sideEffects": false,
   "homepage": "https://github.com/stoplightio/spectral",
   "bugs": "https://github.com/stoplightio/spectral/issues",
@@ -21,7 +21,7 @@
   "dependencies": {
     "@stoplight/better-ajv-errors": "1.0.3",
     "@stoplight/json": "^3.17.1",
-    "@stoplight/spectral-core": "^1.19.4",
+    "@stoplight/spectral-core": "1.23.0",
     "@stoplight/spectral-formats": "^1.8.1",
     "@stoplight/spectral-runtime": "^1.1.2",
     "ajv": "^8.18.0",

--- a/packages/rulesets/package.json
+++ b/packages/rulesets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/spectral-rulesets",
-  "version": "1.22.3",
+  "version": "1.22.4",
   "homepage": "https://github.com/stoplightio/spectral",
   "bugs": "https://github.com/stoplightio/spectral/issues",
   "author": "Stoplight <support@stoplight.io>",
@@ -21,7 +21,7 @@
     "@asyncapi/specs": "^6.8.0",
     "@stoplight/better-ajv-errors": "1.0.3",
     "@stoplight/json": "^3.17.0",
-    "@stoplight/spectral-core": "^1.19.4",
+    "@stoplight/spectral-core": "1.23.0",
     "@stoplight/spectral-formats": "^1.8.1",
     "@stoplight/spectral-functions": "^1.9.1",
     "@stoplight/spectral-runtime": "^1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3257,7 +3257,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@stoplight/spectral-core@*, @stoplight/spectral-core@>=1, @stoplight/spectral-core@^1.19.2, @stoplight/spectral-core@^1.19.4, @stoplight/spectral-core@^1.19.5, @stoplight/spectral-core@workspace:packages/core":
+"@stoplight/spectral-core@*, @stoplight/spectral-core@1.23.0, @stoplight/spectral-core@>=1, @stoplight/spectral-core@^1.19.4, @stoplight/spectral-core@^1.19.5, @stoplight/spectral-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@stoplight/spectral-core@workspace:packages/core"
   dependencies:
@@ -3297,7 +3297,7 @@ __metadata:
   resolution: "@stoplight/spectral-formats@workspace:packages/formats"
   dependencies:
     "@stoplight/json": ^3.17.0
-    "@stoplight/spectral-core": ^1.19.2
+    "@stoplight/spectral-core": 1.23.0
     "@types/json-schema": ^7.0.7
     tslib: ^2.8.1
   languageName: unknown
@@ -3334,7 +3334,7 @@ __metadata:
   dependencies:
     "@stoplight/better-ajv-errors": 1.0.3
     "@stoplight/json": ^3.17.1
-    "@stoplight/spectral-core": ^1.19.4
+    "@stoplight/spectral-core": 1.23.0
     "@stoplight/spectral-formats": ^1.8.1
     "@stoplight/spectral-parsers": "*"
     "@stoplight/spectral-runtime": ^1.1.2
@@ -3432,7 +3432,7 @@ __metadata:
     "@stoplight/better-ajv-errors": 1.0.3
     "@stoplight/json": ^3.17.0
     "@stoplight/path": ^1.3.2
-    "@stoplight/spectral-core": ^1.19.4
+    "@stoplight/spectral-core": 1.23.0
     "@stoplight/spectral-formats": ^1.8.1
     "@stoplight/spectral-functions": ^1.9.1
     "@stoplight/spectral-parsers": "*"


### PR DESCRIPTION
[STOP-5292](https://smartbear.atlassian.net/browse/STOP-5292)
## Description:
For this release Bump Up **Spectral-core** in **Spectral-functions, rulesets & formats** Packages
### Releasing Packages with Versions:
**@stoplight/spectral-rulesets: 1.22.4
@stoplight/spectral-functions: 1.10.3
@stoplight/spectral-formats: 1.8.3**
## How Has This Been Tested?
Testing was completed by creating a **Beta version** and validating it on the **Platform-internal**
### Tested Beta versions:

**@stoplight/spectral-rulesets: 1.22.3-beta-0.2
@stoplight/spectral-functions: 1.10.2-beta-0.2
@stoplight/spectral-formats: 1.8.2-beta-0.2**
## Screen Recording / ScreenShots:

https://github.com/user-attachments/assets/122a88f1-7600-4b08-be2c-575d9bcc8779



[STOP-5292]: https://smartbear.atlassian.net/browse/STOP-5292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ