### PR TITLE
fix(repo): report download failures in install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -50,13 +50,13 @@ fi
 SRC="$(pwd)/${FILENAME}"
 DEST=/usr/local/bin/spectral
 
-STATUS=$(curl -sL -w %{http_code} -o "$SRC" "$URL")
-if [ $STATUS -ge 200 ] & [ $STATUS -le 308 ]; then
+STATUS=$(curl -sL -w "%{http_code}" -o "$SRC" "$URL") || STATUS=000
+if [ "$STATUS" -ge 200 ] && [ "$STATUS" -le 308 ]; then
   mv "$SRC" "$DEST"
   chmod +x "$DEST"
   echo "Spectral was installed to: ${DEST}"
 else
-  rm "$SRC"
+  rm -f "$SRC"
   echo "Error requesting. Download binary from ${URL}"
   exit 1
 fi


### PR DESCRIPTION
Fixes #3040.

**Checklist**

- [ ] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Additional context**

Three lines in the download block combined to swallow connection-level failures, so `curl -L .../install.sh | sh` exited non-zero with no explanation at all. Reasoning is in #3040.

```diff
-STATUS=$(curl -sL -w %{http_code} -o "$SRC" "$URL")
-if [ $STATUS -ge 200 ] & [ $STATUS -le 308 ]; then
+STATUS=$(curl -sL -w "%{http_code}" -o "$SRC" "$URL") || STATUS=000
+if [ "$STATUS" -ge 200 ] && [ "$STATUS" -le 308 ]; then
   mv "$SRC" "$DEST"
   chmod +x "$DEST"
   echo "Spectral was installed to: ${DEST}"
 else
-  rm "$SRC"
+  rm -f "$SRC"
```

- `|| STATUS=000` stops `set -eu` from terminating on the assignment, so a curl failure now falls through to the error branch that already exists instead of exiting with curl's own status.
- `&` → `&&` makes the lower bound actually apply. With `&` the first test is backgrounded and its result discarded, leaving the condition as `-le 308` alone — which would accept `000` as success once the line above stops exiting early. The two have to change together.
- `rm -f` lets the error branch finish when curl never created the output file; previously `rm` failed there and `set -e` killed the script before the message on the next line.

The two quoting changes sit on lines already being touched and clear the remaining shellcheck notes.

### Verification

| case | before | after |
| --- | --- | --- |
| no network | `exit 6`, no output | `Error requesting. Download binary from <URL>`, `exit 1` |
| version that doesn't exist (404) | already correct | unchanged |
| normal install | works | works |

<details>
<summary>Commands and output</summary>

```
# no network
$ docker run --rm --network none --user root -w /tmp \
    -v "$PWD/scripts/install.sh:/install.sh:ro" \
    curlimages/curl:latest sh /install.sh 6.16.3; echo "exit: $?"
Installing on Alpine Linux.
Error requesting. Download binary from https://github.com/stoplightio/spectral/releases/download/v6.16.3/spectral-alpine-arm64
exit: 1

# version that doesn't exist
$ ... sh /install.sh 99.99.99; echo "exit: $?"
Installing on Alpine Linux.
Error requesting. Download binary from https://github.com/stoplightio/spectral/releases/download/v99.99.99/spectral-alpine-arm64
exit: 1

# normal install, unchanged
$ ... sh /install.sh 6.16.3; echo "exit: $?"
Spectral was installed to: /usr/local/bin/spectral
exit: 0
$ ls -l /usr/local/bin/spectral && /usr/local/bin/spectral --version
-rwxr-xr-x 1 root root 78334324 /usr/local/bin/spectral
6.16.3
```

</details>

`shellcheck` on this file goes from 5 findings to 0, including the one it classifies as an error:

```
54:24: error: Use && for logical AND. Single & will background and return true. [SC2265]
```

No tests are included — there's no harness for the shell installer, and reproducing the failure needs a network-isolated container. Happy to add coverage if you'd like it.
