### PR TITLE
docs: document default severity for builtin rules

### DIFF
--- a/docs/reference/asyncapi-rules.md
+++ b/docs/reference/asyncapi-rules.md
@@ -4,6 +4,8 @@ Spectral has a built-in "asyncapi" ruleset for the [AsyncAPI Specification](http
 
 In your ruleset file you can add `extends: "spectral:asyncapi"` and you'll get all of the following rules applied.
 
+`Recommended` indicates whether a rule is enabled by default. `Default severity when enabled` is the severity the rule reports when active.
+
 For simplicity, the rules are split up into v2 and v3 compliant rules to make it easier to know which apply when.
 
 ## AsyncAPI v2 and v3
@@ -16,6 +18,8 @@ All channel parameters should be defined in the `parameters` object of the chann
 
 **Recommended:** Yes
 
+**Default severity when enabled:** error
+
 ### asyncapi-info-contact-properties
 
 The [asyncapi-info-contact](#asyncapi-info-contact) rule will ask you to put in a contact object, and this rule will make sure it's full of the most useful properties: `name`, `url`, and `email`.
@@ -23,6 +27,8 @@ The [asyncapi-info-contact](#asyncapi-info-contact) rule will ask you to put in 
 Putting in the name of the developer/team/department/company responsible for the API, along with the support email and help-desk/GitHub Issues/whatever URL means people know where to go for help. This can mean more money in the bank, instead of developers just wandering off or complaining online.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** warn
 
 **Good Example**
 
@@ -46,6 +52,8 @@ Hopefully, your API description document is so good that nobody ever needs to co
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 **Good Example**
 
 ```yaml
@@ -66,6 +74,8 @@ Examples can contain Markdown so you can really go to town with them, implementi
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 **Good Example**
 
 ```yaml
@@ -82,6 +92,8 @@ info:
 Mentioning a license is only useful if people know what the license means, so add a link to the full text for those who need it.
 
 **Recommended:** No
+
+**Default severity when enabled:** warn
 
 **Good Example**
 
@@ -103,6 +115,8 @@ How useful this is in court is not entirely known, but having a license is bette
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 **Good Example**
 
 ```yaml
@@ -118,17 +132,23 @@ Checking if the AsyncAPI document is using the latest version.
 
 **Recommended:** Yes
 
+**Default severity when enabled:** info
+
 ### asyncapi-parameter-description
 
 Parameter objects should have a `description`.
 
 **Recommended:** No
 
+**Default severity when enabled:** warn
+
 ### asyncapi-servers
 
 A non-empty `servers` object is expected to be located at the root of the document.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** warn
 
 ### asyncapi-unused-components-schema
 
@@ -142,6 +162,8 @@ specifications that reference those objects).
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 ### asyncapi-unused-components-server
 
 Potential unused reusable `server` entry has been detected.
@@ -154,6 +176,8 @@ specifications that reference those objects).
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 ## AsyncAPI v2
 
 The following rules ONLY apply to AsyncAPI v2 documents.
@@ -164,11 +188,15 @@ Validate structure of AsyncAPI specification.
 
 **Recommended:** Yes
 
+**Default severity when enabled:** error
+
 ### asyncapi-server-security
 
 Server `security` values must match a scheme defined in the `components.securitySchemes` object. It also checks if there are `oauth2` scopes that have been defined for the given security.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** error
 
 **Good Example**
 
@@ -204,17 +232,23 @@ Channel parameter declarations cannot be empty, ex.`/given/{}` is invalid.
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 ### asyncapi-channel-no-query-nor-fragment
 
 Query parameters and fragments shouldn't be used in channel names. Instead, use bindings to define them.
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 ### asyncapi-channel-no-trailing-slash
 
 Keep trailing slashes off of channel names, as it can cause some confusion. Most messaging protocols will treat `example/foo` and `example/foo/` as different things. Keep in mind that tooling may replace slashes (`/`) with protocol-specific notation (e.g.: `.` for AMQP), therefore, a trailing slash may result in an invalid channel name in some protocols.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** warn
 
 ### asyncapi-channel-servers
 
@@ -258,11 +292,15 @@ channels:
 
 **Recommended:** Yes
 
+**Default severity when enabled:** error
+
 ### asyncapi-headers-schema-type-object
 
 The schema definition of the application headers must be of type “object”.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** error
 
 ### asyncapi-message-examples
 
@@ -309,11 +347,15 @@ components:
 
 **Recommended:** Yes
 
+**Default severity when enabled:** error
+
 ### asyncapi-message-messageId-uniqueness
 
 `messageId` must be unique across all the messages (except those one defined in the components).
 
 **Recommended:** Yes
+
+**Default severity when enabled:** error
 
 **Bad Example**
 
@@ -349,11 +391,15 @@ Operation objects should have a description.
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 ### asyncapi-operation-operationId-uniqueness
 
 `operationId` must be unique across all the operations (except the ones defined in the components).
 
 **Recommended:** Yes
+
+**Default severity when enabled:** error
 
 **Bad Example**
 
@@ -385,11 +431,15 @@ This operation ID is essentially a reference for the operation. Tools may use it
 
 **Recommended:** Yes
 
+**Default severity when enabled:** error
+
 ### asyncapi-operation-security
 
 Operation `security` values must match a scheme defined in the `components.securitySchemes` object. It also checks if there are `oauth2` scopes that have been defined for the given security.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** error
 
 **Good Example**
 
@@ -422,6 +472,8 @@ components:
 `default` objects should be valid against the `payload` they decorate.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** error
 
 **Good Example**
 
@@ -456,6 +508,8 @@ payload:
 Values of the `examples` array should be valid against the `payload` they decorate.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** error
 
 **Good Example**
 
@@ -501,11 +555,15 @@ Other formats such as OpenAPI Schema Object, JSON Schema Draft 07, and Avro will
 
 **Recommended:** Yes
 
+**Default severity when enabled:** info
+
 ### asyncapi-payload
 
 When `schemaFormat` is undefined, the `payload` object should be valid against the AsyncAPI v2 Schema Object definition.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** error
 
 ### asyncapi-schema-default
 
@@ -513,17 +571,23 @@ When `schemaFormat` is undefined, the `payload` object should be valid against t
 
 **Recommended:** Yes
 
+**Default severity when enabled:** error
+
 ### asyncapi-schema-examples
 
 Values of the `examples` array should be valid against the `schema` they decorate.
 
 **Recommended:** Yes
 
+**Default severity when enabled:** error
+
 ### asyncapi-server-no-empty-variable
 
 Server URL variable declarations cannot be empty, ex.`gigantic-server.com/{}` is invalid.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** warn
 
 ### asyncapi-server-no-trailing-slash
 
@@ -532,6 +596,8 @@ Server URL should not have a trailing slash.
 Some tooling forgets to strip trailing slashes off when it's joining the `servers.url` with `channels`, and you can get awkward URLs like `mqtt://example.com/broker//pets`. Best to just strip them off yourself.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** warn
 
 **Good Example**
 
@@ -555,11 +621,15 @@ Server URL should not point to example.com.
 
 **Recommended:** No
 
+**Default severity when enabled:** warn
+
 ### asyncapi-server-variables
 
 All server URL variables should be defined in the `variables` object of the server. They should also not contain redundant variables that do not exist in the server address.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** error
 
 ### asyncapi-tag-description
 
@@ -584,11 +654,15 @@ tags:
 
 **Recommended:** No
 
+**Default severity when enabled:** warn
+
 ### asyncapi-tags-alphabetical
 
 AsyncAPI object should have alphabetical `tags`. This will be sorted by the `name` property.
 
 **Recommended:** No
+
+**Default severity when enabled:** warn
 
 **Bad Example**
 
@@ -613,6 +687,8 @@ tags:
 Tags must not have duplicate names (identifiers).
 
 **Recommended:** Yes
+
+**Default severity when enabled:** error
 
 **Bad Example**
 
@@ -646,6 +722,8 @@ Defining tags allows you to add more information like a `description`. For more 
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 ## AsyncAPI v3
 
 The following rules ONLY apply to AsyncAPI v3 documents.
@@ -656,17 +734,23 @@ Channel address parameter declarations cannot be empty, ex.`/given/{}` is invali
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 ### asyncapi-3-channel-no-query-nor-fragment
 
 Query parameters and fragments shouldn't be used in channel address. Instead, use bindings to define them, ex.`/given?test` is invalid.
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 ### asyncapi-3-channel-no-trailing-slash
 
 Keep trailing slashes off of channel address, as it can cause some confusion. Most messaging protocols will treat `example/foo` and `example/foo/` as different things. Keep in mind that tooling may replace slashes (`/`) with protocol-specific notation (e.g.: `.` for AMQP), therefore, a trailing slash may result in an invalid channel address in some protocols.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** warn
 
 ### asyncapi-3-channel-servers
 
@@ -710,17 +794,31 @@ channels:
 
 **Recommended:** Yes
 
+**Default severity when enabled:** error
+
 ### asyncapi-3-headers-schema-type-object
 
 The schema definition of the application headers must be of type “object”.
 
 **Recommended:** Yes
 
+**Default severity when enabled:** error
+
+### asyncapi-3-operation-security
+
+Operations must reference a defined security scheme.
+
+**Recommended:** Yes
+
+**Default severity when enabled:** error
+
 ### asyncapi-3-operation-description
 
 Operation objects should have a description.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** warn
 
 ### asyncapi-3-payload-unsupported-schemaFormat
 
@@ -736,11 +834,15 @@ Other formats such as OpenAPI Schema Object, JSON Schema Draft 07, and Avro will
 
 **Recommended:** Yes
 
+**Default severity when enabled:** info
+
 ### asyncapi-3-server-no-empty-variable
 
 Server host and pathname variable declarations cannot be empty, ex.`gigantic-server.com{}` is invalid.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** warn
 
 ### asyncapi-3-server-no-trailing-slash
 
@@ -749,6 +851,8 @@ Server host should not have a trailing slash.
 Some tooling forgets to strip trailing slashes off when it's joining the `servers.host` with `channels`, and you can get awkward URLs like `mqtt://example.com//pets`. Best to just strip them off yourself.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** warn
 
 **Good Example**
 
@@ -770,6 +874,8 @@ servers:
 Server host should not point to example.com.
 
 **Recommended:** No
+
+**Default severity when enabled:** warn
 
 ### asyncapi-3-tag-description
 
@@ -796,11 +902,15 @@ info:
 
 **Recommended:** No
 
+**Default severity when enabled:** warn
+
 ### asyncapi-3-tags-alphabetical
 
 AsyncAPI object should have alphabetical `tags`. This will be sorted by the `name` property.
 
 **Recommended:** No
+
+**Default severity when enabled:** warn
 
 **Bad Example**
 
@@ -827,6 +937,8 @@ info:
 Tags must not have duplicate names (identifiers).
 
 **Recommended:** Yes
+
+**Default severity when enabled:** error
 
 **Bad Example**
 
@@ -863,14 +975,20 @@ Defining tags allows you to add more information like a `description`. For more 
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 ### asyncapi-3-document-resolved
 
 Validate structure of AsyncAPI specification when references have been resolved.
 
 **Recommended:** Yes
 
+**Default severity when enabled:** error
+
 ### asyncapi-3-document-unresolved
 
 Validate structure of AsyncAPI specification before references have been resolved.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** error

--- a/docs/reference/openapi-rules.md
+++ b/docs/reference/openapi-rules.md
@@ -4,6 +4,8 @@ Spectral has a built-in "oas" ruleset, with OAS being shorthand for the [OpenAPI
 
 In your ruleset file you can add `extends: "spectral:oas"` and you'll get all of the following rules applied, depending on the appropriate OpenAPI version used (detected through [formats](../getting-started/3-rulesets.md#formats)).
 
+`Recommended` indicates whether a rule is enabled by default. `Default severity when enabled` is the severity the rule reports when active.
+
 ## OpenAPI v2 & v3
 
 These rules apply to both OpenAPI v2.0, v3.0, and most likely v3.1, although there are some differences.
@@ -15,6 +17,8 @@ The [info-contact](#info-contact) rule will ask you to put in a contact object, 
 Putting in the name of the developer/team/department/company responsible for the API, along with the support email and help-desk/GitHub Issues/whatever URL means people know where to go for help. This can mean more money in the bank, instead of developers just wandering off or complaining online.
 
 **Recommended:** No
+
+**Default severity when enabled:** warn
 
 **Good Example**
 
@@ -35,6 +39,8 @@ info:
 Each value of an `enum` must be different from one another.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** warn
 
 **Good Example**
 
@@ -76,6 +82,8 @@ Hopefully, your API description document is so good that nobody ever needs to co
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 **Good Example**
 
 ```yaml
@@ -95,6 +103,8 @@ OpenAPI object info `description` must be present and non-empty string.
 Examples can contain Markdown so you can really go to town with them, implementing getting started information like where to find authentication keys, and how to use them.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** warn
 
 **Good Example**
 
@@ -117,6 +127,8 @@ How useful this is in court is not entirely known, but having a license is bette
 
 **Recommended:** No
 
+**Default severity when enabled:** warn
+
 **Good Example**
 
 ```yaml
@@ -131,6 +143,8 @@ info:
 Mentioning a license is only useful if people know what the license means, so add a link to the full text for those who need it.
 
 **Recommended:** No
+
+**Default severity when enabled:** warn
 
 **Good Example**
 
@@ -148,6 +162,8 @@ Before OpenAPI v3.1, keywords next to `$ref` were ignored by most tooling, but n
 
 **Recommended:** Yes
 
+**Default severity when enabled:** error
+
 **Bad Example**
 
 ```yaml
@@ -163,6 +179,8 @@ This rule protects against an edge case, for anyone bringing in description docu
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 **Bad Example**
 
 ```yaml
@@ -176,6 +194,8 @@ info:
 This rule protects against a potential hack, for anyone bringing in description documents from third parties and then generating HTML documentation. If one of those third parties does something shady like injecting `<script>` tags, they could easily execute arbitrary code on your domain, which if it's the same as your main application could be all sorts of terrible.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** warn
 
 **Bad Example**
 
@@ -200,11 +220,17 @@ Why? Well, you _can_ reference tags arbitrarily in operations, and definition is
 
 Defining tags allows you to add more information like a `description`. For more information see [tag-description](#tag-description).
 
+**Recommended:** No
+
+**Default severity when enabled:** warn
+
 ### openapi-tags-alphabetical
 
 OpenAPI object should have alphabetical `tags`. This will be sorted by the `name` property.
 
 **Recommended:** No
+
+**Default severity when enabled:** warn
 
 **Bad Example**
 
@@ -228,6 +254,8 @@ OpenAPI object must not have duplicated tag names (identifiers).
 
 **Recommended:** Yes
 
+**Default severity when enabled:** error
+
 **Bad Example**
 
 ```yaml
@@ -248,6 +276,8 @@ tags:
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 ### operation-operationId
 
 This operation ID is essentially a reference for the operation, which can be used to visually suggest a connection to other operations. This is like some theoretical static HATEOAS-style referencing, but it's also used for the URL in some documentation systems.
@@ -256,6 +286,8 @@ Make the value `lower-hyphen-case`, and try and think of a name for the action w
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 ### operation-operationId-unique
 
 Every operation must have a unique `operationId`.
@@ -263,6 +295,8 @@ Every operation must have a unique `operationId`.
 Why? A lot of documentation systems use this as an identifier, some SDK generators convert them to a method name, among other things.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** error
 
 **Bad Example**
 
@@ -304,6 +338,8 @@ Seeing as operationId is often used for unique URLs in documentation systems, it
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 **Bad Example**
 
 ```yaml
@@ -323,17 +359,23 @@ Operation parameters are unique and non-repeating.
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 ### operation-singular-tag
 
 Use just one tag for an operation, which is helpful for some documentation systems which use tags to avoid duplicate content.
 
 **Recommended:** No
 
+**Default severity when enabled:** warn
+
 ### operation-success-response
 
 Operation must have at least one `2xx` or `3xx` response. Any API operation (endpoint) can fail, but presumably, it is also meant to do something constructive at some point. If you forget to write out a success case for this API, then this rule will let you know.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** warn
 
 **Bad Example**
 
@@ -352,11 +394,15 @@ Operation should have non-empty `tags` array.
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 ### operation-tag-defined
 
 Operation tags should be defined in global tags.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** warn
 
 ### path-declarations-must-exist
 
@@ -364,17 +410,23 @@ Path parameter declarations cannot be empty, ex.`/given/{}` is invalid.
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 ### path-keys-no-trailing-slash
 
 Keep trailing slashes off of paths, as it can cause some confusion. Some web tooling (like mock servers, real servers, code generators, application frameworks, etc.) will treat `example.com/foo` and `example.com/foo/` as the same thing, but other tooling will not. Avoid any confusion by just documenting them without the slash, and maybe some tooling will let people shove a / on there when they're using it, or maybe not, but at least the docs are suggesting how it should be done properly.
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 ### path-not-include-query
 
 Don't put query string items in the path, they belong in parameters with `in: query`.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** warn
 
 ### path-params
 
@@ -386,6 +438,8 @@ Path parameters are correct and valid.
 2. every `path.parameters` and `operation.parameters` parameter must be used in the path string.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** error
 
 ### tag-description
 
@@ -410,11 +464,15 @@ tags:
 
 **Recommended:** No
 
+**Default severity when enabled:** warn
+
 ### typed-enum
 
 Enum values should respect the `type` specifier.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** warn
 
 **Good Example**
 
@@ -454,6 +512,8 @@ Schemas with `type: array`, require a sibling `items` field.
 
 **Recommended:** Yes
 
+**Default severity when enabled:** error
+
 **Good Example**
 
 ```yaml
@@ -489,11 +549,15 @@ OpenAPI v3 keyword `anyOf` detected in OpenAPI v2 document.
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 ### oas2-api-host
 
 OpenAPI `host` must be present and non-empty string.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** warn
 
 ### oas2-api-schemes
 
@@ -501,11 +565,15 @@ OpenAPI host `schemes` must be present and non-empty array.
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 ### oas2-discriminator
 
 The discriminator property MUST be defined at this schema and it MUST be in the required property list.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** error
 
 ### oas2-host-not-example
 
@@ -513,11 +581,15 @@ Server URL should not point to example.com.
 
 **Recommended:** No
 
+**Default severity when enabled:** warn
+
 ### oas2-host-trailing-slash
 
 Server URL should not have a trailing slash.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** warn
 
 ### oas2-oneOf
 
@@ -525,11 +597,15 @@ OpenAPI v3 keyword `oneOf` detected in OpenAPI v2 document.
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 ### oas2-operation-formData-consume-check
 
 Operations with an `in: formData` parameter must include `application/x-www-form-urlencoded` or `multipart/form-data` in their `consumes` property.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** warn
 
 ### oas2-operation-security-defined
 
@@ -538,17 +614,23 @@ Ignores empty `security` values for cases where authentication is explicitly not
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 ### oas2-parameter-description
 
 Parameter objects should have a `description`.
 
 **Recommended:** No
 
+**Default severity when enabled:** warn
+
 ### oas2-schema
 
 Validate structure of OpenAPI v2 specification.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** error
 
 ### oas2-unused-definition
 
@@ -564,6 +646,8 @@ Potential unused reusable `definition` entry has been detected.
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 ### oas2-valid-media-example
 
 Examples must be valid against their defined schema. Common reasons you may see errors are:
@@ -572,6 +656,8 @@ Examples must be valid against their defined schema. Common reasons you may see 
 - Examples contain properties not included in the schema.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** error
 
 For example, if you have a Pet object with an `id` property as type `integer`, and `name` and `petType` properties as type `string`, the `examples` properties type should match the schema:
 
@@ -633,6 +719,14 @@ paths:
               petType: 123
 ```
 
+### oas2-valid-schema-example
+
+Examples must be valid against their defined schema.
+
+**Recommended:** Yes
+
+**Default severity when enabled:** error
+
 ## OpenAPI v3-only
 
 These rules will only be applied to OpenAPI v3.0 documents.
@@ -642,6 +736,8 @@ These rules will only be applied to OpenAPI v3.0 documents.
 OpenAPI `servers` must be present and non-empty array.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** warn
 
 Share links to any servers that people might care about. If this is going to be given to internal people then usually that is localhost (so they know the right port number), staging, and production.
 
@@ -662,6 +758,8 @@ If this is going out to the world, maybe have production and a general sandbox p
 Examples for `requestBody` or response examples can have an `externalValue` or a `value`, but they cannot have both.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** warn
 
 **Bad Example**
 
@@ -687,11 +785,15 @@ Operation `security` values must match a scheme defined in the `components.secur
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 ### oas3-parameter-description
 
 Parameter objects should have a `description`.
 
 **Recommended:** No
+
+**Default severity when enabled:** warn
 
 ### oas3-schema
 
@@ -701,11 +803,15 @@ If you define your own `jsonSchemaDialect`, you'll most likely want to disable t
 
 **Recommended:** Yes
 
+**Default severity when enabled:** error
+
 ### oas3-server-not-example.com
 
 Server URL should not point to example.com.
 
 **Recommended:** No
+
+**Default severity when enabled:** warn
 
 **Bad Example**
 
@@ -728,6 +834,8 @@ Server URL should not have a trailing slash.
 Some tooling forgets to strip trailing slashes off when it's joining the `servers.url` with `paths`, and you can get awkward URLs like `https://example.com/api//pets`. Best to just strip them off yourself.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** warn
 
 **Good Example**
 
@@ -759,11 +867,15 @@ Potential unused reusable `components` entry has been detected.
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 ### oas3-valid-media-example
 
 Examples must be valid against their defined schema. This rule is applied to Media Type objects.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** error
 
 For example, if you have a Pet object with an `id` property as type `integer`, and `name` and `petType` properties as type `string`, the examples properties type should match the schema:
 
@@ -831,6 +943,8 @@ Examples must be valid against their defined schema. This rule is applied to Sch
 
 **Recommended:** Yes
 
+**Default severity when enabled:** error
+
 **Good Example**
 
 ```yaml
@@ -882,7 +996,9 @@ schemas:
 
 This rule ensures that server variables defined in OpenAPI Specification 3 (OAS3) and 3.1 are valid, not unused, and result in a valid URL. Properly defining and using server variables is crucial for the accurate representation of API endpoints and preventing potential misconfigurations or security issues.
 
-**Recommended**: Yes
+**Recommended:** Yes
+
+**Default severity when enabled:** error
 
 **Bad Examples**
 
@@ -960,6 +1076,8 @@ A callback should not be defined within another callback.
 
 **Recommended:** Yes
 
+**Default severity when enabled:** warn
+
 **Bad Example**
 
 ```yaml
@@ -978,6 +1096,8 @@ paths:
 Servers should not be defined in a webhook.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** warn
 
 **Bad Example**
 
@@ -1007,6 +1127,8 @@ webhooks:
 Callbacks should not be defined in a webhook.
 
 **Recommended:** Yes
+
+**Default severity when enabled:** warn
 
 **Bad Example**
 


### PR DESCRIPTION
Closes #2445.

Documents the default severity for every built-in OpenAPI and AsyncAPI rule. Each rule now shows its `Recommended` status and `Default severity when enabled` severity, taken directly from the ruleset definitions. I also added the two small rule sections that were missing from the reference docs and verified the pages with Prettier.