### PR TITLE
chore: pin @asyncapi/specs to 6.11.1

### DIFF
--- a/packages/rulesets/package.json
+++ b/packages/rulesets/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/stoplightio/spectral.git"
   },
   "dependencies": {
-    "@asyncapi/specs": "^6.8.0",
+    "@asyncapi/specs": "6.11.1",
     "@scarf/scarf": "^1.4.0",
     "@stoplight/better-ajv-errors": "1.0.3",
     "@stoplight/json": "^3.17.0",

--- a/test-harness/scenarios/asyncapi2-streetlights.scenario
+++ b/test-harness/scenarios/asyncapi2-streetlights.scenario
@@ -218,7 +218,7 @@ module.exports = asyncapi;
 ====stdout====
 {document}
   1:1       warning  asyncapi-tags                   AsyncAPI object must have non-empty "tags" array.
-  1:11  information  asyncapi-latest-version         The latest version is not used. You should update to the "3.0.0" version.  asyncapi
+  1:11  information  asyncapi-latest-version         The latest version is not used. You should update to the "3.1.0" version.  asyncapi
   2:6       warning  asyncapi-info-contact           Info object must have "contact" object.                                    info
  45:13      warning  asyncapi-operation-description  Operation "description" must be present and non-empty string.              channels.smartylighting/streetlights/1/0/event/{streetlightId}/lighting/measured.publish
  57:15      warning  asyncapi-operation-description  Operation "description" must be present and non-empty string.              channels.smartylighting/streetlights/1/0/action/{streetlightId}/turn/on.subscribe

--- a/yarn.lock
+++ b/yarn.lock
@@ -73,12 +73,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@asyncapi/specs@npm:^6.8.0":
-  version: 6.8.0
-  resolution: "@asyncapi/specs@npm:6.8.0"
+"@asyncapi/specs@npm:6.11.1":
+  version: 6.11.1
+  resolution: "@asyncapi/specs@npm:6.11.1"
   dependencies:
     "@types/json-schema": ^7.0.11
-  checksum: 8a968a9fb842fa0facf4b727cca4e17792cca26b08f8df4f3c5e32a015a9e30c8a2651f76faaabf0933ec2796b9e6318fc7a8abb64a7a95930637ab3af2bebb4
+  checksum: 3492128c6cdb2437890c7b21d72e251052972d35dfa5fcc258a957bbe1346663c71c4e00cc5c5c3354b51d752ba2a20bc344ec8d2ea5de1ba1dca79243e8e97f
   languageName: node
   linkType: hard
 
@@ -3439,7 +3439,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@stoplight/spectral-rulesets@workspace:packages/rulesets"
   dependencies:
-    "@asyncapi/specs": ^6.8.0
+    "@asyncapi/specs": 6.11.1
     "@scarf/scarf": ^1.4.0
     "@stoplight/better-ajv-errors": 1.0.3
     "@stoplight/json": ^3.17.0


### PR DESCRIPTION
Fixes [#2999](https://github.com/stoplightio/spectral/issues/2999)

**Summary**

-  `@asyncapi/specs` 6.11.2 and 6.11.2-alpha.1 were compromised on July 14, 2026 — malicious code injected via the upstream alpha branch executes on package import and downloads a credential-stealing RAT (browser passwords, SSH keys, npm/GitHub/AWS tokens). See asyncapi/spec-json-schemas#656.
- The caret range ^6.8.0 allowed any consumer of `@stoplight/spectral-rulesets` to resolve the malicious 6.11.2 (currently tagged latest on npm) on a fresh install.
- 6.11.1 (published Jan 30, 2026) is the last known-safe version; the exact pin (no ^/~) removes any upgrade path into the compromised release.
- Picks up ~10 releases of legitimate AsyncAPI schema updates over the previously locked 6.8.0.
- Regenerates the yarn.lock entry (resolution + integrity checksum) for the new version.
- Updates the asyncapi2-streetlights test-harness scenario: the asyncapi-latest-version diagnostic now reports 3.1.0, since @asyncapi/specs 6.11.1 ships the AsyncAPI 3.1.0 schema (6.8.0's newest was 3.0.0). Intentional, data-driven behavior - the rule interpolates the latest version known to the package.

---
**Security notes**

- This repo's own yarn.lock was never resolving the malicious version (it held 6.8.0) — the exposure is for downstream npm consumers of the published package, so a patch release of @stoplight/spectral-rulesets should follow this merge.
- yarn why @asyncapi/specs confirms a single resolution at 6.11.1 — no other version anywhere in the dependency tree.
- Follow-up: once upstream publishes a clean 6.11.3+ and npm removes the malicious versions, this pin can move forward (recommend keeping exact or ~, not ^).

---
**Test plan**

- [x] yarn install — lockfile regenerated, single clean resolution at 6.11.1
- [x] compile-schemas (packages/rulesets pretest) — passes against 6.11.1
- [x] yarn test.jest -- asyncapi — 58/58 suites, 377/377 tests pass
- [x] Verified CLI output for the streetlights sample matches the updated scenario line-for-line

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
