### PR TITLE
fix(ref-resolver): isolate concurrent root back-references

### DIFF
--- a/packages/ref-resolver/src/__tests__/concurrent-external-refs.jest.test.ts
+++ b/packages/ref-resolver/src/__tests__/concurrent-external-refs.jest.test.ts
@@ -1,0 +1,100 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { IUriParser } from '@stoplight/json-ref-resolver/types';
+import { createHttpAndFileResolver } from '..';
+
+const pathCount = 40;
+const parameters = {
+  TenantId: { name: 'tenantId', in: 'path', required: true, schema: { type: 'string' } },
+  SampleId: { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+};
+
+describe('concurrent file references', () => {
+  let fixtureDirectory: string;
+  let rootUri: string;
+  let root: Record<string, unknown>;
+
+  beforeAll(() => {
+    fixtureDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'spectral-gh-2640-'));
+    rootUri = path.join(fixtureDirectory, 'openapi.json');
+
+    for (const directory of ['parameters', 'paths', 'schemas']) {
+      fs.mkdirSync(path.join(fixtureDirectory, directory));
+    }
+
+    fs.writeFileSync(path.join(fixtureDirectory, 'parameters', 'tenant.json'), JSON.stringify(parameters.TenantId));
+    fs.writeFileSync(path.join(fixtureDirectory, 'parameters', 'sample.json'), JSON.stringify(parameters.SampleId));
+
+    const paths: Record<string, unknown> = {};
+    const schemas: Record<string, unknown> = {};
+
+    for (let index = 0; index < pathCount; index++) {
+      const schemaName = `Sample${index}`;
+      const pathName = `/tenants/{tenantId}/samples/${index}/{id}`;
+
+      schemas[schemaName] = { $ref: `./schemas/sample-${index}.json` };
+      paths[pathName] = { $ref: `./paths/sample-${index}.json` };
+      fs.writeFileSync(
+        path.join(fixtureDirectory, 'schemas', `sample-${index}.json`),
+        JSON.stringify({ type: 'object', properties: { id: { type: 'integer' } } }),
+      );
+      fs.writeFileSync(
+        path.join(fixtureDirectory, 'paths', `sample-${index}.json`),
+        JSON.stringify({
+          get: {
+            parameters: [
+              { $ref: '../openapi.json#/components/parameters/TenantId' },
+              { $ref: '../openapi.json#/components/parameters/SampleId' },
+            ],
+            responses: {
+              '200': {
+                description: 'Successful response',
+                content: {
+                  'application/json': {
+                    schema: { $ref: `../openapi.json#/components/schemas/${schemaName}` },
+                  },
+                },
+              },
+            },
+          },
+        }),
+      );
+    }
+
+    root = {
+      openapi: '3.0.3',
+      components: {
+        parameters: {
+          TenantId: { $ref: './parameters/tenant.json' },
+          SampleId: { $ref: './parameters/sample.json' },
+        },
+        schemas,
+      },
+      paths,
+    };
+    fs.writeFileSync(rootUri, JSON.stringify(root));
+  });
+
+  afterAll(() => {
+    fs.rmSync(fixtureDirectory, { recursive: true, force: true });
+  });
+
+  test('resolves all root back-references on every run (gh-2640)', async () => {
+    for (let attempt = 0; attempt < 10; attempt++) {
+      const result = await createHttpAndFileResolver().resolve(root, {
+        baseUri: rootUri,
+        parseResolveResult: async (options: IUriParser) => ({
+          ...options,
+          result: JSON.parse(String(options.result)) as unknown,
+        }),
+      });
+      const resolvedPaths = (result.result as { paths: Record<string, { get: { parameters: unknown[] } }> }).paths;
+
+      expect(result.errors).toEqual([]);
+      expect(Object.values(resolvedPaths).map(resolvedPath => resolvedPath.get.parameters)).toEqual(
+        Array.from({ length: pathCount }, () => [parameters.TenantId, parameters.SampleId]),
+      );
+    }
+  });
+});

--- a/packages/ref-resolver/src/__tests__/concurrent-external-refs.test.ts
+++ b/packages/ref-resolver/src/__tests__/concurrent-external-refs.test.ts
@@ -1,0 +1,113 @@
+import { serveAssets } from '@stoplight/spectral-test-utils';
+import type { IUriParser } from '@stoplight/json-ref-resolver/types';
+import { createHttpAndFileResolver } from '..';
+
+const fixtureDirectory = 'https://example.com/spectral-gh-2640';
+const rootUri = `${fixtureDirectory}/openapi.json`;
+const pathCount = 12;
+
+const parameterFixtures = {
+  TenantId: { name: 'tenantId', in: 'path', required: true, schema: { type: 'string' } },
+  SampleId: { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+};
+
+function createFixture(): { root: Record<string, unknown>; assets: Record<string, Record<string, unknown>> } {
+  const paths: Record<string, unknown> = {};
+  const schemas: Record<string, unknown> = {};
+  const assets: Record<string, Record<string, unknown>> = {
+    [`${fixtureDirectory}/parameters/tenant.json`]: parameterFixtures.TenantId,
+    [`${fixtureDirectory}/parameters/sample.json`]: parameterFixtures.SampleId,
+    [`${fixtureDirectory}/responses/invalid.json`]: {
+      description: 'Invalid request',
+      content: {
+        'application/json': {
+          schema: { $ref: '../openapi.json#/components/schemas/Error' },
+        },
+      },
+    },
+    [`${fixtureDirectory}/schemas/error.json`]: {
+      type: 'object',
+      properties: { message: { type: 'string' } },
+    },
+  };
+
+  for (let index = 0; index < pathCount; index++) {
+    const schemaName = `Sample${index}`;
+    const pathName = `/tenants/{tenantId}/samples/${index}/{id}`;
+
+    schemas[schemaName] = { $ref: `./schemas/sample-${index}.json` };
+    paths[pathName] = { $ref: `./paths/sample-${index}.json` };
+    assets[`${fixtureDirectory}/schemas/sample-${index}.json`] = {
+      type: 'object',
+      properties: { id: { type: 'integer' } },
+    };
+    assets[`${fixtureDirectory}/paths/sample-${index}.json`] = {
+      get: {
+        parameters: [
+          { $ref: '../openapi.json#/components/parameters/TenantId' },
+          { $ref: '../openapi.json#/components/parameters/SampleId' },
+        ],
+        responses: {
+          '200': {
+            description: 'Successful response',
+            content: {
+              'application/json': {
+                schema: { $ref: `../openapi.json#/components/schemas/${schemaName}` },
+              },
+            },
+          },
+          '400': { $ref: '../openapi.json#/components/responses/InvalidRequest' },
+        },
+      },
+    };
+  }
+
+  const root = {
+    openapi: '3.0.3',
+    components: {
+      parameters: {
+        TenantId: { $ref: './parameters/tenant.json' },
+        SampleId: { $ref: './parameters/sample.json' },
+      },
+      responses: {
+        InvalidRequest: { $ref: './responses/invalid.json' },
+      },
+      schemas: {
+        Error: { $ref: './schemas/error.json' },
+        ...schemas,
+      },
+    },
+    paths,
+  };
+
+  assets[rootUri] = root;
+
+  return { root, assets };
+}
+
+describe('concurrent external references', () => {
+  test('resolves every external root back-reference deterministically (gh-2640)', async () => {
+    const { root, assets } = createFixture();
+    serveAssets(assets);
+
+    for (let attempt = 0; attempt < 10; attempt++) {
+      const result = await createHttpAndFileResolver().resolve(root, {
+        baseUri: rootUri,
+        parseResolveResult: async (options: IUriParser) => {
+          await new Promise(resolve => setTimeout(resolve, 0));
+
+          return {
+            ...options,
+            result: JSON.parse(String(options.result)) as unknown,
+          };
+        },
+      });
+      const resolvedPaths = (result.result as { paths: Record<string, { get: { parameters: unknown[] } }> }).paths;
+
+      expect(result.errors).toEqual([]);
+      expect(Object.values(resolvedPaths).map(path => path.get.parameters)).toEqual(
+        Array.from({ length: pathCount }, () => [parameterFixtures.TenantId, parameterFixtures.SampleId]),
+      );
+    }
+  });
+});

--- a/packages/ref-resolver/src/cache.ts
+++ b/packages/ref-resolver/src/cache.ts
@@ -1,0 +1,78 @@
+import { Cache } from '@stoplight/json-ref-resolver';
+import { ResolveRunner } from '@stoplight/json-ref-resolver/runner';
+import type { IResolveRunner, IResolveRunnerOpts } from '@stoplight/json-ref-resolver/types';
+
+type RootRunner = IResolveRunner & {
+  readonly resolvers: IResolveRunnerOpts['resolvers'];
+  readonly getRef: IResolveRunnerOpts['getRef'];
+  readonly transformRef: IResolveRunnerOpts['transformRef'];
+  readonly parseResolveResult: IResolveRunnerOpts['parseResolveResult'];
+  readonly transformDereferenceResult: IResolveRunnerOpts['transformDereferenceResult'];
+  readonly ctx: unknown;
+};
+
+function isRootRunner(value: unknown): value is RootRunner {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'resolve' in value &&
+    typeof (value as IResolveRunner).resolve === 'function' &&
+    (value as IResolveRunner).depth === 0
+  );
+}
+
+function cloneSource<T>(source: T): T {
+  if (source === null || typeof source !== 'object') {
+    return source;
+  }
+
+  return JSON.parse(JSON.stringify(source)) as T;
+}
+
+/**
+ * json-ref-resolver caches the mutable root runner so external documents can
+ * resolve references back into the root document. When several external
+ * documents do that concurrently, they re-enter and mutate the same runner.
+ * Give each back-reference an isolated source while retaining the shared cache
+ * and graph used for external-document de-duplication and source attribution.
+ */
+export class RootRunnerCache extends Cache {
+  private readonly rootSources = new WeakMap<IResolveRunner, { source: unknown }>();
+
+  public get(key: string): unknown {
+    const value: unknown = super.get(key);
+
+    if (!isRootRunner(value)) {
+      return value;
+    }
+
+    const snapshot = this.rootSources.get(value);
+    if (snapshot === void 0) {
+      return value;
+    }
+
+    return new ResolveRunner(cloneSource(snapshot.source), value.graph, {
+      depth: value.depth + 1,
+      baseUri: value.baseUri.toString(),
+      root: value.baseUri,
+      uriStack: value.uriStack.slice(),
+      uriCache: this,
+      resolvers: value.resolvers,
+      getRef: value.getRef,
+      transformRef: value.transformRef,
+      parseResolveResult: value.parseResolveResult,
+      transformDereferenceResult: value.transformDereferenceResult,
+      dereferenceInline: value.dereferenceInline,
+      dereferenceRemote: value.dereferenceRemote,
+      ctx: value.ctx,
+    });
+  }
+
+  public set(key: string, value: unknown): void {
+    if (isRootRunner(value)) {
+      this.rootSources.set(value, { source: cloneSource(value.source) });
+    }
+
+    super.set(key, value);
+  }
+}

--- a/packages/ref-resolver/src/index.ts
+++ b/packages/ref-resolver/src/index.ts
@@ -4,6 +4,7 @@ import type { IGraphNodeData } from '@stoplight/json-ref-resolver/types';
 import type { Agent } from 'http';
 import { DEFAULT_REQUEST_OPTIONS } from '@stoplight/spectral-runtime';
 import { DepGraph } from 'dependency-graph';
+import { RootRunnerCache } from './cache';
 
 export interface IHttpAndFileResolverOptions {
   agent?: Agent;
@@ -22,6 +23,7 @@ export function createHttpAndFileResolver(opts?: IHttpAndFileResolverOptions): R
   const resolveHttp = createResolveHttp({ ...DEFAULT_REQUEST_OPTIONS, ...opts });
 
   return new Resolver({
+    uriCache: new RootRunnerCache(),
     resolvers: {
       https: { resolve: resolveHttp },
       http: { resolve: resolveHttp },


### PR DESCRIPTION
Fixes #2640.

## Summary

- isolate cached root runners when external documents reference the root document concurrently
- retain the shared URI cache and dependency graph for external-document de-duplication and source attribution
- add deterministic file-system regression coverage plus browser-compatible HTTP coverage for repeated multi-file root back-references

The archived json-ref-resolver dependency stores the mutable depth-zero root runner directly in its shared URI cache. External documents that point back into the root retrieve that same runner, and Promise.all then re-enters resolve on it concurrently. Those calls overwrite the runner source nondeterministically, leaving raw $ref objects in random path documents. The new cache snapshots the original root source and returns an isolated runner only for this direct root cache hit; ordinary memoized external lookups remain unchanged.

**Checklist**

- [x] Tests added / updated
- [ ] Docs added / updated (not applicable; no user-facing API or configuration change)

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

## Validation

- corepack yarn build
- corepack yarn lint: 0 errors; 40 existing warnings
- full Jest run: 202 suites passed, 1992 tests passed, 1 skipped
- focused Edge/Karma regression: 1 passed
- linked reproduction with the locally built CLI: 100/100 runs produced only the expected oas3-api-servers warning

Full Edge/Karma execution reached 1824 passing tests; 60 existing ruleset-migrator cases failed because their shared memfs fixture directories were absent. The new regression passed independently. The standalone binary build could not fetch the pkg Node 24 base binary or Node source archive in this environment, so the binary-backed harness was not available.