### PR TITLE
chore(deps): bump minimatch to 5.1.9 via resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "path-to-regexp": "3.3.0",
     "tar": "7.5.21",
     "node-gyp": "^11.0.0",
-    "lodash": "4.18.1"
+    "lodash": "4.18.1",
+    "minimatch@^5.0.1": "5.1.9"
   },
   "devDependencies": {
     "@commitlint/cli": "^14.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10916,6 +10916,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:5.1.9":
+  version: 5.1.9
+  resolution: "minimatch@npm:5.1.9"
+  dependencies:
+    brace-expansion: ^2.0.1
+  checksum: 418438bd7701ba811f1108f28fcd3a638a6065c7b1245b85e25bcdb674410b4bebd8763c90c91bc8d22d93260c02cc129b354267a463c3399be5732d6e11e120
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^10.0.3, minimatch@npm:^10.1.1, minimatch@npm:^10.2.2":
   version: 10.2.4
   resolution: "minimatch@npm:10.2.4"
@@ -10931,15 +10940,6 @@ __metadata:
   dependencies:
     brace-expansion: ^1.1.7
   checksum: 47ef6f412c08be045a7291d11b1c40777925accf7252dc6d3caa39b1bfbb3a7ea390ba7aba464d762d783265c644143d2c8a204e6b5763145024d52ee65a1941
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^5.0.1":
-  version: 5.1.6
-  resolution: "minimatch@npm:5.1.6"
-  dependencies:
-    brace-expansion: ^2.0.1
-  checksum: 7564208ef81d7065a370f788d337cd80a689e981042cb9a1d0e6580b6c6a8c9279eba80010516e258835a988363f99f54a6f711a315089b8b42694f5da9d0d77
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes CVE-2026-26996

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ x ] No
