### PR TITLE
chore(repo): extend Node.js versions for testing matrix

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -16,7 +16,10 @@ jobs:
       matrix:
         node-version:
         - '18.20.8'
-        - '20.20.0' # maintenance LTS
+        - '20.20.2'
+        - '22.23.2'
+        - '24.18.1'
+        - '26.5.1'
     steps:
     - name: Checkout code
       uses: actions/checkout@v5.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ COPY scripts/install.sh /usr/src/spectral/
 COPY scripts/scarf-telemetry.js /usr/local/lib/scarf-telemetry.js
 COPY packages/cli/package.json /usr/src/spectral/
 COPY packages/cli/package.json /usr/local/lib/package.json
-RUN apk --no-cache add curl jq
-RUN ./install.sh $(cat package.json | jq -r '.version') \
+RUN apk --no-cache add curl jq \
+  && ./install.sh $(cat package.json | jq -r '.version') \
   && rm ./install.sh && rm ./package.json
 ENV NODE_ENV production
 

--- a/README.md
+++ b/README.md
@@ -152,5 +152,3 @@ Spectral is 100% free and open-source, under [Apache License 2.0](LICENSE).
 If you would like to thank Stoplight for creating Spectral, [**buy the world a tree**][stoplight_forest].
 
 [stoplight_forest]: https://ecologi.com/stoplightinc
-
-trigger me

--- a/README.md
+++ b/README.md
@@ -152,3 +152,5 @@ Spectral is 100% free and open-source, under [Apache License 2.0](LICENSE).
 If you would like to thank Stoplight for creating Spectral, [**buy the world a tree**][stoplight_forest].
 
 [stoplight_forest]: https://ecologi.com/stoplightinc
+
+trigger me


### PR DESCRIPTION
This pull request updates the Node.js versions tested in the CI workflow and improves the Docker build process by combining commands for efficiency.

**CI/CD Pipeline Updates:**

* Updated the Node.js versions matrix in `.github/workflows/commit.yml` to include versions `20.20.2`, `22.23.2`, `24.18.1`, and `26.5.1`, and updated the existing `20.x` version. This ensures broader compatibility and testing against the latest Node.js releases.

**Dockerfile Improvements:**

* Combined the installation of `curl` and `jq` with the execution and cleanup of `install.sh` into a single `RUN` command in `Dockerfile`, reducing the number of layers and improving build efficiency.


**Does this PR introduce a breaking change?**

No breaking change. Just testing on higher node versions

**Screenshots**
None

**Additional context**

Slowly preparing to drop node 18 and 20 support
