### PR TITLE
chore(deps): upgrade TypeScript 4.4.4 → 4.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "semantic-release": "^25.0.3",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.8.2",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "lint-staged": {
     "*.{ts,js}": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -13131,7 +13131,7 @@ __metadata:
     semantic-release: ^25.0.3
     ts-jest: ^29.2.5
     ts-node: ^10.8.2
-    typescript: 4.4.4
+    typescript: 4.7.4
   languageName: unknown
   linkType: soft
 
@@ -14624,7 +14624,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.4.4, typescript@npm:^4.4.3":
+"typescript@npm:4.7.4":
+  version: 4.7.4
+  resolution: "typescript@npm:4.7.4"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 5750181b1cd7e6482c4195825547e70f944114fb47e58e4aa7553e62f11b3f3173766aef9c281783edfd881f7b8299cf35e3ca8caebe73d8464528c907a164df
+  languageName: node
+  linkType: hard
+
+"typescript@npm:^4.4.3":
   version: 4.4.4
   resolution: "typescript@npm:4.4.4"
   bin:
@@ -14634,7 +14644,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@4.4.4#~builtin<compat/typescript>, typescript@patch:typescript@^4.4.3#~builtin<compat/typescript>":
+"typescript@patch:typescript@4.7.4#~builtin<compat/typescript>":
+  version: 4.7.4
+  resolution: "typescript@patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=65a307"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 9096d8f6c16cb80ef3bf96fcbbd055bf1c4a43bd14f3b7be45a9fbe7ada46ec977f604d5feed3263b4f2aa7d4c7477ce5f9cd87de0d6feedec69a983f3a4f93e
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@^4.4.3#~builtin<compat/typescript>":
   version: 4.4.4
   resolution: "typescript@patch:typescript@npm%3A4.4.4#~builtin<compat/typescript>::version=4.4.4&hash=bbeadb"
   bin:


### PR DESCRIPTION
## Summary

- Bumps `typescript` from `4.4.4` to `4.7.4` (latest 4.7.x patch, exact pin)
- No source code changes required — TypeScript 4.7 introduces no breaking changes that affect this codebase
- Keeps TypeScript on the 4.x line intentionally (not upgrading to 5.x)

## Motivation

TypeScript 4.4.4 is over 3 years old. 4.7.4 is also the minimum version required by `@typescript-eslint` v8, keeping the door open for a future ESLint 10 upgrade without a toolchain conflict.

## Test plan

- [x] `yarn build` — passes with no errors
- [x] `yarn test.jest` — 199/200 suites pass (1 pre-existing unrelated failure in `ruleset-migrator` fixture, present on `develop` before this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)