### PR TITLE
fix(rulesets): clarify operationId URL validation message

### DIFF
--- a/packages/rulesets/src/oas/__tests__/operation-operationId-valid-in-url.test.ts
+++ b/packages/rulesets/src/oas/__tests__/operation-operationId-valid-in-url.test.ts
@@ -31,7 +31,7 @@ testRule('operation-operationId-valid-in-url', [
     },
     errors: [
       {
-        message: 'operationId must not characters that are invalid when used in URL.',
+        message: 'operationId must not contain characters that are invalid when used in URL.',
         path: ['paths', '/todos', 'get', 'operationId'],
         severity: DiagnosticSeverity.Warning,
       },

--- a/packages/rulesets/src/oas/index.ts
+++ b/packages/rulesets/src/oas/index.ts
@@ -286,7 +286,7 @@ const ruleset = {
       },
     },
     'operation-operationId-valid-in-url': {
-      message: 'operationId must not characters that are invalid when used in URL.',
+      message: 'operationId must not contain characters that are invalid when used in URL.',
       recommended: true,
       given: '#OperationObject',
       then: {


### PR DESCRIPTION
Closes #2605.

Fixes the grammar of the built-in `operation-operationId-valid-in-url` message so the error clearly says the operationId cannot contain invalid URL characters. Updated the matching rule test and verified it with the focused Jest suite.