### PR TITLE
chore(deps): un-pin rollup version range

### DIFF
--- a/packages/ruleset-bundler/package.json
+++ b/packages/ruleset-bundler/package.json
@@ -48,7 +48,7 @@
     "@stoplight/types": "^13.6.0",
     "@types/node": "*",
     "pony-cause": "1.1.1",
-    "rollup": "~2.80.0",
+    "rollup": "^2.80.0",
     "tslib": "^2.8.1",
     "validate-npm-package-name": "3.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3419,7 +3419,7 @@ __metadata:
     memfs: ^3.5.3
     pony-cause: 1.1.1
     prettier: ^2.4.1
-    rollup: ~2.80.0
+    rollup: ^2.80.0
     tslib: ^2.8.1
     validate-npm-package-name: 3.0.0
   languageName: unknown
@@ -13084,7 +13084,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:~2.80.0":
+"rollup@npm:^2.80.0":
   version: 2.80.0
   resolution: "rollup@npm:2.80.0"
   dependencies:


### PR DESCRIPTION
Fixes #2901.

**Checklist**

- [ ] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Additional context**

Widen rollup from ~2.80.0 to ^2.80.0 in ruleset-bundler to make future non-breaking upgrades easier. Rollup was already bumped to 2.80.0 (the patched release for CVE-2026-27606 / GHSA-mw96-cpmx-2vgc) in a prior PR, so this only relaxes the version constraint — no functional change.