### PR TITLE
test: cover optional operation security alternatives

### DIFF
--- a/packages/rulesets/src/oas/__tests__/oas3-operation-security-defined.test.ts
+++ b/packages/rulesets/src/oas/__tests__/oas3-operation-security-defined.test.ts
@@ -36,6 +36,50 @@ testRule('oas3-operation-security-defined', [
   },
 
   {
+    name: 'valid OpenAPI 3.1 operation with optional security alternatives',
+    document: {
+      openapi: '3.1.0',
+      components: {
+        securitySchemes: {
+          apiKey: {
+            type: 'apiKey',
+            name: 'x-api-key',
+            in: 'header',
+          },
+          oauthBearer: {
+            type: 'http',
+            scheme: 'bearer',
+          },
+        },
+      },
+      security: [
+        {
+          apiKey: [],
+        },
+        {
+          oauthBearer: [],
+        },
+      ],
+      paths: {
+        '/tweets/search': {
+          get: {
+            security: [
+              {
+                apiKey: [],
+              },
+              {
+                oauthBearer: [],
+              },
+              {},
+            ],
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+
+  {
     name: 'valid and invalid object',
     document: {
       openapi: '3.0.2',


### PR DESCRIPTION
## Summary

Adds a focused OpenAPI 3.1 regression case for operation-level security alternatives that include:

- API key auth
- bearer auth
- an empty security requirement object for anonymous access

This is valid OpenAPI behavior and is already accepted by the rule. The new case keeps that behavior covered directly.

## Validation

- `git diff --check`
- Targeted Jest was not run locally because the repo dependency install hit local disk exhaustion while populating the Yarn cache.
