### PR TITLE
chore(repo): pin actions and update workflow references

### DIFF
--- a/.github/workflows/jira-issue-label-added.yaml
+++ b/.github/workflows/jira-issue-label-added.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-workflow:
-    uses: stoplightio/.github/.github/workflows/jira-issue-label-added.yaml@master
+    uses: stoplightio/.github/.github/workflows/jira-issue-label-added.yaml@6aa5c56e3ddc56017e2e4e7ad34f9cd5f7ac09fb # master branch commit, fetched 2026-07-31
     with:
       team-name: ${{ contains(github.event.pull_request.labels.*.name, 'team/bad-news-bears') && 'Bad News Bears' || contains(github.event.pull_request.labels.*.name, 'team/maintenance') && 'Maintenance' || '' }}
     secrets: inherit

--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -10,7 +10,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@main
-    - uses: gaurav-nelson/github-action-markdown-link-check@master
+    - uses: actions/checkout@v5.0.1
+    - uses: gaurav-nelson/github-action-markdown-link-check@3c3b66f1f7d0900e37b71eca45b63ea9eedfce31 # v1.0.17
       with:
         folder-path: 'docs'


### PR DESCRIPTION
This pull request updates workflow configuration files to use specific commit SHAs or version tags for GitHub Actions, improving build reliability and security by preventing unexpected changes from upstream repositories.

**Workflow dependency pinning:**

* [`.github/workflows/jira-issue-label-added.yaml`](diffhunk://#diff-4a725bfa71cbb03d0ffaaaa91a25f39badc93c6fed2a861f86aefaff79d68af6L10-R10): Updated the `uses` reference to a specific commit SHA (`6aa5c56e3ddc56017e2e4e7ad34f9cd5f7ac09fb`) instead of the `master` branch for the `jira-issue-label-added.yaml` workflow.
* [`.github/workflows/markdown-links.yml`](diffhunk://#diff-02bf52018a03ac6334ad443e5b419dfe9e0bb4a4431c4226b64f45d7d29472d2L13-R14): Updated the `actions/checkout` action to use a specific version tag (`v5.0.1`) and pinned the `gaurav-nelson/github-action-markdown-link-check` action to a specific commit SHA (`3c3b66f1f7d0900e37b71eca45b63ea9eedfce31`).
